### PR TITLE
Validation for deleting system slots

### DIFF
--- a/kairon/shared/data/processor.py
+++ b/kairon/shared/data/processor.py
@@ -3070,10 +3070,10 @@ class MongoProcessor:
         """
 
         try:
-            if slot_name in {KaironSystemSlots.bot.value, KaironSystemSlots.bot.value.upper(),
-                             KaironSystemSlots.kairon_action_response.value,
-                             KaironSystemSlots.kairon_action_response.value.upper()}:
+            if slot_name.lower() in {s.value for s in KaironSystemSlots}:
                 raise AppException('Default kAIron slot deletion not allowed')
+            if self.get_row_count(SlotMapping, bot, slot=slot_name, status=True) > 0:
+                raise AppException("Cannot delete slot without removing its mappings!")
             slot = Slots.objects(name__iexact=slot_name, bot=bot, status=True).get()
             forms_with_slot = Forms.objects(bot=bot, status=True, required_slots__contains=slot_name)
             action_with_slot = GoogleSearchAction.objects(bot=bot, status=True, set_slot=slot_name)

--- a/kairon/shared/trackers.py
+++ b/kairon/shared/trackers.py
@@ -156,6 +156,7 @@ class KMongoTrackerStore(TrackerStore):
 
         stored = list(self.conversations.aggregate([
             {"$match": filter_query},
+            {"$sort": {"event.timestamp": 1}},
             {"$group": {"_id": "$sender_id", "events": {"$push": "$event"}}},
             {"$project": {"sender_id": "$_id", "events": 1, "_id": 0}}
         ]))

--- a/tests/unit_test/data_processor/data_processor_test.py
+++ b/tests/unit_test/data_processor/data_processor_test.py
@@ -2995,6 +2995,38 @@ class TestMongoProcessor:
         with pytest.raises(AppException, match='Default kAIron slot deletion not allowed'):
             processor.delete_slot(slot_name='kairon_action_response', bot=bot, user=user)
 
+        with pytest.raises(AppException, match='Default kAIron slot deletion not allowed'):
+            processor.delete_slot(slot_name='image', bot=bot, user=user)
+
+        with pytest.raises(AppException, match='Default kAIron slot deletion not allowed'):
+            processor.delete_slot(slot_name='video', bot=bot, user=user)
+
+        with pytest.raises(AppException, match='Default kAIron slot deletion not allowed'):
+            processor.delete_slot(slot_name='audio', bot=bot, user=user)
+
+        with pytest.raises(AppException, match='Default kAIron slot deletion not allowed'):
+            processor.delete_slot(slot_name='document', bot=bot, user=user)
+
+        with pytest.raises(AppException, match='Default kAIron slot deletion not allowed'):
+            processor.delete_slot(slot_name='doc_url', bot=bot, user=user)
+
+
+    def test_delete_slot_having_slot_mapping_attached(self):
+        processor = MongoProcessor()
+        bot = 'test_add_slot'
+        user = 'test_user'
+        slot_name = 'is_new_user'
+        slot = {"name": slot_name, "type": "any", "initial_value": None, "influence_conversation": False}
+        mapping = {"slot": slot_name, 'mapping': [{'type': 'from_entity', 'entity': 'name'}]}
+        processor.add_slot(slot_value=slot, bot=bot, user=user)
+        processor.add_or_update_slot_mapping(mapping, bot, user)
+
+        with pytest.raises(AppException, match="Cannot delete slot without removing its mappings!"):
+            processor.delete_slot(slot_name=slot_name, bot=bot, user=user)
+
+        processor.delete_slot_mapping(slot_name, bot, user)
+        processor.delete_slot(slot_name=slot_name, bot=bot, user=user)
+
     def test_delete_inexistent_slot(self):
         processor = MongoProcessor()
         bot = 'test_add_slot'


### PR DESCRIPTION
1. added check to prevent deletion of default system slots
2. added check to prevent deletion of slot before deletion of its mapping
3. added sort stage while retrieving events in mongo tracker to prevent jumbling
4. unit tests