### PR TITLE
Demo mail api latest changes

### DIFF
--- a/email.yaml
+++ b/email.yaml
@@ -22,3 +22,4 @@ email:
         transfer_ownership_mail_body: ${EMAIL_TEMPLATES_UPDATE_ROLE_OWNER_BODY:"Access to member MEMBER_EMAIL on BOT_NAME bot has been changed to NEW_ROLE by MODIFIER_NAME. You are no more the owner of the bot. Your current role has been changed to admin."}
         password_generated_subject: ${EMAIL_TEMPLATES_PASSWORD_GENERATED_SUBJECT:"Welcome to kAIron!"}
         untrusted_login_subject: ${EMAIL_TEMPLATES_UNTRUSTED_LOGIN_SUBJECT:"Suspicious sign-in detected!"}
+        book_a_demo_subject: ${EMAIL_TEMPLATES_BOOK_A_DEMO_SUBJECT:"kAIron Demo Requested"}

--- a/kairon/actions/definitions/email.py
+++ b/kairon/actions/definitions/email.py
@@ -5,7 +5,7 @@ from mongoengine import DoesNotExist
 from rasa_sdk import Tracker
 from rasa_sdk.executor import CollectingDispatcher
 
-from kairon.shared.utils import Utility
+from kairon.shared.utils import MailUtility
 from kairon.actions.definitions.base import ActionsBase
 from kairon.shared.actions.data_objects import ActionServerLogs, EmailActionConfig
 from kairon.shared.actions.exception import ActionFailure
@@ -66,16 +66,16 @@ class ActionEmail(ActionsBase):
                     body = ActionUtility.prepare_email_body(tracker_data[ActionParameterType.chat_log.value], action_config['subject'], mail)
                 else:
                     body = ActionUtility.prepare_email_text(custom_text, tracker_data, action_config['subject'], mail)
-                await Utility.trigger_email(email=[mail],
-                                            subject=f"{tracker.sender_id} {action_config['subject']}",
-                                            body=body,
-                                            smtp_url=action_config['smtp_url'],
-                                            smtp_port=action_config['smtp_port'],
-                                            sender_email=action_config['from_email'],
-                                            smtp_password=password,
-                                            smtp_userid=userid,
-                                            tls=action_config['tls']
-                                            )
+                await MailUtility.trigger_email(email=[mail],
+                                                subject=f"{tracker.sender_id} {action_config['subject']}",
+                                                body=body,
+                                                smtp_url=action_config['smtp_url'],
+                                                smtp_port=action_config['smtp_port'],
+                                                sender_email=action_config['from_email'],
+                                                smtp_password=password,
+                                                smtp_userid=userid,
+                                                tls=action_config['tls']
+                                                )
 
         except Exception as e:
             logger.exception(e)

--- a/kairon/api/app/routers/auth.py
+++ b/kairon/api/app/routers/auth.py
@@ -8,8 +8,7 @@ from kairon.shared.data.utils import DataUtility
 from kairon.shared.organization.processor import OrgProcessor
 from kairon.shared.utils import Utility, MailUtility
 from kairon.shared.auth import Authentication
-from kairon.api.models import Response, IntegrationRequest, RecaptchaVerifiedOAuth2PasswordRequestForm, \
-    RecaptchaVerifiedDictData
+from kairon.api.models import Response, IntegrationRequest, RecaptchaVerifiedOAuth2PasswordRequestForm
 from kairon.shared.authorization.processor import IntegrationProcessor
 from kairon.shared.constants import ADMIN_ACCESS, TESTER_ACCESS
 from kairon.shared.data.constant import ACCESS_ROLES, TOKEN_TYPE
@@ -39,20 +38,6 @@ async def login_for_access_token(
             "refresh_token": refresh_tkn, "refresh_token_expiry": refresh_tkn_exp
         }, "message": "User Authenticated",
     }
-
-
-@router.post("/demo", response_model=Response)
-async def book_a_demo(
-        background_tasks: BackgroundTasks, request: Request,
-        form_data: RecaptchaVerifiedDictData
-):
-    """
-    Books a Demo for the User
-    """
-    Utility.validate_recaptcha_response(form_data.recaptcha_response, request=request)
-    background_tasks.add_task(MailUtility.format_and_send_mail, mail_type='book_a_demo', email=form_data.data['email'],
-                              first_name=form_data.data['first_name'], request=request, **form_data.dict())
-    return {"message": "Thank You for your interest in Kairon. We will reach out to you soon."}
 
 
 @router.get("/{bot}/token/refresh", response_model=Response)

--- a/kairon/api/app/routers/user.py
+++ b/kairon/api/app/routers/user.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Path, Security
+from starlette.requests import Request
 
 from kairon.shared.constants import ADMIN_ACCESS, TESTER_ACCESS, OWNER_ACCESS
 from kairon.shared.data.constant import ACCESS_ROLES, ACTIVITY_STATUS
@@ -6,7 +7,7 @@ from kairon.shared.multilingual.utils.translator import Translator
 from kairon.shared.utils import Utility, MailUtility
 from kairon.shared.auth import Authentication
 from kairon.shared.account.processor import AccountProcessor
-from kairon.api.models import Response, BotAccessRequest, RecaptchaVerifiedTextData
+from kairon.api.models import Response, BotAccessRequest, RecaptchaVerifiedTextData, RecaptchaVerifiedDictData
 from kairon.shared.models import User
 from fastapi import Depends
 from fastapi import BackgroundTasks
