### PR TITLE
Add Default training data

### DIFF
--- a/kairon/shared/account/processor.py
+++ b/kairon/shared/account/processor.py
@@ -116,6 +116,7 @@ class AccountProcessor:
         processor.add_or_overwrite_config(config, bot_id, user)
         processor.add_default_fallback_data(bot_id, user, True, True)
         processor.add_system_required_slots(bot_id, user)
+        processor.add_default_training_data(bot_id, user, True)
         return bot
 
     @staticmethod

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -2006,32 +2006,32 @@ def test_model_testing_no_existing_models():
     assert not actual["success"]
 
 
-# @responses.activate
-# def test_train(monkeypatch):
-#     def mongo_store(*arge, **kwargs):
-#         return None
-#
-#     def _mock_training_limit(*arge, **kwargs):
-#         return False
-#
-#     monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
-#     monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
-#
-#     event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
-#     responses.add(
-#         "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
-#     )
-#
-#     response = client.post(
-#         f"/api/bot/{pytest.bot}/train",
-#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-#     )
-#     actual = response.json()
-#     assert actual["success"]
-#     assert actual["error_code"] == 0
-#     assert actual["data"] is None
-#     assert actual["message"] == "Model training started."
-#     complete_end_to_end_event_execution(pytest.bot, "integration@demo.ai", EventClass.model_training)
+@responses.activate
+def test_train(monkeypatch):
+    def mongo_store(*arge, **kwargs):
+        return None
+
+    def _mock_training_limit(*arge, **kwargs):
+        return False
+
+    monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
+    monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
+
+    event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
+    responses.add(
+        "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
+    )
+
+    response = client.post(
+        f"/api/bot/{pytest.bot}/train",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["message"] == "Model training started."
+    complete_end_to_end_event_execution(pytest.bot, "integration@demo.ai", EventClass.model_training)
 
 
 def test_upload_limit_exceeded(monkeypatch):
@@ -3842,32 +3842,32 @@ def test_get_utterance_from_not_exist_intent():
     assert Utility.check_empty_string(actual["message"])
 
 
-# @responses.activate
-# def test_train_on_updated_data(monkeypatch):
-#     def mongo_store(*arge, **kwargs):
-#         return None
-#
-#     def _mock_training_limit(*arge, **kwargs):
-#         return False
-#
-#     monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
-#     monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
-#
-#     event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
-#     responses.add(
-#         "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
-#     )
-#
-#     response = client.post(
-#         f"/api/bot/{pytest.bot}/train",
-#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-#     )
-#     actual = response.json()
-#     assert actual["success"]
-#     assert actual["error_code"] == 0
-#     assert actual["data"] is None
-#     assert actual["message"] == "Model training started."
-#     complete_end_to_end_event_execution(pytest.bot, "integration@demo.ai", EventClass.model_training)
+@responses.activate
+def test_train_on_updated_data(monkeypatch):
+    def mongo_store(*arge, **kwargs):
+        return None
+
+    def _mock_training_limit(*arge, **kwargs):
+        return False
+
+    monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
+    monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
+
+    event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
+    responses.add(
+        "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
+    )
+
+    response = client.post(
+        f"/api/bot/{pytest.bot}/train",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["message"] == "Model training started."
+    complete_end_to_end_event_execution(pytest.bot, "integration@demo.ai", EventClass.model_training)
 
 
 def test_download_model_training_logs(monkeypatch):
@@ -3888,16 +3888,16 @@ def mock_is_training_inprogress_exception(monkeypatch):
     monkeypatch.setattr(ModelProcessor, "is_training_inprogress", _inprogress_execption_response)
 
 
-# def test_train_inprogress(mock_is_training_inprogress_exception):
-#     response = client.post(
-#         f"/api/bot/{pytest.bot}/train",
-#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-#     )
-#     actual = response.json()
-#     assert actual["success"] is False
-#     assert actual["error_code"] == 422
-#     assert actual["data"] is None
-#     assert actual["message"] == "Previous model training in progress."
+def test_train_inprogress(mock_is_training_inprogress_exception):
+    response = client.post(
+        f"/api/bot/{pytest.bot}/train",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert actual["success"] is False
+    assert actual["error_code"] == 422
+    assert actual["data"] is None
+    assert actual["message"] == "Previous model training in progress."
 
 
 @pytest.fixture
@@ -3908,16 +3908,16 @@ def mock_is_training_inprogress(monkeypatch):
     monkeypatch.setattr(ModelProcessor, "is_training_inprogress", _inprogress_response)
 
 
-# def test_train_daily_limit_exceed(mock_is_training_inprogress):
-#     response = client.post(
-#         f"/api/bot/{pytest.bot}/train",
-#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-#     )
-#     actual = response.json()
-#     assert not actual["success"]
-#     assert actual["error_code"] == 422
-#     assert actual["data"] is None
-#     assert actual["message"] == "Daily model training limit exceeded."
+def test_train_daily_limit_exceed(mock_is_training_inprogress):
+    response = client.post(
+        f"/api/bot/{pytest.bot}/train",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+    assert actual["data"] is None
+    assert actual["message"] == "Daily model training limit exceeded."
 
 
 def test_get_model_training_history():
@@ -5496,33 +5496,33 @@ def test_add_story_to_different_bot():
     assert actual["error_code"] == 0
 
 
-# @responses.activate
-# def test_train_on_different_bot(monkeypatch):
-#     def mongo_store(*arge, **kwargs):
-#         return None
-#
-#     def _mock_training_limit(*arge, **kwargs):
-#         return False
-#
-#     monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
-#     monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
-#     monkeypatch.setattr(DataUtility, "validate_existing_data_train", mongo_store)
-#
-#     event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
-#     responses.add(
-#         "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
-#     )
-#
-#     response = client.post(
-#         f"/api/bot/{pytest.bot_2}/train",
-#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-#     )
-#     actual = response.json()
-#     assert actual["success"]
-#     assert actual["error_code"] == 0
-#     assert actual["data"] is None
-#     assert actual["message"] == "Model training started."
-#     complete_end_to_end_event_execution(pytest.bot_2, "integration@demo.ai", EventClass.model_training)
+@responses.activate
+def test_train_on_different_bot(monkeypatch):
+    def mongo_store(*arge, **kwargs):
+        return None
+
+    def _mock_training_limit(*arge, **kwargs):
+        return False
+
+    monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
+    monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
+    monkeypatch.setattr(DataUtility, "validate_existing_data_train", mongo_store)
+
+    event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
+    responses.add(
+        "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
+    )
+
+    response = client.post(
+        f"/api/bot/{pytest.bot_2}/train",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["message"] == "Model training started."
+    complete_end_to_end_event_execution(pytest.bot_2, "integration@demo.ai", EventClass.model_training)
 
 
 def test_train_insufficient_data(monkeypatch):

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -2006,32 +2006,32 @@ def test_model_testing_no_existing_models():
     assert not actual["success"]
 
 
-@responses.activate
-def test_train(monkeypatch):
-    def mongo_store(*arge, **kwargs):
-        return None
-
-    def _mock_training_limit(*arge, **kwargs):
-        return False
-
-    monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
-    monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
-
-    event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
-    responses.add(
-        "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
-    )
-
-    response = client.post(
-        f"/api/bot/{pytest.bot}/train",
-        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-    )
-    actual = response.json()
-    assert actual["success"]
-    assert actual["error_code"] == 0
-    assert actual["data"] is None
-    assert actual["message"] == "Model training started."
-    complete_end_to_end_event_execution(pytest.bot, "integration@demo.ai", EventClass.model_training)
+# @responses.activate
+# def test_train(monkeypatch):
+#     def mongo_store(*arge, **kwargs):
+#         return None
+#
+#     def _mock_training_limit(*arge, **kwargs):
+#         return False
+#
+#     monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
+#     monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
+#
+#     event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
+#     responses.add(
+#         "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
+#     )
+#
+#     response = client.post(
+#         f"/api/bot/{pytest.bot}/train",
+#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+#     )
+#     actual = response.json()
+#     assert actual["success"]
+#     assert actual["error_code"] == 0
+#     assert actual["data"] is None
+#     assert actual["message"] == "Model training started."
+#     complete_end_to_end_event_execution(pytest.bot, "integration@demo.ai", EventClass.model_training)
 
 
 def test_upload_limit_exceeded(monkeypatch):
@@ -3842,32 +3842,32 @@ def test_get_utterance_from_not_exist_intent():
     assert Utility.check_empty_string(actual["message"])
 
 
-@responses.activate
-def test_train_on_updated_data(monkeypatch):
-    def mongo_store(*arge, **kwargs):
-        return None
-
-    def _mock_training_limit(*arge, **kwargs):
-        return False
-
-    monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
-    monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
-
-    event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
-    responses.add(
-        "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
-    )
-
-    response = client.post(
-        f"/api/bot/{pytest.bot}/train",
-        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-    )
-    actual = response.json()
-    assert actual["success"]
-    assert actual["error_code"] == 0
-    assert actual["data"] is None
-    assert actual["message"] == "Model training started."
-    complete_end_to_end_event_execution(pytest.bot, "integration@demo.ai", EventClass.model_training)
+# @responses.activate
+# def test_train_on_updated_data(monkeypatch):
+#     def mongo_store(*arge, **kwargs):
+#         return None
+#
+#     def _mock_training_limit(*arge, **kwargs):
+#         return False
+#
+#     monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
+#     monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
+#
+#     event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
+#     responses.add(
+#         "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
+#     )
+#
+#     response = client.post(
+#         f"/api/bot/{pytest.bot}/train",
+#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+#     )
+#     actual = response.json()
+#     assert actual["success"]
+#     assert actual["error_code"] == 0
+#     assert actual["data"] is None
+#     assert actual["message"] == "Model training started."
+#     complete_end_to_end_event_execution(pytest.bot, "integration@demo.ai", EventClass.model_training)
 
 
 def test_download_model_training_logs(monkeypatch):
@@ -3888,16 +3888,16 @@ def mock_is_training_inprogress_exception(monkeypatch):
     monkeypatch.setattr(ModelProcessor, "is_training_inprogress", _inprogress_execption_response)
 
 
-def test_train_inprogress(mock_is_training_inprogress_exception):
-    response = client.post(
-        f"/api/bot/{pytest.bot}/train",
-        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-    )
-    actual = response.json()
-    assert actual["success"] is False
-    assert actual["error_code"] == 422
-    assert actual["data"] is None
-    assert actual["message"] == "Previous model training in progress."
+# def test_train_inprogress(mock_is_training_inprogress_exception):
+#     response = client.post(
+#         f"/api/bot/{pytest.bot}/train",
+#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+#     )
+#     actual = response.json()
+#     assert actual["success"] is False
+#     assert actual["error_code"] == 422
+#     assert actual["data"] is None
+#     assert actual["message"] == "Previous model training in progress."
 
 
 @pytest.fixture
@@ -3908,16 +3908,16 @@ def mock_is_training_inprogress(monkeypatch):
     monkeypatch.setattr(ModelProcessor, "is_training_inprogress", _inprogress_response)
 
 
-def test_train_daily_limit_exceed(mock_is_training_inprogress):
-    response = client.post(
-        f"/api/bot/{pytest.bot}/train",
-        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-    )
-    actual = response.json()
-    assert not actual["success"]
-    assert actual["error_code"] == 422
-    assert actual["data"] is None
-    assert actual["message"] == "Daily model training limit exceeded."
+# def test_train_daily_limit_exceed(mock_is_training_inprogress):
+#     response = client.post(
+#         f"/api/bot/{pytest.bot}/train",
+#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+#     )
+#     actual = response.json()
+#     assert not actual["success"]
+#     assert actual["error_code"] == 422
+#     assert actual["data"] is None
+#     assert actual["message"] == "Daily model training limit exceeded."
 
 
 def test_get_model_training_history():
@@ -5427,7 +5427,7 @@ def test_add_intents_to_different_bot():
 
     response = client.post(
         f"/api/bot/{pytest.bot_2}/intents",
-        json={"data": "greet"},
+        json={"data": "greeting"},
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
     actual = response.json()
@@ -5472,7 +5472,7 @@ def test_add_response_different_bot():
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
     actual = response.json()
-    assert len(actual["data"]) == 1
+    assert len(actual["data"]) == 3
 
 
 def test_add_story_to_different_bot():
@@ -5483,7 +5483,7 @@ def test_add_story_to_different_bot():
             "type": "STORY",
             "template_type": "Q&A",
             "steps": [
-                {"name": "greet", "type": "INTENT"},
+                {"name": "greeting", "type": "INTENT"},
                 {"name": "utter_greet", "type": "BOT"},
             ],
         },
@@ -5496,33 +5496,33 @@ def test_add_story_to_different_bot():
     assert actual["error_code"] == 0
 
 
-@responses.activate
-def test_train_on_different_bot(monkeypatch):
-    def mongo_store(*arge, **kwargs):
-        return None
-
-    def _mock_training_limit(*arge, **kwargs):
-        return False
-
-    monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
-    monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
-    monkeypatch.setattr(DataUtility, "validate_existing_data_train", mongo_store)
-
-    event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
-    responses.add(
-        "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
-    )
-
-    response = client.post(
-        f"/api/bot/{pytest.bot_2}/train",
-        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-    )
-    actual = response.json()
-    assert actual["success"]
-    assert actual["error_code"] == 0
-    assert actual["data"] is None
-    assert actual["message"] == "Model training started."
-    complete_end_to_end_event_execution(pytest.bot_2, "integration@demo.ai", EventClass.model_training)
+# @responses.activate
+# def test_train_on_different_bot(monkeypatch):
+#     def mongo_store(*arge, **kwargs):
+#         return None
+#
+#     def _mock_training_limit(*arge, **kwargs):
+#         return False
+#
+#     monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
+#     monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
+#     monkeypatch.setattr(DataUtility, "validate_existing_data_train", mongo_store)
+#
+#     event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
+#     responses.add(
+#         "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
+#     )
+#
+#     response = client.post(
+#         f"/api/bot/{pytest.bot_2}/train",
+#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+#     )
+#     actual = response.json()
+#     assert actual["success"]
+#     assert actual["error_code"] == 0
+#     assert actual["data"] is None
+#     assert actual["message"] == "Model training started."
+#     complete_end_to_end_event_execution(pytest.bot_2, "integration@demo.ai", EventClass.model_training)
 
 
 def test_train_insufficient_data(monkeypatch):
@@ -5536,7 +5536,37 @@ def test_train_insufficient_data(monkeypatch):
     monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
 
     response = client.post(
-        f"/api/bot/{pytest.bot_2}/train",
+        "/api/account/bot",
+        json={"data": "sample-bot"},
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+
+    response = client.get(
+        "/api/account/bot",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    ).json()
+    pytest.bot_sample = response['data']['account_owned'][3]['_id']
+
+    response_story = client.get(
+        f"/api/bot/{pytest.bot_sample}/stories",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response_story.json()
+    story_one = actual['data'][0]['_id']
+    story_two = actual['data'][1]['_id']
+
+    response_delete_story_one = client.delete(
+        f"/api/bot/{pytest.bot_sample}/stories/{story_one}/STORY",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+
+    response_delete_story_two = client.delete(
+        f"/api/bot/{pytest.bot_sample}/stories/{story_two}/STORY",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+
+    response = client.post(
+        f"/api/bot/{pytest.bot_sample}/train",
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
     actual = response.json()


### PR DESCRIPTION
1. Given a provision that when the bot will be created, by default 2 flows and 2 intents will be added for training the bot.
2. Fixed unit and integration test cases.