@@ -31,6 +32,20 @@ async def list_access_for_roles(current_user: User = Security(Authentication.get
     Lists roles and what components they can have access to.
     """
     return Response(data=Utility.system_metadata["roles"])
+
+
+@router.post("/demo", response_model=Response)
+async def book_a_demo(
+        background_tasks: BackgroundTasks, request: Request,
+        form_data: RecaptchaVerifiedDictData
+):
+    """
+    Books a Demo for the User
+    """
+    Utility.validate_recaptcha_response(form_data.recaptcha_response, request=request)
+    background_tasks.add_task(MailUtility.format_and_send_mail, mail_type='book_a_demo', email=form_data.data['email'],
+                              first_name=form_data.data['first_name'], request=request, **form_data.dict())
+    return {"message": "Thank You for your interest in Kairon. We will reach out to you soon."}
 
 
 @router.post("/{bot}/member", response_model=Response)

--- a/kairon/api/app/routers/user.py
+++ b/kairon/api/app/routers/user.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Path, Security
 from kairon.shared.constants import ADMIN_ACCESS, TESTER_ACCESS, OWNER_ACCESS
 from kairon.shared.data.constant import ACCESS_ROLES, ACTIVITY_STATUS
 from kairon.shared.multilingual.utils.translator import Translator
-from kairon.shared.utils import Utility
+from kairon.shared.utils import Utility, MailUtility
 from kairon.shared.auth import Authentication
 from kairon.shared.account.processor import AccountProcessor
 from kairon.api.models import Response, BotAccessRequest, RecaptchaVerifiedTextData
@@ -46,7 +46,7 @@ async def allow_bot_for_user(
                                                                        current_user.get_user(),
                                                                        current_user.account, allow_bot.role)
     if Utility.email_conf["email"]["enable"]:
-        background_tasks.add_task(Utility.format_and_send_mail, mail_type='add_member', email=allow_bot.email, url=url,
+        background_tasks.add_task(MailUtility.format_and_send_mail, mail_type='add_member', email=allow_bot.email, url=url,
                                   first_name=f'{current_user.first_name} {current_user.last_name}',
                                   bot_name=bot_name, role=allow_bot.role)
         return Response(message='An invitation has been sent to the user')
@@ -65,7 +65,7 @@ async def accept_bot_collaboration_invite_with_token_validation(
     bot_admin, bot_name, accessor_email, role = AccountProcessor.validate_request_and_accept_bot_access_invite(token.data, bot)
     user = AccountProcessor.get_user(bot_admin)
     if Utility.email_conf["email"]["enable"]:
-        background_tasks.add_task(Utility.format_and_send_mail, mail_type='add_member_confirmation', email=bot_admin,
+        background_tasks.add_task(MailUtility.format_and_send_mail, mail_type='add_member_confirmation', email=bot_admin,
                                   first_name=bot_admin, accessor_email=accessor_email,
                                   bot_name=bot_name, role=role, member_confirm=user['first_name'])
     return {"message": "Invitation accepted"}
@@ -82,7 +82,7 @@ async def accept_bot_collaboration_invite(
     """
     bot_admin, bot_name, accessor_email, role = AccountProcessor.accept_bot_access_invite(bot, current_user.get_user())
     if Utility.email_conf["email"]["enable"]:
-        background_tasks.add_task(Utility.format_and_send_mail, mail_type='add_member_confirmation', email=bot_admin,
+        background_tasks.add_task(MailUtility.format_and_send_mail, mail_type='add_member_confirmation', email=bot_admin,
                                   first_name=bot_admin, accessor_email=accessor_email,
                                   bot_name=bot_name, role=role)
     return {"message": "Invitation accepted"}
@@ -101,11 +101,11 @@ async def update_bot_access_for_user(
         bot, allow_bot.email, current_user.get_user(), allow_bot.role, allow_bot.activity_status
     )
     if Utility.email_conf["email"]["enable"]:
-        background_tasks.add_task(Utility.format_and_send_mail, mail_type='update_role_member_mail',
+        background_tasks.add_task(MailUtility.format_and_send_mail, mail_type='update_role_member_mail',
                                   email=allow_bot.email, first_name=f'{current_user.first_name} {current_user.last_name}',
                                   bot_name=bot_name, new_role=allow_bot.role, status=allow_bot.activity_status,
                                   member_name=member_name)
-        background_tasks.add_task(Utility.format_and_send_mail, mail_type='update_role_owner_mail', email=owner_email,
+        background_tasks.add_task(MailUtility.format_and_send_mail, mail_type='update_role_owner_mail', email=owner_email,
                                   member_email=allow_bot.email, bot_name=bot_name, new_role=allow_bot.role,
                                   first_name=f'{current_user.first_name} {current_user.last_name}',
                                   status=allow_bot.activity_status, owner_name=owner_name)
@@ -123,11 +123,11 @@ async def transfer_ownership(
     """
     bot_name = AccountProcessor.transfer_ownership(current_user.account, bot, current_user.get_user(), request_data.data)
     if Utility.email_conf["email"]["enable"]:
-        background_tasks.add_task(Utility.format_and_send_mail, mail_type='update_role_member_mail',
+        background_tasks.add_task(MailUtility.format_and_send_mail, mail_type='update_role_member_mail',
                                   email=request_data.data, bot_name=bot_name, new_role=ACCESS_ROLES.OWNER.value,
                                   first_name=f'{current_user.first_name} {current_user.last_name}',
                                   status=ACTIVITY_STATUS.ACTIVE.value)
-        background_tasks.add_task(Utility.format_and_send_mail, mail_type='transfer_ownership_mail',
+        background_tasks.add_task(MailUtility.format_and_send_mail, mail_type='transfer_ownership_mail',
                                   email=current_user.get_user(), member_email=current_user.get_user(),
                                   bot_name=bot_name, new_role=ACCESS_ROLES.OWNER.value,
                                   first_name=f'{current_user.first_name} {current_user.last_name}')

--- a/kairon/api/models.py
+++ b/kairon/api/models.py
@@ -502,6 +502,10 @@ class DictData(BaseModel):
     data: dict
 
 
+class RecaptchaVerifiedDictData(DictData):
+    recaptcha_response: str = None
+
+
 class RegexRequest(BaseModel):
     name: constr(to_lower=True, strip_whitespace=True)
     pattern: str

--- a/kairon/shared/auth.py
+++ b/kairon/shared/auth.py
@@ -21,7 +21,7 @@ from kairon.shared.metering.metering_processor import MeteringProcessor
 from kairon.shared.models import User
 from kairon.shared.plugins.factory import PluginFactory
 from kairon.shared.sso.factory import LoginSSOFactory
-from kairon.shared.utils import Utility
+from kairon.shared.utils import Utility, MailUtility
 from kairon.shared.account.data_objects import UserActivityLog, UserActivityType
 
 Utility.load_environment()
@@ -408,6 +408,6 @@ class Authentication:
             trusted_fingerprints = AccountProcessor.list_trusted_device_fingerprints(user)
             if fingerprint not in trusted_fingerprints and Utility.email_conf["email"]["enable"]:
                 trust_device_url = AccountProcessor.add_trusted_device(user, fingerprint, True, **geo_location)
-                await Utility.format_and_send_mail(
+                await MailUtility.format_and_send_mail(
                     mail_type='untrusted_login', email=user, first_name=user, url=trust_device_url, **geo_location
                 )

--- a/kairon/shared/utils.py
+++ b/kairon/shared/utils.py
@@ -1932,7 +1932,7 @@ class MailUtility:
         ip = request.headers.get('X-Forwarded-For')
         geo_location = PluginFactory.get_instance(PluginTypes.ip_info.value).execute(ip=ip) or {}
         data.update(geo_location)
-        user_details = f"Hi,\nFollowing demo has been requested for Kairon:\n"
+        user_details = "Hi,\nFollowing demo has been requested for Kairon:\n"
         body = Utility.email_conf['email']['templates']['custom_text_mail']
         for key, value in data.items():
             user_details = f"{user_details}<li>{key}: {value}</li>"

--- a/kairon/shared/utils.py
+++ b/kairon/shared/utils.py
@@ -1366,8 +1366,7 @@ class Utility:
     def validate_recaptcha_response(recaptcha_response: str = None, **kwargs):
         request = kwargs.get('request')
         remote_ip = request.headers.get('X-Forwarded-For')
-        secret = Utility.environment['security'].get('recaptcha_secret', None)
-        if Utility.environment['security']['validate_recaptcha'] and not Utility.check_empty_string(secret):
+        if Utility.environment['security']['validate_recaptcha']:
             Utility.validate_recaptcha(recaptcha_response, remote_ip)
 
     @staticmethod

--- a/kairon/shared/utils.py
+++ b/kairon/shared/utils.py
@@ -54,7 +54,7 @@ from validators import email as mail_check
 from websockets import connect
 
 from .actions.models import ActionParameterType
-from .constants import MaskingStrategy, SYSTEM_TRIGGERED_UTTERANCES, ChannelTypes
+from .constants import MaskingStrategy, SYSTEM_TRIGGERED_UTTERANCES, ChannelTypes, PluginTypes
 from .constants import EventClass
 from .data.base_data import AuditLogData
 from .data.constant import TOKEN_TYPE, AuditlogActions, KAIRON_TWO_STAGE_FALLBACK
@@ -628,189 +628,6 @@ class Utility:
             for cleanUp in glob(os.path.join(path, '*.tar.gz')):
                 if model != cleanUp:
                     shutil.move(cleanUp, new_path)
-
-    @staticmethod
-    async def format_and_send_mail(mail_type: str, email: str, first_name: str, url: str = None, **kwargs):
-        if mail_type == 'password_reset':
-            body = Utility.email_conf['email']['templates']['password_reset']
-            body = body.replace('FIRST_NAME', first_name.capitalize())
-            subject = Utility.email_conf['email']['templates']['password_reset_subject']
-        elif mail_type == 'password_reset_confirmation':
-            body = Utility.email_conf['email']['templates']['password_reset_confirmation']
-            subject = Utility.email_conf['email']['templates']['password_changed_subject']
-        elif mail_type == 'verification':
-            body = Utility.email_conf['email']['templates']['verification']
-            body = body.replace('FIRST_NAME', first_name.capitalize())
-            subject = Utility.email_conf['email']['templates']['confirmation_subject']
-        elif mail_type == 'verification_confirmation':
-            body = Utility.email_conf['email']['templates']['verification_confirmation']
-            body = body.replace('FIRST_NAME', first_name.capitalize())
-            subject = Utility.email_conf['email']['templates']['confirmed_subject']
-        elif mail_type == 'add_member':
-            body = Utility.email_conf['email']['templates']['add_member_invitation']
-            body = body.replace('BOT_NAME', kwargs.get('bot_name', ""))
-            body = body.replace('BOT_OWNER_NAME', first_name.capitalize())
-            body = body.replace('ACCESS_TYPE', kwargs.get('role', ""))
-            body = body.replace('ACCESS_URL', url)
-            subject = Utility.email_conf['email']['templates']['add_member_subject']
-            subject = subject.replace('BOT_NAME', kwargs.get('bot_name', ""))
-        elif mail_type == 'add_member_confirmation':
-            body = Utility.email_conf['email']['templates']['add_member_confirmation']
-            body = body.replace('BOT_NAME', kwargs.get('bot_name', ""))
-            body = body.replace('ACCESS_TYPE', kwargs.get('role', ""))
-            body = body.replace('INVITED_PERSON_NAME', kwargs.get('accessor_email', ""))
-            body = body.replace('NAME', kwargs.get('member_confirm', "").capitalize())
-            subject = Utility.email_conf['email']['templates']['add_member_confirmation_subject']
-            subject = subject.replace('INVITED_PERSON_NAME', kwargs.get('accessor_email', ""))
-        elif mail_type == 'update_role_member_mail':
-            body = Utility.email_conf['email']['templates']['update_role']
-            body = body.replace('MAIL_BODY_HERE',
-                                Utility.email_conf['email']['templates']['update_role_member_mail_body'])
-            body = body.replace('BOT_NAME', kwargs.get('bot_name', ""))
-            body = body.replace('NEW_ROLE', kwargs.get('new_role', ""))
-            body = body.replace('STATUS', kwargs.get('status', ""))
-            body = body.replace('MODIFIER_NAME', first_name.capitalize())
-            body = body.replace('NAME', kwargs.get('member_name', "").capitalize())
-            subject = Utility.email_conf['email']['templates']['update_role_subject']
-            subject = subject.replace('BOT_NAME', kwargs.get('bot_name', ""))
-        elif mail_type == 'update_role_owner_mail':
-            body = Utility.email_conf['email']['templates']['update_role']
-            body = body.replace('MAIL_BODY_HERE',
-                                Utility.email_conf['email']['templates']['update_role_owner_mail_body'])
-            body = body.replace('MEMBER_EMAIL', kwargs.get('member_email', ""))
-            body = body.replace('BOT_NAME', kwargs.get('bot_name', ""))
-            body = body.replace('NEW_ROLE', kwargs.get('new_role', ""))
-            body = body.replace('STATUS', kwargs.get('status', ""))
-            body = body.replace('MODIFIER_NAME', first_name.capitalize())
-            body = body.replace('NAME', kwargs.get('owner_name', "").capitalize())
-            subject = Utility.email_conf['email']['templates']['update_role_subject']
-            subject = subject.replace('BOT_NAME', kwargs.get('bot_name', ""))
-        elif mail_type == 'transfer_ownership_mail':
-            body = Utility.email_conf['email']['templates']['update_role']
-            body = body.replace('MAIL_BODY_HERE',
-                                Utility.email_conf['email']['templates']['transfer_ownership_mail_body'])
-            body = body.replace('MEMBER_EMAIL', kwargs.get('member_email', ""))
-            body = body.replace('BOT_NAME', kwargs.get('bot_name', ""))
-            body = body.replace('NEW_ROLE', kwargs.get('new_role', ""))
-            body = body.replace('MODIFIER_NAME', first_name.capitalize())
-            subject = Utility.email_conf['email']['templates']['update_role_subject']
-            subject = subject.replace('BOT_NAME', kwargs.get('bot_name', ""))
-        elif mail_type == 'password_generated':
-            body = Utility.email_conf['email']['templates']['password_generated']
-            body = body.replace('PASSWORD', kwargs.get('password', ""))
-            subject = Utility.email_conf['email']['templates']['password_generated_subject']
-        elif mail_type == 'untrusted_login':
-            geo_location = ""
-            reset_password_url = Utility.email_conf["app"]["url"] + "/reset_password"
-            body = Utility.email_conf['email']['templates']['untrusted_login']
-            for key, value in kwargs.items():
-                geo_location = f"{geo_location}<li>{key}: {value}</li>"
-            body = body.replace('GEO_LOCATION', geo_location)
-            body = body.replace('TRUST_DEVICE_URL', url)
-            body = body.replace('RESET_PASSWORD_URL', reset_password_url)
-            subject = Utility.email_conf['email']['templates']['untrusted_login_subject']
-        elif mail_type == 'add_trusted_device':
-            geo_location = ""
-            body = Utility.email_conf['email']['templates']['add_trusted_device']
-            for key, value in kwargs.items():
-                geo_location = f"{geo_location}<li>{key}: {value}</li>"
-            body = body.replace('GEO_LOCATION', geo_location)
-            subject = Utility.email_conf['email']['templates']['add_trusted_device']
-        else:
-            logger.debug('Skipping sending mail as no template found for the mail type')
-            return
-        body = body.replace('FIRST_NAME', first_name)
-        body = body.replace('USER_EMAIL', email)
-        if url:
-            body = body.replace('VERIFICATION_LINK', url)
-        await Utility.validate_and_send_mail(email, subject, body)
-
-    @staticmethod
-    async def validate_and_send_mail(email: str, subject: str, body: str):
-        """
-        Used to validate the parameters of the mail to be sent
-
-        :param email: email id of the recipient
-        :param subject: subject of the mail
-        :param body: body or message of the mail
-        :return: None
-        """
-        if isinstance(mail_check(email), ValidationFailure):
-            raise AppException("Please check if email is valid")
-
-        if (
-                Utility.check_empty_string(subject)
-                or Utility.check_empty_string(body)
-        ):
-            raise ValidationError(
-                "Subject and body of the mail cannot be empty or blank space"
-            )
-        await Utility.trigger_smtp(email, subject, body)
-
-    @staticmethod
-    async def trigger_smtp(email: str, subject: str, body: str, content_type='html'):
-        """
-        Sends an email to the mail id of the recipient
-
-        :param email: the mail id of the recipient
-        :param subject: the subject of the mail
-        :param body: the body of the mail
-        :param content_type: "plain" or "html" content
-        :return: None
-        """
-        await Utility.trigger_email([email],
-                                    subject,
-                                    body,
-                                    content_type=content_type,
-                                    smtp_url=Utility.email_conf["email"]["sender"]["service"],
-                                    smtp_port=Utility.email_conf["email"]["sender"]["port"],
-                                    sender_email=Utility.email_conf["email"]["sender"]["email"],
-                                    smtp_userid=Utility.email_conf["email"]["sender"]["userid"],
-                                    smtp_password=Utility.email_conf["email"]["sender"]["password"],
-                                    tls=True)
-
-    @staticmethod
-    async def trigger_email(email: List[str],
-                            subject: str,
-                            body: str,
-                            smtp_url: str,
-                            smtp_port: int,
-                            sender_email: str,
-                            smtp_password: str,
-                            smtp_userid: str = None,
-                            tls: bool = False,
-                            content_type='html'):
-        """
-        Sends an email to the mail id of the recipient
-
-        :param smtp_userid:
-        :param sender_email:
-        :param tls:
-        :param smtp_port:
-        :param smtp_url:
-        :param email: the mail id of the recipient
-        :param subject: the subject of the mail
-        :param body: the body of the mail
-        :param content_type: "plain" or "html" content
-        :return: None
-        """
-        smtp = SMTP(smtp_url, port=smtp_port, timeout=10)
-        smtp.connect(smtp_url, smtp_port)
-        if tls:
-            smtp.starttls()
-        smtp.login(smtp_userid if
-                   smtp_userid else
-                   sender_email,
-                   smtp_password)
-        from_addr = sender_email
-        body = MIMEText(body, content_type)
-        msg = MIMEMultipart('alternative')
-        msg['Subject'] = subject
-        msg['From'] = from_addr
-        msg['To'] = ",".join(email)
-        msg.attach(body)
-        smtp.sendmail(from_addr, email, msg.as_string())
-        smtp.quit()
 
     @staticmethod
     def initiate_apm_client_config():
@@ -1546,6 +1363,14 @@ class Utility:
             raise AppException("Failed to validate recaptcha")
 
     @staticmethod
+    def validate_recaptcha_response(recaptcha_response: str = None, **kwargs):
+        request = kwargs.get('request')
+        remote_ip = request.headers.get('X-Forwarded-For')
+        secret = Utility.environment['security'].get('recaptcha_secret', None)
+        if Utility.environment['security']['validate_recaptcha'] and not Utility.check_empty_string(secret):
+            Utility.validate_recaptcha(recaptcha_response, remote_ip)
+
+    @staticmethod
     def compare_string_constant_time(val1: str, val2: str):
         if len(val1) != len(val2):
             return False
@@ -1849,3 +1674,269 @@ class StoryValidator:
                     raise AppException("Intent should be followed by an Action")
                 if len(list(story_graph.successors(story_node))) > 1:
                     raise AppException("Intent can only have one connection of action type")
+
+
+class MailUtility:
+
+    @staticmethod
+    async def format_and_send_mail(mail_type: str, email: str, first_name: str, url: str = None, **kwargs):
+        mail_actions_dict = {
+            'password_reset': MailUtility.__handle_password_reset,
+            'password_reset_confirmation': MailUtility.__handle_password_reset_confirmation,
+            'verification': MailUtility.__handle_verification,
+            'verification_confirmation': MailUtility.__handle_verification_confirmation,
+            'add_member': MailUtility.__handle_add_member,
+            'add_member_confirmation': MailUtility.__handle_add_member_confirmation,
+            'update_role_member_mail': MailUtility.__handle_update_role_member_mail,
+            'update_role_owner_mail': MailUtility.__handle_update_role_owner_mail,
+            'transfer_ownership_mail': MailUtility.__handle_transfer_ownership_mail,
+            'password_generated': MailUtility.__handle_password_generated,
+            'untrusted_login': MailUtility.__handle_untrusted_login,
+            'add_trusted_device': MailUtility.__handle_add_trusted_device,
+            'book_a_demo': MailUtility.__handle_book_a_demo
+        }
+        if not mail_actions_dict.get(mail_type):
+            logger.debug('Skipping sending mail as no template found for the mail type')
+            return
+        body, subject = mail_actions_dict[mail_type](first_name=first_name, url=url, **kwargs)
+        body = body.replace('FIRST_NAME', first_name)
+        body = body.replace('USER_EMAIL', email)
+        if url:
+            body = body.replace('VERIFICATION_LINK', url)
+        await MailUtility.validate_and_send_mail(email, subject, body)
+
+    @staticmethod
+    async def validate_and_send_mail(email: str, subject: str, body: str):
+        """
+        Used to validate the parameters of the mail to be sent
+
+        :param email: email id of the recipient
+        :param subject: subject of the mail
+        :param body: body or message of the mail
+        :return: None
+        """
+        if isinstance(mail_check(email), ValidationFailure):
+            raise AppException("Please check if email is valid")
+
+        if (
+                Utility.check_empty_string(subject)
+                or Utility.check_empty_string(body)
+        ):
+            raise ValidationError(
+                "Subject and body of the mail cannot be empty or blank space"
+            )
+        await MailUtility.trigger_smtp(email, subject, body)
+
+    @staticmethod
+    async def trigger_smtp(email: str, subject: str, body: str, content_type='html'):
+        """
+        Sends an email to the mail id of the recipient
+
+        :param email: the mail id of the recipient
+        :param subject: the subject of the mail
+        :param body: the body of the mail
+        :param content_type: "plain" or "html" content
+        :return: None
+        """
+        await MailUtility.trigger_email([email],
+                                        subject,
+                                        body,
+                                        content_type=content_type,
+                                        smtp_url=Utility.email_conf["email"]["sender"]["service"],
+                                        smtp_port=Utility.email_conf["email"]["sender"]["port"],
+                                        sender_email=Utility.email_conf["email"]["sender"]["email"],
+                                        smtp_userid=Utility.email_conf["email"]["sender"]["userid"],
+                                        smtp_password=Utility.email_conf["email"]["sender"]["password"],
+                                        tls=True)
+
+    @staticmethod
+    async def trigger_email(email: List[str],
+                            subject: str,
+                            body: str,
+                            smtp_url: str,
+                            smtp_port: int,
+                            sender_email: str,
+                            smtp_password: str,
+                            smtp_userid: str = None,
+                            tls: bool = False,
+                            content_type='html'):
+        """
+        Sends an email to the mail id of the recipient
+
+        :param smtp_userid:
+        :param sender_email:
+        :param tls:
+        :param smtp_port:
+        :param smtp_url:
+        :param email: the mail id of the recipient
+        :param smtp_password:
+        :param subject: the subject of the mail
+        :param body: the body of the mail
+        :param content_type: "plain" or "html" content
+        :return: None
+        """
+        smtp = SMTP(smtp_url, port=smtp_port, timeout=10)
+        smtp.connect(smtp_url, smtp_port)
+        if tls:
+            smtp.starttls()
+        smtp.login(smtp_userid if
+                   smtp_userid else
+                   sender_email,
+                   smtp_password)
+        from_addr = sender_email
+        body = MIMEText(body, content_type)
+        msg = MIMEMultipart('alternative')
+        msg['Subject'] = subject
+        msg['From'] = from_addr
+        msg['To'] = ",".join(email)
+        msg.attach(body)
+        smtp.sendmail(from_addr, email, msg.as_string())
+        smtp.quit()
+
+    @staticmethod
+    def __handle_password_reset(**kwargs):
+        first_name = kwargs.get('first_name')
+        body = Utility.email_conf['email']['templates']['password_reset']
+        body = body.replace('FIRST_NAME', first_name.capitalize())
+        subject = Utility.email_conf['email']['templates']['password_reset_subject']
+        return body, subject
+
+    @staticmethod
+    def __handle_password_reset_confirmation(**kwargs):
+        body = Utility.email_conf['email']['templates']['password_reset_confirmation']
+        subject = Utility.email_conf['email']['templates']['password_changed_subject']
+        return body, subject
+
+    @staticmethod
+    def __handle_verification(**kwargs):
+        first_name = kwargs.get('first_name')
+        body = Utility.email_conf['email']['templates']['verification']
+        body = body.replace('FIRST_NAME', first_name.capitalize())
+        subject = Utility.email_conf['email']['templates']['confirmation_subject']
+        return body, subject
+
+    @staticmethod
+    def __handle_verification_confirmation(**kwargs):
+        first_name = kwargs.get('first_name')
+        body = Utility.email_conf['email']['templates']['verification_confirmation']
+        body = body.replace('FIRST_NAME', first_name.capitalize())
+        subject = Utility.email_conf['email']['templates']['confirmed_subject']
+        return body, subject
+
+    @staticmethod
+    def __handle_add_member(**kwargs):
+        first_name = kwargs.get('first_name')
+        url = kwargs.get('url')
+        body = Utility.email_conf['email']['templates']['add_member_invitation']
+        body = body.replace('BOT_NAME', kwargs.get('bot_name', ""))
+        body = body.replace('BOT_OWNER_NAME', first_name.capitalize())
+        body = body.replace('ACCESS_TYPE', kwargs.get('role', ""))
+        body = body.replace('ACCESS_URL', url)
+        subject = Utility.email_conf['email']['templates']['add_member_subject']
+        subject = subject.replace('BOT_NAME', kwargs.get('bot_name', ""))
+        return body, subject
+
+    @staticmethod
+    def __handle_add_member_confirmation(**kwargs):
+        body = Utility.email_conf['email']['templates']['add_member_confirmation']
+        body = body.replace('BOT_NAME', kwargs.get('bot_name', ""))
+        body = body.replace('ACCESS_TYPE', kwargs.get('role', ""))
+        body = body.replace('INVITED_PERSON_NAME', kwargs.get('accessor_email', ""))
+        body = body.replace('NAME', kwargs.get('member_confirm', "").capitalize())
+        subject = Utility.email_conf['email']['templates']['add_member_confirmation_subject']
+        subject = subject.replace('INVITED_PERSON_NAME', kwargs.get('accessor_email', ""))
+        return body, subject
+
+    @staticmethod
+    def __handle_update_role_member_mail(**kwargs):
+        first_name = kwargs.get('first_name')
+        body = Utility.email_conf['email']['templates']['update_role']
+        body = body.replace('MAIL_BODY_HERE',
+                            Utility.email_conf['email']['templates']['update_role_member_mail_body'])
+        body = body.replace('BOT_NAME', kwargs.get('bot_name', ""))
+        body = body.replace('NEW_ROLE', kwargs.get('new_role', ""))
+        body = body.replace('STATUS', kwargs.get('status', ""))
+        body = body.replace('MODIFIER_NAME', first_name.capitalize())
+        body = body.replace('NAME', kwargs.get('member_name', "").capitalize())
+        subject = Utility.email_conf['email']['templates']['update_role_subject']
+        subject = subject.replace('BOT_NAME', kwargs.get('bot_name', ""))
+        return body, subject
+
+    @staticmethod
+    def __handle_update_role_owner_mail(**kwargs):
+        first_name = kwargs.get('first_name')
+        body = Utility.email_conf['email']['templates']['update_role']
+        body = body.replace('MAIL_BODY_HERE',
+                            Utility.email_conf['email']['templates']['update_role_owner_mail_body'])
+        body = body.replace('MEMBER_EMAIL', kwargs.get('member_email', ""))
+        body = body.replace('BOT_NAME', kwargs.get('bot_name', ""))
+        body = body.replace('NEW_ROLE', kwargs.get('new_role', ""))
+        body = body.replace('STATUS', kwargs.get('status', ""))
+        body = body.replace('MODIFIER_NAME', first_name.capitalize())
+        body = body.replace('NAME', kwargs.get('owner_name', "").capitalize())
+        subject = Utility.email_conf['email']['templates']['update_role_subject']
+        subject = subject.replace('BOT_NAME', kwargs.get('bot_name', ""))
+        return body, subject
+
+    @staticmethod
+    def __handle_transfer_ownership_mail(**kwargs):
+        first_name = kwargs.get('first_name')
+        body = Utility.email_conf['email']['templates']['update_role']
+        body = body.replace('MAIL_BODY_HERE',
+                            Utility.email_conf['email']['templates']['transfer_ownership_mail_body'])
+        body = body.replace('MEMBER_EMAIL', kwargs.get('member_email', ""))
+        body = body.replace('BOT_NAME', kwargs.get('bot_name', ""))
+        body = body.replace('NEW_ROLE', kwargs.get('new_role', ""))
+        body = body.replace('MODIFIER_NAME', first_name.capitalize())
+        subject = Utility.email_conf['email']['templates']['update_role_subject']
+        subject = subject.replace('BOT_NAME', kwargs.get('bot_name', ""))
+        return body, subject
+
+    @staticmethod
+    def __handle_password_generated(**kwargs):
+        body = Utility.email_conf['email']['templates']['password_generated']
+        body = body.replace('PASSWORD', kwargs.get('password', ""))
+        subject = Utility.email_conf['email']['templates']['password_generated_subject']
+        return body, subject
+
+    @staticmethod
+    def __handle_untrusted_login(**kwargs):
+        url = kwargs.get('url')
+        geo_location = ""
+        reset_password_url = Utility.email_conf["app"]["url"] + "/reset_password"
+        body = Utility.email_conf['email']['templates']['untrusted_login']
+        for key, value in kwargs.items():
+            geo_location = f"{geo_location}<li>{key}: {value}</li>"
+        body = body.replace('GEO_LOCATION', geo_location)
+        body = body.replace('TRUST_DEVICE_URL', url)
+        body = body.replace('RESET_PASSWORD_URL', reset_password_url)
+        subject = Utility.email_conf['email']['templates']['untrusted_login_subject']
+        return body, subject
+
+    @staticmethod
+    def __handle_add_trusted_device(**kwargs):
+        geo_location = ""
+        body = Utility.email_conf['email']['templates']['add_trusted_device']
+        for key, value in kwargs.items():
+            geo_location = f"{geo_location}<li>{key}: {value}</li>"
+        body = body.replace('GEO_LOCATION', geo_location)
+        subject = Utility.email_conf['email']['templates']['add_trusted_device']
+        return body, subject
+
+    @staticmethod
+    def __handle_book_a_demo(**kwargs):
+        from kairon.shared.plugins.factory import PluginFactory
+
+        request = kwargs.get('request')
+        data = kwargs.get('data')
+        ip = request.headers.get('X-Forwarded-For')
+        geo_location = PluginFactory.get_instance(PluginTypes.ip_info.value).execute(ip=ip) or {}
+        data.update(geo_location)
+        user_details = f"Hi,\nFollowing demo has been requested for Kairon:\n"
+        body = Utility.email_conf['email']['templates']['custom_text_mail']
+        for key, value in data.items():
+            user_details = f"{user_details}<li>{key}: {value}</li>"
+        subject = Utility.email_conf['email']['templates']['book_a_demo_subject']
+        body = body.replace('CUSTOM_TEXT', user_details)
+        body = body.replace('SUBJECT', subject)
+        return body, subject

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -8,6 +8,7 @@ from io import BytesIO
 from urllib.parse import urljoin
 from zipfile import ZipFile
 
+import mock
 import pytest
 import responses
 from botocore.exceptions import ClientError
@@ -46,7 +47,7 @@ from kairon.shared.models import User
 from kairon.shared.multilingual.processor import MultilingualLogProcessor
 from kairon.shared.organization.processor import OrgProcessor
 from kairon.shared.sso.clients.google import GoogleSSO
-from kairon.shared.utils import Utility
+from kairon.shared.utils import Utility, MailUtility
 from kairon.shared.multilingual.utils.translator import Translator
 import json
 from unittest.mock import patch
@@ -126,6 +127,82 @@ def test_api_wrong_login():
     assert value[0]["metric_type"] == "invalid_login"
     assert value[0]["timestamp"]
     assert len(value) == 1
+
+
+@mock.patch("kairon.shared.utils.Utility.validate_recaptcha", autospec=True)
+@mock.patch("kairon.shared.utils.MailUtility.trigger_smtp", autospec=True)
+def test_book_a_demo(trigger_smtp_mock, validate_recaptcha_mock, monkeypatch):
+    monkeypatch.setitem(Utility.environment['security'], 'validate_recaptcha', True)
+    monkeypatch.setitem(Utility.environment['security'], 'recaptcha_secret', 'asdfghjkl1234567890')
+    data = {
+        "first_name": "sample",
+        "last_name": 'test',
+        "email": "sampletest@gmail.com",
+        "contact": "9876543210",
+        "additional_info": "Thank You"
+    }
+    form_data = {"data": data, "recaptcha_response": "1234567890"}
+
+    with patch("kairon.shared.plugins.ipinfo.IpInfoTracker.execute") as mock_geo:
+        mock_geo.return_value = {"City": "Mumbai", "Network": "CATO"}
+        response = client.post(
+            "/api/auth/demo",
+            json=form_data
+        ).json()
+    assert response['message'] == 'Thank You for your interest in Kairon. We will reach out to you soon.'
+    assert not response['data']
+    assert response['error_code'] == 0
+    assert response['success']
+
+
+@mock.patch("kairon.shared.utils.MailUtility.trigger_smtp", autospec=True)
+def test_book_a_demo_with_invalid_recaptcha_response(trigger_smtp_mock, monkeypatch):
+    monkeypatch.setitem(Utility.environment['security'], 'validate_recaptcha', True)
+    monkeypatch.setitem(Utility.environment['security'], 'recaptcha_secret', 'asdfghjkl1234567890')
+    data = {
+        "first_name": "sample",
+        "last_name": 'test',
+        "email": "sampletest@gmail.com",
+        "contact": "9876543210",
+        "additional_info": "Thank You"
+    }
+    form_data = {"data": data, "recaptcha_response": ""}
+
+    with patch("kairon.shared.plugins.ipinfo.IpInfoTracker.execute") as mock_geo:
+        mock_geo.return_value = {"City": "Mumbai", "Network": "CATO"}
+        response = client.post(
+            "/api/auth/demo",
+            json=form_data
+        ).json()
+    assert response['message'] == 'recaptcha_response is required'
+    assert not response['data']
+    assert response['error_code'] == 422
+    assert not response['success']
+
+
+@mock.patch("kairon.shared.utils.MailUtility.trigger_smtp", autospec=True)
+def test_book_a_demo_with_validate_recaptcha_failed(trigger_smtp_mock, monkeypatch):
+    monkeypatch.setitem(Utility.environment['security'], 'validate_recaptcha', True)
+    monkeypatch.setitem(Utility.environment['security'], 'recaptcha_secret', 'asdfghjkl1234567890')
+    data = {
+        "first_name": "sample",
+        "last_name": 'test',
+        "email": "sampletest@gmail.com",
+        "contact": "9876543210",
+        "additional_info": "Thank You"
+    }
+    form_data = {"data": data, "recaptcha_response": "1234567890"}
+
+    with patch("kairon.shared.plugins.ipinfo.IpInfoTracker.execute") as mock_geo:
+        mock_geo.return_value = {"City": "Mumbai", "Network": "CATO"}
+        response = client.post(
+            "/api/auth/demo",
+            json=form_data
+        ).json()
+    assert response['message'] == 'Failed to validate recaptcha'
+    assert not response['data']
+    assert response['error_code'] == 422
+    assert not response['success']
 
 
 def test_account_registration_error():
@@ -693,7 +770,7 @@ def test_add_trusted_device_on_signup_error(monkeypatch):
 
 def test_add_trusted_device_disabled(monkeypatch):
     monkeypatch.setattr(AccountProcessor, "check_email_confirmation", mock_smtp)
-    monkeypatch.setattr(Utility, 'trigger_smtp', mock_smtp)
+    monkeypatch.setattr(MailUtility, 'trigger_smtp', mock_smtp)
     response = client.post(
         "/api/account/device/trusted",
         json={"data": "0987654321234567890"},
@@ -709,7 +786,7 @@ def test_add_trusted_device(monkeypatch):
     monkeypatch.setitem(Utility.environment["user"], "validate_trusted_device", True)
     monkeypatch.setitem(Utility.email_conf["email"], "enable", True)
     monkeypatch.setattr(AccountProcessor, "check_email_confirmation", mock_smtp)
-    monkeypatch.setattr(Utility, 'trigger_smtp', mock_smtp)
+    monkeypatch.setattr(MailUtility, 'trigger_smtp', mock_smtp)
 
     with patch("kairon.shared.plugins.ipinfo.IpInfoTracker.execute") as mock_geo:
         mock_geo.return_value = {"City": "Mumbai", "Network": "CATO"}
@@ -4362,7 +4439,7 @@ def test_api_login_with_account_not_verified():
 
 
 def test_account_registration_with_confirmation(monkeypatch):
-    monkeypatch.setattr(Utility, 'trigger_smtp', mock_smtp)
+    monkeypatch.setattr(MailUtility, 'trigger_smtp', mock_smtp)
     Utility.email_conf["email"]["enable"] = True
     response = client.post(
         "/api/account/registration",
@@ -4437,7 +4514,7 @@ def test_invalid_token_for_confirmation():
 
 
 def test_add_member(monkeypatch):
-    monkeypatch.setattr(Utility, 'trigger_smtp', mock_smtp)
+    monkeypatch.setattr(MailUtility, 'trigger_smtp', mock_smtp)
     monkeypatch.setitem(Utility.email_conf["email"], "enable", True)
 
     response = client.post(
@@ -4521,7 +4598,7 @@ def test_accept_bot_invite(monkeypatch):
         return {"mail_id" : "integration@demo.ai"}
 
     monkeypatch.setattr(Utility, 'verify_token', __mock_verify_token)
-    monkeypatch.setattr(Utility, 'trigger_smtp', mock_smtp)
+    monkeypatch.setattr(MailUtility, 'trigger_smtp', mock_smtp)
     monkeypatch.setattr(AccountProcessor, 'get_user_details', mock_smtp)
     monkeypatch.setitem(Utility.email_conf["email"], "enable", True)
     response = client.post(
@@ -4604,7 +4681,7 @@ def test_list_members():
 
 def test_transfer_ownership(monkeypatch):
     monkeypatch.setitem(Utility.email_conf["email"], "enable", True)
-    monkeypatch.setattr(Utility, 'trigger_smtp', mock_smtp)
+    monkeypatch.setattr(MailUtility, 'trigger_smtp', mock_smtp)
     response = client.put(
         f"/api/user/{pytest.add_member_bot}/owner/change",
         json={"data": "integration@demo.ai"},
@@ -4700,7 +4777,7 @@ def test_update_member_role(monkeypatch):
     assert actual["message"] == "Account Registered!"
 
     monkeypatch.setitem(Utility.email_conf["email"], "enable", True)
-    monkeypatch.setattr(Utility, 'trigger_smtp', mock_smtp)
+    monkeypatch.setattr(MailUtility, 'trigger_smtp', mock_smtp)
     response = client.put(
         f"/api/user/{pytest.add_member_bot}/member",
         json={"email": "integration_email_false@demo.ai", "role": "admin", "status": "inactive"},
@@ -5002,7 +5079,7 @@ def test_list_bots_for_different_user():
 
 
 def test_reset_password_for_valid_id(monkeypatch):
-    monkeypatch.setattr(Utility, 'trigger_smtp', mock_smtp)
+    monkeypatch.setattr(MailUtility, 'trigger_smtp', mock_smtp)
     Utility.email_conf["email"]["enable"] = True
     response = client.post(
         "/api/account/password/reset",
@@ -5055,7 +5132,7 @@ def test_list_bots_for_different_user_2():
 
 
 def test_send_link_for_valid_id(monkeypatch):
-    monkeypatch.setattr(Utility, 'trigger_smtp', mock_smtp)
+    monkeypatch.setattr(MailUtility, 'trigger_smtp', mock_smtp)
     Utility.email_conf["email"]["enable"] = True
     response = client.post("/api/account/email/confirmation/link",
                            json={
@@ -9883,7 +9960,7 @@ def test_trigger_mail_on_new_signup_with_sso(monkeypatch):
         return False, {'email': 'new_user@digite.com', 'first_name': 'new', 'password': SecretStr('123456789')}, token
 
     monkeypatch.setattr(Authentication, 'verify_and_process', __mock_verify_and_process)
-    monkeypatch.setattr(Utility, 'trigger_smtp', mock_smtp)
+    monkeypatch.setattr(MailUtility, 'trigger_smtp', mock_smtp)
     Utility.email_conf["email"]["enable"] = True
     response = client.get(
         url=f"/api/auth/login/sso/callback/google?code=123456789", allow_redirects=False
@@ -13844,7 +13921,7 @@ def test_get_responses_post_passwd_reset(monkeypatch):
         return token
 
     monkeypatch.setattr(Authentication, "create_access_token", get_token)
-    monkeypatch.setattr(Utility, 'trigger_smtp', mock_smtp)
+    monkeypatch.setattr(MailUtility, 'trigger_smtp', mock_smtp)
     passwrd_change_response = client.post(
         "/api/account/password/change",
         json={
@@ -13875,7 +13952,7 @@ def test_create_access_token_with_iat():
 
 
 def test_overwrite_password_for_matching_passwords(monkeypatch):
-    monkeypatch.setattr(Utility, 'trigger_smtp', mock_smtp)
+    monkeypatch.setattr(MailUtility, 'trigger_smtp', mock_smtp)
     response = client.post(
         "/api/account/password/change",
         json={
@@ -13939,7 +14016,7 @@ def test_get_responses_change_passwd_with_same_passwrd(monkeypatch):
         return token
 
     monkeypatch.setattr(Authentication, "create_access_token", get_token)
-    monkeypatch.setattr(Utility, 'trigger_smtp', mock_smtp)
+    monkeypatch.setattr(MailUtility, 'trigger_smtp', mock_smtp)
     Utility.environment['user']['reset_password_cooldown_period'] = 0
     passwrd_change_response = client.post(
         "/api/account/password/change",
@@ -13974,7 +14051,7 @@ def test_get_responses_change_passwd_with_same_passwrd_rechange(monkeypatch):
         return token
 
     monkeypatch.setattr(Authentication, "create_access_token", get_token)
-    monkeypatch.setattr(Utility, 'trigger_smtp', mock_smtp)
+    monkeypatch.setattr(MailUtility, 'trigger_smtp', mock_smtp)
     passwrd_change_response = client.post(
         "/api/account/password/change",
         json={

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -146,7 +146,7 @@ def test_book_a_demo(trigger_smtp_mock, validate_recaptcha_mock, monkeypatch):
     with patch("kairon.shared.plugins.ipinfo.IpInfoTracker.execute") as mock_geo:
         mock_geo.return_value = {"City": "Mumbai", "Network": "CATO"}
         response = client.post(
-            "/api/auth/demo",
+            "/api/user/demo",
             json=form_data
         ).json()
     assert response['message'] == 'Thank You for your interest in Kairon. We will reach out to you soon.'
@@ -171,7 +171,7 @@ def test_book_a_demo_with_invalid_recaptcha_response(trigger_smtp_mock, monkeypa
     with patch("kairon.shared.plugins.ipinfo.IpInfoTracker.execute") as mock_geo:
         mock_geo.return_value = {"City": "Mumbai", "Network": "CATO"}
         response = client.post(
-            "/api/auth/demo",
+            "/api/user/demo",
             json=form_data
         ).json()
     assert response['message'] == 'recaptcha_response is required'
@@ -196,7 +196,7 @@ def test_book_a_demo_with_validate_recaptcha_failed(trigger_smtp_mock, monkeypat
     with patch("kairon.shared.plugins.ipinfo.IpInfoTracker.execute") as mock_geo:
         mock_geo.return_value = {"City": "Mumbai", "Network": "CATO"}
         response = client.post(
-            "/api/auth/demo",
+            "/api/user/demo",
             json=form_data
         ).json()
     assert response['message'] == 'Failed to validate recaptcha'

--- a/tests/unit_test/api/api_processor_test.py
+++ b/tests/unit_test/api/api_processor_test.py
@@ -32,7 +32,7 @@ from kairon.shared.metering.data_object import Metering
 from kairon.shared.organization.processor import OrgProcessor
 from kairon.shared.sso.clients.facebook import FacebookSSO
 from kairon.shared.sso.clients.google import GoogleSSO
-from kairon.shared.utils import Utility
+from kairon.shared.utils import Utility, MailUtility
 from kairon.exceptions import AppException
 import time
 from kairon.idp.data_objects import IdpConfig
@@ -971,32 +971,32 @@ class TestAccountProcessor:
         return None
 
     def test_validate_and_send_mail(self, monkeypatch):
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
-        loop.run_until_complete(Utility.validate_and_send_mail('demo@ac.in', subject='test', body='test'))
+        loop.run_until_complete(MailUtility.validate_and_send_mail('demo@ac.in', subject='test', body='test'))
         assert True
 
     def test_send_false_email_id(self, monkeypatch):
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         with pytest.raises(Exception):
-            loop.run_until_complete(Utility.validate_and_send_mail('..', subject='test', body="test"))
+            loop.run_until_complete(MailUtility.validate_and_send_mail('..', subject='test', body="test"))
 
     def test_send_empty_mail_subject(self, monkeypatch):
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         with pytest.raises(Exception):
-            loop.run_until_complete(Utility.validate_and_send_mail('demo@ac.in', subject=' ', body='test'))
+            loop.run_until_complete(MailUtility.validate_and_send_mail('demo@ac.in', subject=' ', body='test'))
 
     def test_send_empty_mail_body(self, monkeypatch):
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         with pytest.raises(Exception):
-            loop.run_until_complete(Utility.validate_and_send_mail('demo@ac.in', subject='test', body=' '))
+            loop.run_until_complete(MailUtility.validate_and_send_mail('demo@ac.in', subject='test', body=' '))
 
     def test_format_and_send_mail_invalid_type(self):
         loop = asyncio.new_event_loop()
-        assert not loop.run_until_complete(Utility.format_and_send_mail('training_failure', 'demo@ac.in', 'udit'))
+        assert not loop.run_until_complete(MailUtility.format_and_send_mail('training_failure', 'demo@ac.in', 'udit'))
 
     def test_valid_token(self):
         token = Utility.generate_token('integ1@gmail.com')
@@ -1016,14 +1016,14 @@ class TestAccountProcessor:
             account=1,
             user="testAdmin",
         )
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         token = Utility.generate_token('integ2@gmail.com')
         loop = asyncio.new_event_loop()
         loop.run_until_complete(AccountProcessor.confirm_email(token))
         assert True
 
     def test_user_already_confirmed(self, monkeypatch):
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         token = Utility.generate_token('integ2@gmail.com')
         with pytest.raises(Exception):
@@ -1043,7 +1043,7 @@ class TestAccountProcessor:
 
     def test_reset_link_with_mail(self, monkeypatch):
         Utility.email_conf["email"]["enable"] = True
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         result = loop.run_until_complete(AccountProcessor.send_reset_link('integ2@gmail.com'))
         assert result[0] == 'integ2@gmail.com'
@@ -1054,7 +1054,7 @@ class TestAccountProcessor:
     def test_reset_link_with_mail_limit_exceeded(self, monkeypatch):
         Utility.email_conf["email"]["enable"] = True
         monkeypatch.setitem(Utility.environment['user'], 'reset_password_request_limit', 2)
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         result = loop.run_until_complete(AccountProcessor.send_reset_link('integ2@gmail.com'))
         assert result[0] == 'integ2@gmail.com'
@@ -1067,7 +1067,7 @@ class TestAccountProcessor:
 
     def test_reset_link_with_empty_mail(self, monkeypatch):
         Utility.email_conf["email"]["enable"] = True
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         with pytest.raises(Exception):
             loop.run_until_complete(AccountProcessor.send_reset_link(''))
@@ -1075,7 +1075,7 @@ class TestAccountProcessor:
 
     def test_reset_link_with_unregistered_mail(self, monkeypatch):
         Utility.email_conf["email"]["enable"] = True
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         with pytest.raises(Exception):
             loop.run_until_complete(AccountProcessor.send_reset_link('sasha.41195@gmail.com'))
@@ -1083,20 +1083,20 @@ class TestAccountProcessor:
 
     def test_reset_link_with_unconfirmed_mail(self, monkeypatch):
         Utility.email_conf["email"]["enable"] = True
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         with pytest.raises(Exception):
             loop.run_until_complete(AccountProcessor.send_reset_link('integration@demo.ai'))
         Utility.email_conf["email"]["enable"] = False
 
     def test_overwrite_password_with_invalid_token(self, monkeypatch):
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         with pytest.raises(Exception):
             loop.run_until_complete(AccountProcessor.overwrite_password('fgh', "asdfghj@1"))
 
     def test_overwrite_password_with_empty_password_string(self, monkeypatch):
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         with pytest.raises(Exception):
             loop.run_until_complete(AccountProcessor.overwrite_password(
@@ -1104,14 +1104,14 @@ class TestAccountProcessor:
                 " "))
 
     def test_overwrite_password_with_valid_entries(self, monkeypatch):
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         token = Utility.generate_token('integ2@gmail.com')
         loop = asyncio.new_event_loop()
         loop.run_until_complete(AccountProcessor.overwrite_password(token, "Welcome@3"))
         assert True
 
     def test_overwrite_password_limit_exceeded(self, monkeypatch):
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         token = Utility.generate_token('integ2@gmail.com')
         loop = asyncio.new_event_loop()
         with pytest.raises(AppException, match='Password reset limit exhausted. Please come back in *'):
@@ -1119,7 +1119,7 @@ class TestAccountProcessor:
 
     def test_reset_link_not_within_cooldown_period(self, monkeypatch):
         Utility.email_conf["email"]["enable"] = True
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         with pytest.raises(AppException, match='Password reset limit exhausted. Please come back in *'):
             loop.run_until_complete(AccountProcessor.send_reset_link('integ2@gmail.com'))
@@ -1135,7 +1135,7 @@ class TestAccountProcessor:
             user="testAdmin",
         )
         Utility.email_conf["email"]["enable"] = True
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         loop.run_until_complete(AccountProcessor.send_confirmation_link('integ3@gmail.com'))
         Utility.email_conf["email"]["enable"] = False
@@ -1143,7 +1143,7 @@ class TestAccountProcessor:
 
     def test_send_confirmation_link_with_confirmed_id(self, monkeypatch):
         Utility.email_conf["email"]["enable"] = True
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         with pytest.raises(Exception):
             loop.run_until_complete(AccountProcessor.send_confirmation_link('integ1@gmail.com'))
@@ -1151,7 +1151,7 @@ class TestAccountProcessor:
 
     def test_send_confirmation_link_with_invalid_id(self, monkeypatch):
         Utility.email_conf["email"]["enable"] = True
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         with pytest.raises(Exception):
             loop.run_until_complete(AccountProcessor.send_confirmation_link(''))
@@ -1159,20 +1159,20 @@ class TestAccountProcessor:
 
     def test_send_confirmation_link_with_unregistered_id(self, monkeypatch):
         Utility.email_conf["email"]["enable"] = True
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         with pytest.raises(Exception):
             loop.run_until_complete(AccountProcessor.send_confirmation_link('sasha.41195@gmail.com'))
         Utility.email_conf["email"]["enable"] = False
 
     def test_reset_link_with_mail_not_enabled(self, monkeypatch):
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         with pytest.raises(Exception):
             loop.run_until_complete(AccountProcessor.send_reset_link('integ1@gmail.com'))
 
     def test_send_confirmation_link_with_mail_not_enabled(self, monkeypatch):
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         with pytest.raises(Exception):
             loop.run_until_complete(AccountProcessor.send_confirmation_link('integration@demo.ai'))
@@ -2191,14 +2191,14 @@ class TestAccountProcessor:
             account=1,
             user="testAdmin",
         )
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         token = Utility.generate_token('samepasswrd@gmail.com')
         loop = asyncio.new_event_loop()
         with pytest.raises(AppException, match='You have already used that password, try another'):
             loop.run_until_complete(AccountProcessor.overwrite_password(token, "Welcome@1"))
 
     def test_overwrite_password_with_same_password_again(self, monkeypatch):
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         token = Utility.generate_token('samepasswrd@gmail.com')
         loop = asyncio.new_event_loop()
         Utility.environment['user']['reset_password_cooldown_period'] = 0
@@ -2208,7 +2208,7 @@ class TestAccountProcessor:
             loop.run_until_complete(AccountProcessor.overwrite_password(token, "Welcome@12"))
 
     def test_overwrite_password_with_original_passwrd(self, monkeypatch):
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         token = Utility.generate_token('samepasswrd@gmail.com')
         loop = asyncio.new_event_loop()
         Utility.environment['user']['reset_password_cooldown_period'] = 0
@@ -2217,7 +2217,7 @@ class TestAccountProcessor:
             loop.run_until_complete(AccountProcessor.overwrite_password(token, "Welcome@1"))
 
     def test_overwrite_password_with_successful_update(self, monkeypatch):
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         token = Utility.generate_token('samepasswrd@gmail.com')
         loop = asyncio.new_event_loop()
         Utility.environment['user']['reset_password_cooldown_period'] = 0
@@ -2235,7 +2235,7 @@ class TestAccountProcessor:
             user="reuselink_acc",
         )
         Utility.email_conf["email"]["enable"] = True
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         usertoken = Utility.generate_token('resuselink@gmail.com')
         loop.run_until_complete(AccountProcessor.confirm_email(usertoken))
@@ -2262,7 +2262,7 @@ class TestAccountProcessor:
 
     def test_reset_password_reuselink_check_uuid(self, monkeypatch):
         Utility.email_conf["email"]["enable"] = True
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         loop = asyncio.new_event_loop()
         result = loop.run_until_complete(AccountProcessor.send_reset_link('resuselink@gmail.com'))
         token = str(result[2]).split("/")[2]
@@ -2499,7 +2499,7 @@ class TestAccountProcessor:
             user="reuse-link_acc",
         )
         Utility.email_conf["email"]["enable"] = True
-        monkeypatch.setattr(Utility, 'trigger_smtp', self.mock_smtp)
+        monkeypatch.setattr(MailUtility, 'trigger_smtp', self.mock_smtp)
         with pytest.raises(AppException, match="Error! The following user's mail is not verified"):
             await(AccountProcessor.send_reset_link('integration@2.com'))
         Utility.email_conf["email"]["enable"] = False

--- a/tests/unit_test/utility_test.py
+++ b/tests/unit_test/utility_test.py
@@ -546,66 +546,92 @@ class TestUtility:
 
     @pytest.mark.asyncio
     @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
-    @mock.patch.object(MailUtility, '_MailUtility__handle_password_reset')
-    async def test_handle_password_reset(self, handle_password_reset_mock, validate_and_send_mail_mock):
+    async def test_handle_password_reset(self, validate_and_send_mail_mock):
         mail_type = 'password_reset'
         email = "sampletest@gmail.com"
         first_name = "sample"
-        handle_password_reset_mock.return_value = "test_body", "test_subject"
+
+        Utility.email_conf['email']['templates']['password_reset'] = open('template/emails/passwordReset.html',
+                                                                          'rb').read().decode()
+        expected_body = Utility.email_conf['email']['templates']['password_reset']
+        expected_body = expected_body.replace('FIRST_NAME', first_name.capitalize()).replace('FIRST_NAME', first_name)\
+            .replace('USER_EMAIL', email)
+        expected_subject = Utility.email_conf['email']['templates']['password_reset_subject']
+
         await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name)
-        handle_password_reset_mock.assert_called_once_with(first_name=first_name, url=None)
+        validate_and_send_mail_mock.assert_called_once_with(email, expected_subject, expected_body)
 
     @pytest.mark.asyncio
     @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
-    @mock.patch.object(MailUtility, '_MailUtility__handle_password_reset_confirmation')
-    async def test_handle_password_reset_confirmation(self, handle_password_reset_confirmation_mock,
-                                                      validate_and_send_mail_mock):
+    async def test_handle_password_reset_confirmation(self, validate_and_send_mail_mock):
         mail_type = 'password_reset_confirmation'
         email = "sampletest@gmail.com"
         first_name = "sample"
-        handle_password_reset_confirmation_mock.return_value = "test_body", "test_subject"
+        Utility.email_conf['email']['templates']['password_reset_confirmation'] = open(
+            'template/emails/passwordResetConfirmation.html', 'rb').read().decode()
+        expected_body = Utility.email_conf['email']['templates']['password_reset_confirmation']
+        expected_body = expected_body.replace('FIRST_NAME', first_name).replace('USER_EMAIL', email)
+        expected_subject = Utility.email_conf['email']['templates']['password_changed_subject']
+
         await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name)
-        handle_password_reset_confirmation_mock.assert_called_once_with(first_name=first_name, url=None)
+        validate_and_send_mail_mock.assert_called_once_with(email, expected_subject, expected_body)
 
     @pytest.mark.asyncio
     @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
-    @mock.patch.object(MailUtility, '_MailUtility__handle_verification')
-    async def test_handle_verification(self, handle_verification_mock, validate_and_send_mail_mock):
+    async def test_handle_verification(self, validate_and_send_mail_mock):
         mail_type = 'verification'
         email = "sampletest@gmail.com"
         first_name = "sample"
-        handle_verification_mock.return_value = "test_body", "test_subject"
+        Utility.email_conf['email']['templates']['verification'] = open('template/emails/verification.html',
+                                                                        'rb').read().decode()
+        expected_body = Utility.email_conf['email']['templates']['verification']
+        expected_body = expected_body.replace('FIRST_NAME', first_name.capitalize()).replace('FIRST_NAME', first_name)\
+            .replace('USER_EMAIL', email)
+        expected_subject = Utility.email_conf['email']['templates']['confirmation_subject']
         await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name)
-        handle_verification_mock.assert_called_once_with(first_name=first_name, url=None)
+        validate_and_send_mail_mock.assert_called_once_with(email, expected_subject, expected_body)
 
     @pytest.mark.asyncio
     @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
-    @mock.patch.object(MailUtility, '_MailUtility__handle_verification_confirmation')
-    async def test_handle_verification_confirmation(self, handle_verification_confirmation_mock,
-                                                    validate_and_send_mail_mock):
+    async def test_handle_verification_confirmation(self, validate_and_send_mail_mock):
         mail_type = 'verification_confirmation'
         email = "sampletest@gmail.com"
         first_name = "sample"
-        handle_verification_confirmation_mock.return_value = "test_body", "test_subject"
+        Utility.email_conf['email']['templates']['verification_confirmation'] = open(
+            'template/emails/verificationConfirmation.html', 'rb').read().decode()
+        expected_body = Utility.email_conf['email']['templates']['verification_confirmation']
+        expected_body = expected_body.replace('FIRST_NAME', first_name.capitalize()).replace('FIRST_NAME', first_name)\
+            .replace('USER_EMAIL', email)
+        expected_subject = Utility.email_conf['email']['templates']['confirmed_subject']
+
         await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name)
-        handle_verification_confirmation_mock.assert_called_once_with(first_name=first_name, url=None)
+        validate_and_send_mail_mock.assert_called_once_with(email, expected_subject, expected_body)
 
     @pytest.mark.asyncio
     @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
-    @mock.patch.object(MailUtility, '_MailUtility__handle_add_member')
-    async def test_handle_add_member(self, handle_add_member_mock, validate_and_send_mail_mock):
+    async def test_handle_add_member(self, validate_and_send_mail_mock):
         mail_type = 'add_member'
         email = "sampletest@gmail.com"
         first_name = "sample"
         url = "https://www.testurl.com"
-        handle_add_member_mock.return_value = "test_body", "test_subject"
-        await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name, url=url)
-        handle_add_member_mock.assert_called_once_with(first_name=first_name, url=url)
+        bot_name = "test_bot"
+        role = "test_role"
+        Utility.email_conf['email']['templates']['add_member_invitation'] = open(
+            'template/emails/memberAddAccept.html', 'rb').read().decode()
+        expected_body = Utility.email_conf['email']['templates']['add_member_invitation']
+        expected_body = expected_body.replace('BOT_NAME', bot_name).replace('BOT_OWNER_NAME', first_name.capitalize()) \
+            .replace('ACCESS_TYPE', role).replace('ACCESS_URL', url).replace('FIRST_NAME', first_name) \
+            .replace('USER_EMAIL', email).replace('VERIFICATION_LINK', url)
+        expected_subject = Utility.email_conf['email']['templates']['add_member_subject']
+        expected_subject = expected_subject.replace('BOT_NAME', bot_name)
+
+        await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name, url=url,
+                                               bot_name=bot_name, role=role)
+        validate_and_send_mail_mock.assert_called_once_with(email, expected_subject, expected_body)
 
     @pytest.mark.asyncio
     @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
-    @mock.patch.object(MailUtility, '_MailUtility__handle_add_member_confirmation')
-    async def test_handle_add_member_confirmation(self, handle_add_member_confirmation_mock, validate_and_send_mail_mock):
+    async def test_handle_add_member_confirmation(self, validate_and_send_mail_mock):
         mail_type = 'add_member_confirmation'
         email = "sampletest@gmail.com"
         first_name = "sample"
@@ -613,20 +639,23 @@ class TestUtility:
         role = "test_role"
         accessor_email = "test@gmail.com"
         member_confirm = "test_name"
-        handle_add_member_confirmation_mock.return_value = "test_body", "test_subject"
+        Utility.email_conf['email']['templates']['add_member_confirmation'] = open(
+            'template/emails/memberAddConfirmation.html', 'rb').read().decode()
+        expected_body = Utility.email_conf['email']['templates']['add_member_confirmation']
+        expected_body = expected_body.replace('BOT_NAME', bot_name).replace('ACCESS_TYPE', role)\
+            .replace('INVITED_PERSON_NAME', accessor_email).replace('NAME', member_confirm.capitalize())\
+            .replace('FIRST_NAME', first_name).replace('USER_EMAIL', email)
+        expected_subject = Utility.email_conf['email']['templates']['add_member_confirmation_subject']
+        expected_subject = expected_subject.replace('INVITED_PERSON_NAME', accessor_email)
+
         await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name,
                                                bot_name=bot_name, role=role, accessor_email=accessor_email,
                                                member_confirm=member_confirm)
-        handle_add_member_confirmation_mock.assert_called_once_with(first_name=first_name, url=None,
-                                                                    bot_name=bot_name, role=role,
-                                                                    accessor_email=accessor_email,
-                                                                    member_confirm=member_confirm)
+        validate_and_send_mail_mock.assert_called_once_with(email, expected_subject, expected_body)
 
     @pytest.mark.asyncio
     @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
-    @mock.patch.object(MailUtility, '_MailUtility__handle_update_role_member_mail')
-    async def test_handle_update_role_member_mail(self, handle_update_role_member_mail_mock,
-                                                  validate_and_send_mail_mock):
+    async def test_handle_update_role_member_mail(self, validate_and_send_mail_mock):
         mail_type = 'update_role_member_mail'
         email = "sampletest@gmail.com"
         first_name = "sample"
@@ -634,17 +663,24 @@ class TestUtility:
         new_role = "test_role"
         status = "test_status"
         member_name = "test_name"
-        handle_update_role_member_mail_mock.return_value = "test_body", "test_subject"
+        Utility.email_conf['email']['templates']['update_role'] = open(
+            'template/emails/memberUpdateRole.html', 'rb').read().decode()
+        expected_body = Utility.email_conf['email']['templates']['update_role']
+        expected_body = expected_body\
+            .replace('MAIL_BODY_HERE', Utility.email_conf['email']['templates']['update_role_member_mail_body'])\
+            .replace('BOT_NAME', bot_name).replace('NEW_ROLE', new_role).replace('STATUS', status)\
+            .replace('MODIFIER_NAME', first_name.capitalize()).replace('NAME', member_name.capitalize())\
+            .replace('FIRST_NAME', first_name).replace('USER_EMAIL', email)
+        expected_subject = Utility.email_conf['email']['templates']['update_role_subject']
+        expected_subject = expected_subject.replace('BOT_NAME', bot_name)
+
         await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name, status=status,
                                                bot_name=bot_name, new_role=new_role, member_name=member_name)
-        handle_update_role_member_mail_mock.assert_called_once_with(first_name=first_name, url=None, status=status,
-                                                                    bot_name=bot_name, new_role=new_role,
-                                                                    member_name=member_name)
+        validate_and_send_mail_mock.assert_called_once_with(email, expected_subject, expected_body)
 
     @pytest.mark.asyncio
     @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
-    @mock.patch.object(MailUtility, '_MailUtility__handle_update_role_owner_mail')
-    async def test_handle_update_role_owner_mail(self, handle_update_role_owner_mail_mock, validate_and_send_mail_mock):
+    async def test_handle_update_role_owner_mail(self, validate_and_send_mail_mock):
         mail_type = 'update_role_owner_mail'
         email = "sampletest@gmail.com"
         first_name = "sample"
@@ -653,75 +689,114 @@ class TestUtility:
         status = "test_status"
         owner_name = "test_name"
         member_email = "test@gmail.com"
-        handle_update_role_owner_mail_mock.return_value = "test_body", "test_subject"
+        Utility.email_conf['email']['templates']['update_role'] = open(
+            'template/emails/memberUpdateRole.html', 'rb').read().decode()
+        expected_body = Utility.email_conf['email']['templates']['update_role']
+        expected_body = expected_body\
+            .replace('MAIL_BODY_HERE', Utility.email_conf['email']['templates']['update_role_owner_mail_body'])\
+            .replace('MEMBER_EMAIL', member_email).replace('BOT_NAME', bot_name).replace('NEW_ROLE', new_role)\
+            .replace('STATUS', status).replace('MODIFIER_NAME', first_name.capitalize())\
+            .replace('NAME', owner_name.capitalize()).replace('FIRST_NAME', first_name).replace('USER_EMAIL', email)
+        expected_subject = Utility.email_conf['email']['templates']['update_role_subject']
+        expected_subject = expected_subject.replace('BOT_NAME', bot_name)
+
         await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name, status=status,
                                                bot_name=bot_name, new_role=new_role, owner_name=owner_name,
                                                member_email=member_email)
-        handle_update_role_owner_mail_mock.assert_called_once_with(first_name=first_name, url=None, status=status,
-                                                                   bot_name=bot_name, new_role=new_role,
-                                                                   owner_name=owner_name, member_email=member_email)
+        validate_and_send_mail_mock.assert_called_once_with(email, expected_subject, expected_body)
 
     @pytest.mark.asyncio
     @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
-    @mock.patch.object(MailUtility, '_MailUtility__handle_transfer_ownership_mail')
-    async def test_handle_transfer_ownership_mail(self, handle_transfer_ownership_mail_mock, validate_and_send_mail_mock):
+    async def test_handle_transfer_ownership_mail(self, validate_and_send_mail_mock):
         mail_type = 'transfer_ownership_mail'
         email = "sampletest@gmail.com"
         first_name = "sample"
         bot_name = "test_bot"
         new_role = "test_role"
         member_email = "test@gmail.com"
-        handle_transfer_ownership_mail_mock.return_value = "test_body", "test_subject"
+        Utility.email_conf['email']['templates']['update_role'] = open(
+            'template/emails/memberUpdateRole.html', 'rb').read().decode()
+        expected_body = Utility.email_conf['email']['templates']['update_role']
+        expected_body = expected_body\
+            .replace('MAIL_BODY_HERE', Utility.email_conf['email']['templates']['transfer_ownership_mail_body'])\
+            .replace('MEMBER_EMAIL', member_email).replace('BOT_NAME', bot_name).replace('NEW_ROLE', new_role)\
+            .replace('MODIFIER_NAME', first_name.capitalize()).replace('FIRST_NAME', first_name)\
+            .replace('USER_EMAIL', email)
+        expected_subject = Utility.email_conf['email']['templates']['update_role_subject']
+        expected_subject = expected_subject.replace('BOT_NAME', bot_name)
+
         await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name,
                                                bot_name=bot_name, new_role=new_role, member_email=member_email)
-        handle_transfer_ownership_mail_mock.assert_called_once_with(first_name=first_name, url=None,
-                                                                    bot_name=bot_name, new_role=new_role,
-                                                                    member_email=member_email)
+        validate_and_send_mail_mock.assert_called_once_with(email, expected_subject, expected_body)
 
     @pytest.mark.asyncio
     @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
-    @mock.patch.object(MailUtility, '_MailUtility__handle_password_generated')
-    async def test_handle_password_generated(self, handle_password_generated_mock, validate_and_send_mail_mock):
+    async def test_handle_password_generated(self, validate_and_send_mail_mock):
         mail_type = 'password_generated'
         email = "sampletest@gmail.com"
         first_name = "sample"
         password = "test@123"
-        handle_password_generated_mock.return_value = "test_body", "test_subject"
+        Utility.email_conf['email']['templates']['password_generated'] = open(
+            'template/emails/passwordGenerated.html', 'rb').read().decode()
+        expected_body = Utility.email_conf['email']['templates']['password_generated']
+        expected_body = expected_body.replace('PASSWORD', password).replace('FIRST_NAME', first_name)\
+            .replace('USER_EMAIL', email)
+        expected_subject = Utility.email_conf['email']['templates']['password_generated_subject']
+
         await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name,
                                                password=password)
-        handle_password_generated_mock.assert_called_once_with(first_name=first_name, url=None, password=password)
+        validate_and_send_mail_mock.assert_called_once_with(email, expected_subject, expected_body)
 
     @pytest.mark.asyncio
     @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
-    @mock.patch.object(MailUtility, '_MailUtility__handle_untrusted_login')
-    async def test_handle_untrusted_login(self, handle_untrusted_login_mock, validate_and_send_mail_mock):
+    async def test_handle_untrusted_login(self, validate_and_send_mail_mock):
         mail_type = 'untrusted_login'
         email = "sampletest@gmail.com"
         first_name = "sample"
         url = "https://www.testurl.com"
-        handle_untrusted_login_mock.return_value = "test_body", "test_subject"
-        await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name, url=url)
-        handle_untrusted_login_mock.assert_called_once_with(first_name=first_name, url=url)
+        geo_location = {'City': 'Mumbai', 'Network': 'CATO'}
+        reset_password_url = Utility.email_conf["app"]["url"] + "/reset_password"
+        Utility.email_conf['email']['templates']['untrusted_login'] = open(
+            'template/emails/untrustedLogin.html', 'rb').read().decode()
+        expected_body = Utility.email_conf['email']['templates']['untrusted_login']
+        expected_geo_location = "<li>first_name: sample</li><li>url: https://www.testurl.com</li>" \
+                                "<li>City: Mumbai</li><li>Network: CATO</li>"
+        expected_body = expected_body.replace('GEO_LOCATION', expected_geo_location).replace('TRUST_DEVICE_URL', url)\
+            .replace('RESET_PASSWORD_URL', reset_password_url).replace('FIRST_NAME', first_name)\
+            .replace('USER_EMAIL', email).replace('VERIFICATION_LINK', url)
+        expected_subject = Utility.email_conf['email']['templates']['untrusted_login_subject']
+
+        await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name, url=url,
+                                               **geo_location)
+        validate_and_send_mail_mock.assert_called_once_with(email, expected_subject, expected_body)
 
     @pytest.mark.asyncio
     @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
-    @mock.patch.object(MailUtility, '_MailUtility__handle_add_trusted_device')
-    async def test_handle_add_trusted_device(self, handle_add_trusted_device_mock, validate_and_send_mail_mock):
+    async def test_handle_add_trusted_device(self, validate_and_send_mail_mock):
         mail_type = 'add_trusted_device'
         email = "sampletest@gmail.com"
         first_name = "sample"
-        handle_add_trusted_device_mock.return_value = "test_body", "test_subject"
-        await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name)
-        handle_add_trusted_device_mock.assert_called_once_with(first_name=first_name, url=None)
+        geo_location = {'City': 'Mumbai', 'Network': 'CATO'}
+        Utility.email_conf['email']['templates']['add_trusted_device'] = open(
+            'template/emails/untrustedLogin.html', 'rb').read().decode()
+        expected_body = Utility.email_conf['email']['templates']['add_trusted_device']
+        expected_geo_location = "<li>first_name: sample</li><li>url: None</li>" \
+                                "<li>City: Mumbai</li><li>Network: CATO</li>"
+        expected_body = expected_body.replace('GEO_LOCATION', expected_geo_location).replace('FIRST_NAME', first_name)\
+            .replace('USER_EMAIL', email)
+        expected_subject = Utility.email_conf['email']['templates']['add_trusted_device']
+
+        await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name, **geo_location)
+        validate_and_send_mail_mock.assert_called_once_with(email, expected_subject, expected_body)
 
     @pytest.mark.asyncio
     @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
-    @mock.patch.object(MailUtility, '_MailUtility__handle_book_a_demo')
-    async def test_handle_book_a_demo(self, handle_book_a_demo_mock, validate_and_send_mail_mock):
+    async def test_handle_book_a_demo(self, validate_and_send_mail_mock):
         mail_type = 'book_a_demo'
         email = "sampletest@gmail.com"
         first_name = "sample"
-        request = "test request"
+        request = mock.Mock()
+        request.headers = {'X-Forwarded-For': '58.0.127.89'}
         data = {
             "first_name": "sample",
             "last_name": 'test',
@@ -729,10 +804,19 @@ class TestUtility:
             "contact": "9876543210",
             "additional_info": "Thank You"
         }
-        handle_book_a_demo_mock.return_value = "test_body", "test_subject"
+        Utility.email_conf['email']['templates']['custom_text_mail'] = open(
+            'template/emails/custom_text_mail.html', 'rb').read().decode()
+        user_details = "Hi,\nFollowing demo has been requested for Kairon:\n<li>first_name: sample</li>" \
+                       "<li>last_name: test</li><li>email: sampletest@gmail.com</li><li>contact: 9876543210</li>" \
+                       "<li>additional_info: Thank You</li>"
+        expected_subject = Utility.email_conf['email']['templates']['book_a_demo_subject']
+        expected_body = Utility.email_conf['email']['templates']['custom_text_mail']
+        expected_body = expected_body.replace('CUSTOM_TEXT', user_details).replace('SUBJECT', expected_subject)\
+            .replace('FIRST_NAME', first_name).replace('USER_EMAIL', email)
+
         await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name, request=request,
                                                data=data)
-        handle_book_a_demo_mock.assert_called_once_with(first_name=first_name, url=None, request=request, data=data)
+        validate_and_send_mail_mock.assert_called_once_with(email, expected_subject, expected_body)
 
     @pytest.mark.asyncio
     async def test_trigger_email(self):

--- a/tests/unit_test/utility_test.py
+++ b/tests/unit_test/utility_test.py
@@ -23,7 +23,7 @@ from kairon.shared.data.base_data import AuditLogData
 from kairon.shared.data.data_objects import EventConfig, StoryEvents, Slots
 from kairon.shared.data.utils import DataUtility
 from kairon.shared.models import TemplateType
-from kairon.shared.utils import Utility
+from kairon.shared.utils import Utility, MailUtility
 from unittest.mock import patch
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -558,16 +558,16 @@ class TestUtility:
             smtp_userid = None
             tls = False
 
-            await Utility.trigger_email([to_email],
-                                        subject,
-                                        body,
-                                        content_type=content_type,
-                                        smtp_url=smtp_url,
-                                        smtp_port=smtp_port,
-                                        sender_email=sender_email,
-                                        smtp_userid=smtp_userid,
-                                        smtp_password=smtp_password,
-                                        tls=tls)
+            await MailUtility.trigger_email([to_email],
+                                            subject,
+                                            body,
+                                            content_type=content_type,
+                                            smtp_url=smtp_url,
+                                            smtp_port=smtp_port,
+                                            sender_email=sender_email,
+                                            smtp_userid=smtp_userid,
+                                            smtp_password=smtp_password,
+                                            tls=tls)
 
             mbody = MIMEText(body, content_type)
             msg = MIMEMultipart('alternative')
@@ -615,16 +615,16 @@ class TestUtility:
             smtp_userid = None
             tls = True
 
-            await Utility.trigger_email([to_email],
-                                        subject,
-                                        body,
-                                        content_type=content_type,
-                                        smtp_url=smtp_url,
-                                        smtp_port=smtp_port,
-                                        sender_email=sender_email,
-                                        smtp_userid=smtp_userid,
-                                        smtp_password=smtp_password,
-                                        tls=tls)
+            await MailUtility.trigger_email([to_email],
+                                            subject,
+                                            body,
+                                            content_type=content_type,
+                                            smtp_url=smtp_url,
+                                            smtp_port=smtp_port,
+                                            sender_email=sender_email,
+                                            smtp_userid=smtp_userid,
+                                            smtp_password=smtp_password,
+                                            tls=tls)
 
             name, args, kwargs = mock.method_calls.pop(0)
             assert name == '().connect'
@@ -669,16 +669,16 @@ class TestUtility:
             smtp_userid = "test_user"
             tls = True
 
-            await Utility.trigger_email([to_email],
-                                        subject,
-                                        body,
-                                        content_type=content_type,
-                                        smtp_url=smtp_url,
-                                        smtp_port=smtp_port,
-                                        sender_email=sender_email,
-                                        smtp_userid=smtp_userid,
-                                        smtp_password=smtp_password,
-                                        tls=tls)
+            await MailUtility.trigger_email([to_email],
+                                            subject,
+                                            body,
+                                            content_type=content_type,
+                                            smtp_url=smtp_url,
+                                            smtp_port=smtp_port,
+                                            sender_email=sender_email,
+                                            smtp_userid=smtp_userid,
+                                            smtp_password=smtp_password,
+                                            tls=tls)
 
             name, args, kwargs = mock.method_calls.pop(0)
             assert name == '().connect'
@@ -730,7 +730,7 @@ class TestUtility:
             smtp_password = "changeit"
             smtp_port = 587
 
-            await Utility.trigger_smtp(to_email,
+            await MailUtility.trigger_smtp(to_email,
                                         subject,
                                         body,
                                         content_type=content_type)

--- a/tests/unit_test/utility_test.py
+++ b/tests/unit_test/utility_test.py
@@ -545,6 +545,196 @@ class TestUtility:
             Utility.is_model_file_exists('invalid_bot')
 
     @pytest.mark.asyncio
+    @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
+    @mock.patch.object(MailUtility, '_MailUtility__handle_password_reset')
+    async def test_handle_password_reset(self, handle_password_reset_mock, validate_and_send_mail_mock):
+        mail_type = 'password_reset'
+        email = "sampletest@gmail.com"
+        first_name = "sample"
+        handle_password_reset_mock.return_value = "test_body", "test_subject"
+        await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name)
+        handle_password_reset_mock.assert_called_once_with(first_name=first_name, url=None)
+
+    @pytest.mark.asyncio
+    @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
+    @mock.patch.object(MailUtility, '_MailUtility__handle_password_reset_confirmation')
+    async def test_handle_password_reset_confirmation(self, handle_password_reset_confirmation_mock,
+                                                      validate_and_send_mail_mock):
+        mail_type = 'password_reset_confirmation'
+        email = "sampletest@gmail.com"
+        first_name = "sample"
+        handle_password_reset_confirmation_mock.return_value = "test_body", "test_subject"
+        await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name)
+        handle_password_reset_confirmation_mock.assert_called_once_with(first_name=first_name, url=None)
+
+    @pytest.mark.asyncio
+    @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
+    @mock.patch.object(MailUtility, '_MailUtility__handle_verification')
+    async def test_handle_verification(self, handle_verification_mock, validate_and_send_mail_mock):
+        mail_type = 'verification'
+        email = "sampletest@gmail.com"
+        first_name = "sample"
+        handle_verification_mock.return_value = "test_body", "test_subject"
+        await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name)
+        handle_verification_mock.assert_called_once_with(first_name=first_name, url=None)
+
+    @pytest.mark.asyncio
+    @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
+    @mock.patch.object(MailUtility, '_MailUtility__handle_verification_confirmation')
+    async def test_handle_verification_confirmation(self, handle_verification_confirmation_mock,
+                                                    validate_and_send_mail_mock):
+        mail_type = 'verification_confirmation'
+        email = "sampletest@gmail.com"
+        first_name = "sample"
+        handle_verification_confirmation_mock.return_value = "test_body", "test_subject"
+        await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name)
+        handle_verification_confirmation_mock.assert_called_once_with(first_name=first_name, url=None)
+
+    @pytest.mark.asyncio
+    @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
+    @mock.patch.object(MailUtility, '_MailUtility__handle_add_member')
+    async def test_handle_add_member(self, handle_add_member_mock, validate_and_send_mail_mock):
+        mail_type = 'add_member'
+        email = "sampletest@gmail.com"
+        first_name = "sample"
+        url = "https://www.testurl.com"
+        handle_add_member_mock.return_value = "test_body", "test_subject"
+        await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name, url=url)
+        handle_add_member_mock.assert_called_once_with(first_name=first_name, url=url)
+
+    @pytest.mark.asyncio
+    @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
+    @mock.patch.object(MailUtility, '_MailUtility__handle_add_member_confirmation')
+    async def test_handle_add_member_confirmation(self, handle_add_member_confirmation_mock, validate_and_send_mail_mock):
+        mail_type = 'add_member_confirmation'
+        email = "sampletest@gmail.com"
+        first_name = "sample"
+        bot_name = "test_bot"
+        role = "test_role"
+        accessor_email = "test@gmail.com"
+        member_confirm = "test_name"
+        handle_add_member_confirmation_mock.return_value = "test_body", "test_subject"
+        await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name,
+                                               bot_name=bot_name, role=role, accessor_email=accessor_email,
+                                               member_confirm=member_confirm)
+        handle_add_member_confirmation_mock.assert_called_once_with(first_name=first_name, url=None,
+                                                                    bot_name=bot_name, role=role,
+                                                                    accessor_email=accessor_email,
+                                                                    member_confirm=member_confirm)
+
+    @pytest.mark.asyncio
+    @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
+    @mock.patch.object(MailUtility, '_MailUtility__handle_update_role_member_mail')
+    async def test_handle_update_role_member_mail(self, handle_update_role_member_mail_mock,
+                                                  validate_and_send_mail_mock):
+        mail_type = 'update_role_member_mail'
+        email = "sampletest@gmail.com"
+        first_name = "sample"
+        bot_name = "test_bot"
+        new_role = "test_role"
+        status = "test_status"
+        member_name = "test_name"
+        handle_update_role_member_mail_mock.return_value = "test_body", "test_subject"
+        await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name, status=status,
+                                               bot_name=bot_name, new_role=new_role, member_name=member_name)
+        handle_update_role_member_mail_mock.assert_called_once_with(first_name=first_name, url=None, status=status,
+                                                                    bot_name=bot_name, new_role=new_role,
+                                                                    member_name=member_name)
+
+    @pytest.mark.asyncio
+    @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
+    @mock.patch.object(MailUtility, '_MailUtility__handle_update_role_owner_mail')
+    async def test_handle_update_role_owner_mail(self, handle_update_role_owner_mail_mock, validate_and_send_mail_mock):
+        mail_type = 'update_role_owner_mail'
+        email = "sampletest@gmail.com"
+        first_name = "sample"
+        bot_name = "test_bot"
+        new_role = "test_role"
+        status = "test_status"
+        owner_name = "test_name"
+        member_email = "test@gmail.com"
+        handle_update_role_owner_mail_mock.return_value = "test_body", "test_subject"
+        await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name, status=status,
+                                               bot_name=bot_name, new_role=new_role, owner_name=owner_name,
+                                               member_email=member_email)
+        handle_update_role_owner_mail_mock.assert_called_once_with(first_name=first_name, url=None, status=status,
+                                                                   bot_name=bot_name, new_role=new_role,
+                                                                   owner_name=owner_name, member_email=member_email)
+
+    @pytest.mark.asyncio
+    @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
+    @mock.patch.object(MailUtility, '_MailUtility__handle_transfer_ownership_mail')
+    async def test_handle_transfer_ownership_mail(self, handle_transfer_ownership_mail_mock, validate_and_send_mail_mock):
+        mail_type = 'transfer_ownership_mail'
+        email = "sampletest@gmail.com"
+        first_name = "sample"
+        bot_name = "test_bot"
+        new_role = "test_role"
+        member_email = "test@gmail.com"
+        handle_transfer_ownership_mail_mock.return_value = "test_body", "test_subject"
+        await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name,
+                                               bot_name=bot_name, new_role=new_role, member_email=member_email)
+        handle_transfer_ownership_mail_mock.assert_called_once_with(first_name=first_name, url=None,
+                                                                    bot_name=bot_name, new_role=new_role,
+                                                                    member_email=member_email)
+
+    @pytest.mark.asyncio
+    @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
+    @mock.patch.object(MailUtility, '_MailUtility__handle_password_generated')
+    async def test_handle_password_generated(self, handle_password_generated_mock, validate_and_send_mail_mock):
+        mail_type = 'password_generated'
+        email = "sampletest@gmail.com"
+        first_name = "sample"
+        password = "test@123"
+        handle_password_generated_mock.return_value = "test_body", "test_subject"
+        await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name,
+                                               password=password)
+        handle_password_generated_mock.assert_called_once_with(first_name=first_name, url=None, password=password)
+
+    @pytest.mark.asyncio
+    @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
+    @mock.patch.object(MailUtility, '_MailUtility__handle_untrusted_login')
+    async def test_handle_untrusted_login(self, handle_untrusted_login_mock, validate_and_send_mail_mock):
+        mail_type = 'untrusted_login'
+        email = "sampletest@gmail.com"
+        first_name = "sample"
+        url = "https://www.testurl.com"
+        handle_untrusted_login_mock.return_value = "test_body", "test_subject"
+        await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name, url=url)
+        handle_untrusted_login_mock.assert_called_once_with(first_name=first_name, url=url)
+
+    @pytest.mark.asyncio
+    @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
+    @mock.patch.object(MailUtility, '_MailUtility__handle_add_trusted_device')
+    async def test_handle_add_trusted_device(self, handle_add_trusted_device_mock, validate_and_send_mail_mock):
+        mail_type = 'add_trusted_device'
+        email = "sampletest@gmail.com"
+        first_name = "sample"
+        handle_add_trusted_device_mock.return_value = "test_body", "test_subject"
+        await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name)
+        handle_add_trusted_device_mock.assert_called_once_with(first_name=first_name, url=None)
+
+    @pytest.mark.asyncio
+    @mock.patch("kairon.shared.utils.MailUtility.validate_and_send_mail", autospec=True)
+    @mock.patch.object(MailUtility, '_MailUtility__handle_book_a_demo')
+    async def test_handle_book_a_demo(self, handle_book_a_demo_mock, validate_and_send_mail_mock):
+        mail_type = 'book_a_demo'
+        email = "sampletest@gmail.com"
+        first_name = "sample"
+        request = "test request"
+        data = {
+            "first_name": "sample",
+            "last_name": 'test',
+            "email": "sampletest@gmail.com",
+            "contact": "9876543210",
+            "additional_info": "Thank You"
+        }
+        handle_book_a_demo_mock.return_value = "test_body", "test_subject"
+        await MailUtility.format_and_send_mail(mail_type=mail_type, email=email, first_name=first_name, request=request,
+                                               data=data)
+        handle_book_a_demo_mock.assert_called_once_with(first_name=first_name, url=None, request=request, data=data)
+
+    @pytest.mark.asyncio
     async def test_trigger_email(self):
         with patch('kairon.shared.utils.SMTP', autospec=True) as mock:
             content_type = "html"


### PR DESCRIPTION
Changes Made:

Added API to trigger mail for demo in kairon
Added MailUtility class and added validate_recaptcha_response method in Utils.
Added book_a_demo_subject in email.yaml
Updated MailUtility usages in other files.
Added/Modified Unit and Integration Tests for the above changes.