### PR TITLE
Adding Payload for Qdrant

### DIFF
--- a/kairon/actions/definitions/factory.py
+++ b/kairon/actions/definitions/factory.py
@@ -7,12 +7,12 @@ from kairon.actions.definitions.google import ActionGoogleSearch
 from kairon.actions.definitions.http import ActionHTTP
 from kairon.actions.definitions.hubspot import ActionHubspotForms
 from kairon.actions.definitions.jira import ActionJiraTicket
-from kairon.actions.definitions.prompt import ActionPrompt
 from kairon.actions.definitions.pipedrive import ActionPipedriveLeads
+from kairon.actions.definitions.prompt import ActionPrompt
 from kairon.actions.definitions.razorpay import ActionRazorpay
 from kairon.actions.definitions.set_slot import ActionSetSlot
 from kairon.actions.definitions.two_stage_fallback import ActionTwoStageFallback
-from kairon.actions.definitions.vector_action import DatabaseAction, ActionDatabase
+from kairon.actions.definitions.vector_action import ActionDatabase
 from kairon.actions.definitions.zendesk import ActionZendeskTicket
 from kairon.shared.actions.exception import ActionFailure
 from kairon.shared.actions.models import ActionType

--- a/kairon/actions/definitions/factory.py
+++ b/kairon/actions/definitions/factory.py
@@ -12,7 +12,7 @@ from kairon.actions.definitions.pipedrive import ActionPipedriveLeads
 from kairon.actions.definitions.razorpay import ActionRazorpay
 from kairon.actions.definitions.set_slot import ActionSetSlot
 from kairon.actions.definitions.two_stage_fallback import ActionTwoStageFallback
-from kairon.actions.definitions.vector_action import DatabaseAction
+from kairon.actions.definitions.vector_action import DatabaseAction, ActionDatabase
 from kairon.actions.definitions.zendesk import ActionZendeskTicket
 from kairon.shared.actions.exception import ActionFailure
 from kairon.shared.actions.models import ActionType
@@ -35,7 +35,7 @@ class ActionFactory:
         ActionType.kairon_bot_response.value: ActionKaironBotResponse,
         ActionType.razorpay_action.value: ActionRazorpay,
         ActionType.prompt_action.value: ActionPrompt,
-        ActionType.database_action.value: DatabaseAction
+        ActionType.database_action.value: ActionDatabase
     }
 
     @staticmethod

--- a/kairon/actions/definitions/factory.py
+++ b/kairon/actions/definitions/factory.py
@@ -12,7 +12,7 @@ from kairon.actions.definitions.pipedrive import ActionPipedriveLeads
 from kairon.actions.definitions.razorpay import ActionRazorpay
 from kairon.actions.definitions.set_slot import ActionSetSlot
 from kairon.actions.definitions.two_stage_fallback import ActionTwoStageFallback
-from kairon.actions.definitions.vector_action import VectorEmbeddingsDbAction
+from kairon.actions.definitions.vector_action import DatabaseAction
 from kairon.actions.definitions.zendesk import ActionZendeskTicket
 from kairon.shared.actions.exception import ActionFailure
 from kairon.shared.actions.models import ActionType
@@ -35,7 +35,7 @@ class ActionFactory:
         ActionType.kairon_bot_response.value: ActionKaironBotResponse,
         ActionType.razorpay_action.value: ActionRazorpay,
         ActionType.prompt_action.value: ActionPrompt,
-        ActionType.vector_embeddings_db_action.value: VectorEmbeddingsDbAction
+        ActionType.database_action.value: DatabaseAction
     }
 
     @staticmethod

--- a/kairon/actions/definitions/vector_action.py
+++ b/kairon/actions/definitions/vector_action.py
@@ -7,7 +7,7 @@ from rasa_sdk.executor import CollectingDispatcher
 
 from kairon.actions.definitions.base import ActionsBase
 from kairon.shared.actions.data_objects import ActionServerLogs
-from kairon.shared.actions.data_objects import VectorEmbeddingDbAction
+from kairon.shared.actions.data_objects import DatabaseAction
 from kairon.shared.actions.exception import ActionFailure
 from kairon.shared.actions.models import ActionType, VectorDbValueType
 from kairon.shared.actions.utils import ActionUtility
@@ -15,7 +15,7 @@ from kairon.shared.constants import KaironSystemSlots
 from kairon.shared.vector_embeddings.db.factory import VectorEmbeddingsDbFactory
 
 
-class VectorEmbeddingsDbAction(ActionsBase):
+class DatabaseAction(ActionsBase):
 
     def __init__(self, bot: Text, name: Text):
         """
@@ -33,11 +33,11 @@ class VectorEmbeddingsDbAction(ActionsBase):
         """
         Fetch Vector action configuration parameters from the database.
 
-        :return: VectorEmbeddingDbAction containing configuration for the action as dict.
+        :return: DatabaseAction containing configuration for the action as dict.
         """
         try:
-            vector_action_dict = VectorEmbeddingDbAction.objects(bot=self.bot, name=self.name,
-                                                                 status=True).get().to_mongo().to_dict()
+            vector_action_dict = DatabaseAction.objects(bot=self.bot, name=self.name,
+                                                        status=True).get().to_mongo().to_dict()
             logger.debug("vector_action_config: " + str(vector_action_dict))
             return vector_action_dict
         except DoesNotExist as e:
@@ -96,7 +96,7 @@ class VectorEmbeddingsDbAction(ActionsBase):
             if dispatch_bot_response:
                 dispatcher.utter_message(bot_response)
             ActionServerLogs(
-                type=ActionType.vector_embeddings_db_action.value,
+                type=ActionType.database_action.value,
                 intent=tracker.get_intent_of_latest_message(skip_fallback_intent=False),
                 action=self.name,
                 config=vector_action_config,

--- a/kairon/actions/definitions/vector_action.py
+++ b/kairon/actions/definitions/vector_action.py
@@ -6,7 +6,7 @@ from rasa_sdk import Tracker
 from rasa_sdk.executor import CollectingDispatcher
 
 from kairon.actions.definitions.base import ActionsBase
-from kairon.shared.actions.data_objects import ActionServerLogs
+from kairon.shared.actions.data_objects import ActionServerLogs, DatabaseAction
 from kairon.shared.actions.exception import ActionFailure
 from kairon.shared.actions.models import ActionType, VectorDbValueType
 from kairon.shared.actions.utils import ActionUtility
@@ -14,7 +14,7 @@ from kairon.shared.constants import KaironSystemSlots
 from kairon.shared.vector_embeddings.db.factory import VectorEmbeddingsDbFactory
 
 
-class DatabaseAction(ActionsBase):
+class ActionDatabase(ActionsBase):
 
     def __init__(self, bot: Text, name: Text):
         """

--- a/kairon/actions/definitions/vector_action.py
+++ b/kairon/actions/definitions/vector_action.py
@@ -7,7 +7,6 @@ from rasa_sdk.executor import CollectingDispatcher
 
 from kairon.actions.definitions.base import ActionsBase
 from kairon.shared.actions.data_objects import ActionServerLogs
-from kairon.shared.actions.data_objects import DatabaseAction
 from kairon.shared.actions.exception import ActionFailure
 from kairon.shared.actions.models import ActionType, VectorDbValueType
 from kairon.shared.actions.utils import ActionUtility

--- a/kairon/api/app/routers/bot/action.py
+++ b/kairon/api/app/routers/bot/action.py
@@ -65,7 +65,7 @@ async def update_http_action(
     return Response(data=response, message=message)
 
 
-@router.post("/embeddings/db", response_model=Response)
+@router.post("/db", response_model=Response)
 async def add_db_action(
         request_data: DatabaseActionRequest,
         current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS)
@@ -78,7 +78,7 @@ async def add_db_action(
     return Response(data={"_id": action_id}, message="Action added!")
 
 
-@router.get("/embeddings/db/{action}", response_model=Response)
+@router.get("/db/{action}", response_model=Response)
 async def get_vector_db_action(action: str = Path(default=None, description="name", example="database_action"),
                                current_user: User = Security(Authentication.get_current_user_and_bot, scopes=TESTER_ACCESS)):
     """
@@ -88,7 +88,7 @@ async def get_vector_db_action(action: str = Path(default=None, description="nam
     return Response(data=action_config)
 
 
-@router.get("/embeddings/db", response_model=Response)
+@router.get("/db", response_model=Response)
 async def list_db_actions(current_user: User = Security(Authentication.get_current_user_and_bot, scopes=TESTER_ACCESS)):
     """
     Returns list of vectordb actions for bot.
@@ -97,7 +97,7 @@ async def list_db_actions(current_user: User = Security(Authentication.get_curre
     return Response(data=actions)
 
 
-@router.put("/embeddings/db", response_model=Response)
+@router.put("/db", response_model=Response)
 async def update_db_action(
         request_data: DatabaseActionRequest,
         current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS)

--- a/kairon/api/app/routers/bot/action.py
+++ b/kairon/api/app/routers/bot/action.py
@@ -6,7 +6,7 @@ from kairon.api.models import (
     Response,
     HttpActionConfigRequest, SlotSetActionRequest, EmailActionRequest, GoogleSearchActionRequest, JiraActionRequest,
     ZendeskActionRequest, PipedriveActionRequest, HubspotFormsActionRequest, TwoStageFallbackConfigRequest,
-    RazorpayActionRequest, PromptActionConfigRequest, VectorEmbeddingActionRequest
+    RazorpayActionRequest, PromptActionConfigRequest, DatabaseActionRequest
 )
 from kairon.shared.constants import TESTER_ACCESS, DESIGNER_ACCESS
 from kairon.shared.models import User
@@ -66,8 +66,8 @@ async def update_http_action(
 
 
 @router.post("/embeddings/db", response_model=Response)
-async def add_vector_embeddings_db_action(
-        request_data: VectorEmbeddingActionRequest,
+async def add_db_action(
+        request_data: DatabaseActionRequest,
         current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS)
 ):
     """
@@ -79,8 +79,8 @@ async def add_vector_embeddings_db_action(
 
 
 @router.get("/embeddings/db/{action}", response_model=Response)
-async def get_vector_embeddings_db_action(action: str = Path(default=None, description="name", example="vector_embeddings_db_action"),
-                                          current_user: User = Security(Authentication.get_current_user_and_bot, scopes=TESTER_ACCESS)):
+async def get_vector_db_action(action: str = Path(default=None, description="name", example="database_action"),
+                               current_user: User = Security(Authentication.get_current_user_and_bot, scopes=TESTER_ACCESS)):
     """
     Returns configuration set for the VectorDb action
     """
@@ -89,7 +89,7 @@ async def get_vector_embeddings_db_action(action: str = Path(default=None, descr
 
 
 @router.get("/embeddings/db", response_model=Response)
-async def list_vector_embeddings_db_actions(current_user: User = Security(Authentication.get_current_user_and_bot, scopes=TESTER_ACCESS)):
+async def list_db_actions(current_user: User = Security(Authentication.get_current_user_and_bot, scopes=TESTER_ACCESS)):
     """
     Returns list of vectordb actions for bot.
     """
@@ -98,8 +98,8 @@ async def list_vector_embeddings_db_actions(current_user: User = Security(Authen
 
 
 @router.put("/embeddings/db", response_model=Response)
-async def update_vector_embeddings_db_action(
-        request_data: VectorEmbeddingActionRequest,
+async def update_db_action(
+        request_data: DatabaseActionRequest,
         current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS)
 ):
     """

--- a/kairon/api/app/routers/bot/data.py
+++ b/kairon/api/app/routers/bot/data.py
@@ -166,7 +166,7 @@ def delete_payload(
     """
     Deletes text content of the bot
     """
-    processor.delete_payload_content(payload_id, current_user.get_bot())
+    processor.delete_payload_content(payload_id, current_user.get_user(), current_user.get_bot())
     return {
         "message": "Text deleted!"
     }

--- a/kairon/api/app/routers/bot/data.py
+++ b/kairon/api/app/routers/bot/data.py
@@ -3,7 +3,7 @@ import os
 from fastapi import UploadFile, File, Security, APIRouter
 from starlette.responses import FileResponse
 
-from kairon.api.models import Response, TextData, PayloadContent
+from kairon.api.models import Response, TextData, CognitiveDataRequest
 from kairon.events.definitions.faq_importer import FaqDataImporterEvent
 from kairon.shared.auth import Authentication
 from kairon.shared.constants import DESIGNER_ACCESS
@@ -116,19 +116,19 @@ def get_text(
     return {"data": list(processor.get_content(current_user.get_bot()))}
 
 
-@router.post("/payload", response_model=Response)
-def save_payload(
-        payload: PayloadContent,
+@router.post("/cognition", response_model=Response)
+def save_cognition(
+        cognition: CognitiveDataRequest,
         current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
 ):
     """
-    Saves text content into the bot
+    Saves cognition content into the bot
     """
     return {
-        "message": "Text saved!",
+        "message": "Cognition saved!",
         "data": {
-            "_id": processor.save_payload_content(
-                    payload.dict(),
+            "_id": processor.save_cognition_content(
+                    cognition.dict(),
                     current_user.get_user(),
                     current_user.get_bot(),
             )
@@ -136,21 +136,21 @@ def save_payload(
     }
 
 
-@router.put("/payload/{payload_id}", response_model=Response)
-def update_payload(
-        payload_id: str,
-        payload: PayloadContent,
+@router.put("/cognition/{cognition_id}", response_model=Response)
+def update_cognition(
+        cognition_id: str,
+        cognition: CognitiveDataRequest,
         current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
 ):
     """
-    Updates text content into the bot
+    Updates cognition content into the bot
     """
     return {
-        "message": "Text updated!",
+        "message": "Cognition updated!",
         "data": {
-            "_id": processor.update_payload_content(
-                payload_id,
-                payload.dict(),
+            "_id": processor.update_cognition_content(
+                cognition_id,
+                cognition.dict(),
                 current_user.get_user(),
                 current_user.get_bot(),
             )
@@ -158,25 +158,25 @@ def update_payload(
     }
 
 
-@router.delete("/payload/{payload_id}", response_model=Response)
-def delete_payload(
-        payload_id: str,
+@router.delete("/cognition/{cognition_id}", response_model=Response)
+def delete_cognition(
+        cognition_id: str,
         current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
 ):
     """
-    Deletes text content of the bot
+    Deletes cognition content of the bot
     """
-    processor.delete_payload_content(payload_id, current_user.get_user(), current_user.get_bot())
+    processor.delete_cognition_content(cognition_id, current_user.get_bot())
     return {
-        "message": "Text deleted!"
+        "message": "Cognition deleted!"
     }
 
 
-@router.get("/payload", response_model=Response)
-def list_payload(
+@router.get("/cognition", response_model=Response)
+def list_cognition(
         current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
 ):
     """
-    Fetches text content of the bot
+    Fetches cognition content of the bot
     """
-    return {"data": list(processor.get_payload_content(current_user.get_bot()))}
+    return {"data": list(processor.get_cognition_content(current_user.get_bot()))}

--- a/kairon/api/app/routers/bot/data.py
+++ b/kairon/api/app/routers/bot/data.py
@@ -166,7 +166,7 @@ def delete_payload(
     """
     Deletes text content of the bot
     """
-    processor.delete_payload_content(payload_id, current_user.get_user(), current_user.get_bot())
+    processor.delete_payload_content(payload_id, current_user.get_bot())
     return {
         "message": "Text deleted!"
     }

--- a/kairon/api/models.py
+++ b/kairon/api/models.py
@@ -1,4 +1,4 @@
-from typing import List, Any, Dict, Optional
+from typing import List, Any, Dict, Optional, Union
 import validators
 from fastapi.param_functions import Form
 from fastapi.security import OAuth2PasswordRequestForm
@@ -6,13 +6,14 @@ from fastapi.security import OAuth2PasswordRequestForm
 from kairon.shared.data.constant import EVENT_STATUS, SLOT_MAPPING_TYPE, SLOT_TYPE, ACCESS_ROLES, ACTIVITY_STATUS, \
     INTEGRATION_STATUS, FALLBACK_MESSAGE, DEFAULT_NLU_FALLBACK_RESPONSE
 from ..shared.actions.models import ActionParameterType, EvaluationType, DispatchType, VectorDbValueType, \
-    VectorDbOperationClass
+    DbOperation
 from ..shared.constants import SLOT_SET_TYPE, FORM_SLOT_SET_TYPE
 from kairon.exceptions import AppException
 
 ValidationFailure = validators.ValidationFailure
 from pydantic import BaseModel, validator, SecretStr, root_validator, constr
-from ..shared.models import StoryStepType, StoryType, TemplateType, HttpContentType, LlmPromptSource, LlmPromptType
+from ..shared.models import StoryStepType, StoryType, TemplateType, HttpContentType, LlmPromptSource, LlmPromptType, \
+    BotContentType
 
 
 class RecaptchaVerifiedRequest(BaseModel):
@@ -355,7 +356,7 @@ class HttpActionConfigRequest(BaseModel):
 
 class OperationConfig(BaseModel):
     type: VectorDbValueType
-    value: VectorDbOperationClass
+    value: DbOperation
 
     @root_validator
     def check(cls, values):
@@ -387,7 +388,7 @@ class PayloadConfig(BaseModel):
         return values
 
 
-class VectorEmbeddingActionRequest(BaseModel):
+class DatabaseActionRequest(BaseModel):
     name: constr(to_lower=True, strip_whitespace=True)
     operation: OperationConfig
     payload: PayloadConfig
@@ -859,6 +860,19 @@ class PromptActionConfigRequest(BaseModel):
             if key not in values['hyperparameters']:
                 values['hyperparameters'][key] = value
         return values
+
+
+class Metadata(BaseModel):
+    column_name: str
+    data_type: Union[str, int]
+    enable_search: bool = True
+    create_embeddings: bool = True
+
+
+class PayloadContent(BaseModel):
+    data: Any
+    content_type: BotContentType
+    metadata: List[Metadata] = None
 
 
 class RazorpayActionRequest(BaseModel):

--- a/kairon/api/models.py
+++ b/kairon/api/models.py
@@ -6,14 +6,14 @@ from fastapi.security import OAuth2PasswordRequestForm
 from kairon.shared.data.constant import EVENT_STATUS, SLOT_MAPPING_TYPE, SLOT_TYPE, ACCESS_ROLES, ACTIVITY_STATUS, \
     INTEGRATION_STATUS, FALLBACK_MESSAGE, DEFAULT_NLU_FALLBACK_RESPONSE
 from ..shared.actions.models import ActionParameterType, EvaluationType, DispatchType, VectorDbValueType, \
-    DbOperation
+    DbActionOperationType
 from ..shared.constants import SLOT_SET_TYPE, FORM_SLOT_SET_TYPE
 from kairon.exceptions import AppException
 
 ValidationFailure = validators.ValidationFailure
 from pydantic import BaseModel, validator, SecretStr, root_validator, constr
 from ..shared.models import StoryStepType, StoryType, TemplateType, HttpContentType, LlmPromptSource, LlmPromptType, \
-    BotContentType
+    CognitionDataType
 
 
 class RecaptchaVerifiedRequest(BaseModel):
@@ -356,7 +356,7 @@ class HttpActionConfigRequest(BaseModel):
 
 class OperationConfig(BaseModel):
     type: VectorDbValueType
-    value: DbOperation
+    value: DbActionOperationType
 
     @root_validator
     def check(cls, values):
@@ -869,9 +869,9 @@ class Metadata(BaseModel):
     create_embeddings: bool = True
 
 
-class PayloadContent(BaseModel):
+class CognitiveDataRequest(BaseModel):
     data: Any
-    content_type: BotContentType
+    content_type: CognitionDataType
     metadata: List[Metadata] = None
 
 

--- a/kairon/shared/actions/data_objects.py
+++ b/kairon/shared/actions/data_objects.py
@@ -15,7 +15,7 @@ from validators import ValidationFailure, url
 from validators import email
 
 from kairon.shared.actions.models import ActionType, ActionParameterType, HttpRequestContentType, \
-    EvaluationType, DispatchType, VectorDbValueType, VectorDbOperationClass
+    EvaluationType, DispatchType, VectorDbValueType, DbOperation
 from kairon.shared.constants import SLOT_SET_TYPE, FORM_SLOT_SET_TYPE
 from kairon.shared.data.base_data import Auditlog
 from kairon.shared.data.constant import KAIRON_TWO_STAGE_FALLBACK, FALLBACK_MESSAGE, DEFAULT_NLU_FALLBACK_RESPONSE
@@ -143,7 +143,7 @@ class HttpActionConfig(Auditlog):
 
 class VectorDbOperation(EmbeddedDocument):
     type = StringField(required=True, choices=[op_type.value for op_type in VectorDbValueType])
-    value = StringField(required=True, choices=[payload.value for payload in VectorDbOperationClass])
+    value = StringField(required=True, choices=[payload.value for payload in DbOperation])
 
     def validate(self, clean=True):
         if Utility.check_empty_string(self.type):
@@ -165,7 +165,7 @@ class VectorDbPayload(EmbeddedDocument):
 
 @auditlogger.log
 @push_notification.apply
-class VectorEmbeddingDbAction(Auditlog):
+class DatabaseAction(Auditlog):
     name = StringField(required=True)
     collection = StringField(required=True)
     operation = EmbeddedDocumentField(VectorDbOperation, required=True)

--- a/kairon/shared/actions/data_objects.py
+++ b/kairon/shared/actions/data_objects.py
@@ -15,7 +15,7 @@ from validators import ValidationFailure, url
 from validators import email
 
 from kairon.shared.actions.models import ActionType, ActionParameterType, HttpRequestContentType, \
-    EvaluationType, DispatchType, VectorDbValueType, DbOperation
+    EvaluationType, DispatchType, VectorDbValueType, DbActionOperationType
 from kairon.shared.constants import SLOT_SET_TYPE, FORM_SLOT_SET_TYPE
 from kairon.shared.data.base_data import Auditlog
 from kairon.shared.data.constant import KAIRON_TWO_STAGE_FALLBACK, FALLBACK_MESSAGE, DEFAULT_NLU_FALLBACK_RESPONSE
@@ -141,9 +141,9 @@ class HttpActionConfig(Auditlog):
                     param.value = Utility.encrypt_message(param.value)
 
 
-class VectorDbOperation(EmbeddedDocument):
+class DbOperation(EmbeddedDocument):
     type = StringField(required=True, choices=[op_type.value for op_type in VectorDbValueType])
-    value = StringField(required=True, choices=[payload.value for payload in DbOperation])
+    value = StringField(required=True, choices=[payload.value for payload in DbActionOperationType])
 
     def validate(self, clean=True):
         if Utility.check_empty_string(self.type):
@@ -168,7 +168,7 @@ class VectorDbPayload(EmbeddedDocument):
 class DatabaseAction(Auditlog):
     name = StringField(required=True)
     collection = StringField(required=True)
-    operation = EmbeddedDocumentField(VectorDbOperation, required=True)
+    operation = EmbeddedDocumentField(DbOperation, required=True)
     payload = EmbeddedDocumentField(VectorDbPayload, default=VectorDbPayload())
     response = EmbeddedDocumentField(HttpActionResponse, default=HttpActionResponse())
     set_slots = ListField(EmbeddedDocumentField(SetSlotsFromResponse))

--- a/kairon/shared/actions/models.py
+++ b/kairon/shared/actions/models.py
@@ -80,7 +80,7 @@ class DispatchType(str, Enum):
     text = "text"
 
 
-class DbOperation(str, Enum):
+class DbActionOperationType(str, Enum):
     payload_search = "payload_search"
     embedding_search = "embedding_search"
 

--- a/kairon/shared/actions/models.py
+++ b/kairon/shared/actions/models.py
@@ -38,7 +38,7 @@ class ActionType(str, Enum):
     kairon_bot_response = "kairon_bot_response"
     razorpay_action = "razorpay_action"
     prompt_action = "prompt_action"
-    vector_embeddings_db_action = "vector_embeddings_db_action"
+    database_action = "database_action"
 
 
 class HttpRequestContentType(str, Enum):
@@ -80,7 +80,7 @@ class DispatchType(str, Enum):
     text = "text"
 
 
-class VectorDbOperationClass(str, Enum):
+class DbOperation(str, Enum):
     payload_search = "payload_search"
     embedding_search = "embedding_search"
 

--- a/kairon/shared/data/data_objects.py
+++ b/kairon/shared/data/data_objects.py
@@ -31,7 +31,7 @@ from validators import url, ValidationFailure
 
 from kairon.exceptions import AppException
 from kairon.shared.data.signals import push_notification, auditlogger
-from kairon.shared.models import TemplateType, StoryStepType, StoryType, BotContentType, MetadataDataType
+from kairon.shared.models import TemplateType, StoryStepType, StoryType, CognitionDataType, CognitionMetadataType
 from kairon.shared.utils import Utility
 from .base_data import Auditlog
 from .constant import EVENT_STATUS, SLOT_MAPPING_TYPE, TrainingDataSourceType
@@ -695,17 +695,17 @@ class Rules(Auditlog):
         DataUtility.validate_flow_events(self.events, "RULE", self.block_name)
 
 
-class PayloadMetadata(EmbeddedDocument):
+class CongnitionMetadata(EmbeddedDocument):
     column_name = StringField(required=True)
-    data_type = StringField(required=True, default=MetadataDataType.str.value,
-                            choices=[MetadataDataType.str.value, MetadataDataType.int.value])
+    data_type = StringField(required=True, default=CognitionMetadataType.str.value,
+                            choices=[CognitionMetadataType.str.value, CognitionMetadataType.int.value])
     enable_search = BooleanField(default=True)
     create_embeddings = BooleanField(default=True)
 
     def validate(self, clean=True):
         if clean:
             self.clean()
-        if self.data_type not in [MetadataDataType.str.value, MetadataDataType.int.value]:
+        if self.data_type not in [CognitionMetadataType.str.value, CognitionMetadataType.int.value]:
             raise ValidationError("Only str and int data types are supported")
         if Utility.check_empty_string(self.column_name):
             raise ValidationError("Column name cannot be empty")
@@ -717,11 +717,11 @@ class PayloadMetadata(EmbeddedDocument):
 
 @auditlogger.log
 @push_notification.apply
-class BotContent(Auditlog):
+class CognitionData(Auditlog):
     vector_id = SequenceField(required=True)
     data = DynamicField(required=True)
-    content_type = StringField(default=BotContentType.text.value, choices=[BotContentType.text.value, BotContentType.json.value])
-    metadata = ListField(EmbeddedDocumentField(PayloadMetadata), default=None)
+    content_type = StringField(default=CognitionDataType.text.value, choices=[CognitionDataType.text.value, CognitionDataType.json.value])
+    metadata = ListField(EmbeddedDocumentField(CongnitionMetadata), default=None)
     user = StringField(required=True)
     bot = StringField(required=True)
     timestamp = DateTimeField(default=datetime.utcnow)

--- a/kairon/shared/data/data_objects.py
+++ b/kairon/shared/data/data_objects.py
@@ -31,7 +31,7 @@ from validators import url, ValidationFailure
 
 from kairon.exceptions import AppException
 from kairon.shared.data.signals import push_notification, auditlogger
-from kairon.shared.models import TemplateType, StoryStepType, StoryType
+from kairon.shared.models import TemplateType, StoryStepType, StoryType, BotContentType, MetadataDataType
 from kairon.shared.utils import Utility
 from .base_data import Auditlog
 from .constant import EVENT_STATUS, SLOT_MAPPING_TYPE, TrainingDataSourceType
@@ -695,16 +695,46 @@ class Rules(Auditlog):
         DataUtility.validate_flow_events(self.events, "RULE", self.block_name)
 
 
+class PayloadMetadata(EmbeddedDocument):
+    column_name = StringField(required=True)
+    data_type = StringField(required=True, default=MetadataDataType.str.value,
+                            choices=[MetadataDataType.str.value, MetadataDataType.int.value])
+    enable_search = BooleanField(default=True)
+    create_embeddings = BooleanField(default=True)
+
+    def validate(self, clean=True):
+        if clean:
+            self.clean()
+        if self.data_type not in [MetadataDataType.str.value, MetadataDataType.int.value]:
+            raise ValidationError("Only str and int data types are supported")
+        if Utility.check_empty_string(self.column_name):
+            raise ValidationError("Column name cannot be empty")
+
+    def clean(self):
+        if not Utility.check_empty_string(self.column_name):
+            self.column_name = self.column_name.strip().lower()
+
+
 @auditlogger.log
 @push_notification.apply
 class BotContent(Auditlog):
     vector_id = SequenceField(required=True)
-    data = StringField(required=True)
+    data = DynamicField(required=True)
+    content_type = StringField(default=BotContentType.text.value, choices=[BotContentType.text.value, BotContentType.json.value])
+    metadata = ListField(EmbeddedDocumentField(PayloadMetadata), default=None)
     user = StringField(required=True)
     bot = StringField(required=True)
     timestamp = DateTimeField(default=datetime.utcnow)
 
     meta = {"indexes": [{"fields": ["bot"]}]}
+
+    def validate(self, clean=True):
+        if clean:
+            self.clean()
+
+        if self.metadata:
+            for data in self.metadata:
+                data.validate()
 
 
 @auditlogger.log

--- a/kairon/shared/data/processor.py
+++ b/kairon/shared/data/processor.py
@@ -43,7 +43,7 @@ from kairon.shared.actions.data_objects import HttpActionConfig, HttpActionReque
     SlotSetAction, FormValidationAction, EmailActionConfig, GoogleSearchAction, JiraAction, ZendeskAction, \
     PipedriveLeadsAction, SetSlots, HubspotFormsAction, HttpActionResponse, SetSlotsFromResponse, \
     CustomActionRequestParameters, KaironTwoStageFallbackAction, QuickReplies, RazorpayAction, PromptAction, \
-    LlmPrompt, FormSlotSet, DatabaseAction, VectorDbOperation, VectorDbPayload
+    LlmPrompt, FormSlotSet, DatabaseAction, DbOperation, VectorDbPayload
 from kairon.shared.actions.models import ActionType, HttpRequestContentType, ActionParameterType, VectorDbValueType
 from kairon.shared.importer.processor import DataImporterLogProcessor
 from kairon.shared.models import StoryEventType, TemplateType, StoryStepType, HttpContentType, StoryType, \
@@ -86,8 +86,8 @@ from .data_objects import (
     ModelDeployment,
     Rules,
     Utterances, BotSettings, ChatClientConfig, SlotMapping, KeyVault, EventConfig, TrainingDataGenerator,
-    MultiflowStories, MultiflowStoryEvents, BotContent, MultiFlowStoryMetadata,
-    Synonyms, Lookup, PayloadMetadata
+    MultiflowStories, MultiflowStoryEvents, CognitionData, MultiFlowStoryMetadata,
+    Synonyms, Lookup, CongnitionMetadata
 )
 from .utils import DataUtility
 from ..constants import KaironSystemSlots
@@ -3008,7 +3008,7 @@ class MongoProcessor:
             raise AppException(f'Action with name "{request_data.get("name")}" not found')
         self.__validate_payload(request_data.get('payload'), bot)
         action = DatabaseAction.objects(name=request_data.get('name'), bot=bot, status=True).get()
-        action.operation = VectorDbOperation(**request_data['operation'])
+        action.operation = DbOperation(**request_data['operation'])
         action.payload = VectorDbPayload(**request_data['payload'])
         action.response = HttpActionResponse(**request_data.get('response', {}))
         action.set_slots = [SetSlotsFromResponse(**slot).to_mongo().to_dict() for slot in
@@ -3031,7 +3031,7 @@ class MongoProcessor:
         set_slots = [SetSlotsFromResponse(**slot) for slot in vector_db_action_config.get('set_slots')]
         action_id = DatabaseAction(
             name=vector_db_action_config['name'],
-            operation=VectorDbOperation(**vector_db_action_config.get('operation')),
+            operation=DbOperation(**vector_db_action_config.get('operation')),
             payload=VectorDbPayload(**vector_db_action_config.get('payload')),
             response=HttpActionResponse(**vector_db_action_config.get('response', {})),
             set_slots=set_slots,
@@ -5442,7 +5442,7 @@ class MongoProcessor:
         if len(content.split()) < 10:
             raise AppException("Content should contain atleast 10 words.")
 
-        content_obj = BotContent()
+        content_obj = CognitionData()
         content_obj.data = content
         content_obj.user = user
         content_obj.bot = bot
@@ -5455,11 +5455,11 @@ class MongoProcessor:
         if len(content.split()) < 10:
             raise AppException("Content should contain atleast 10 words.")
 
-        Utility.is_exist(BotContent, bot=bot, id__ne=content_id, data=content,
-                                exp_message="Text already exists!")
+        Utility.is_exist(CognitionData, bot=bot, id__ne=content_id, data=content,
+                         exp_message="Text already exists!")
 
         try:
-            content_obj = BotContent.objects(bot=bot, id=content_id).get()
+            content_obj = CognitionData.objects(bot=bot, id=content_id).get()
             content_obj.data = content
             content_obj.user = user
             content_obj.timestamp = datetime.utcnow()
@@ -5469,7 +5469,7 @@ class MongoProcessor:
 
     def delete_content(self, content_id: str, user: Text, bot: Text):
         try:
-            content = BotContent.objects(bot=bot, id=content_id).get()
+            content = CognitionData.objects(bot=bot, id=content_id).get()
             content.delete()
         except DoesNotExist:
             raise AppException("Text does not exists!")
@@ -5481,7 +5481,7 @@ class MongoProcessor:
         :param bot: bot id
         :return: yield dict
         """
-        for value in BotContent.objects(bot=bot):
+        for value in CognitionData.objects(bot=bot):
             final_data = {}
             item = value.to_mongo().to_dict()
             data = item.pop("data")
@@ -5489,51 +5489,51 @@ class MongoProcessor:
             final_data['content'] = data
             yield final_data
 
-    def save_payload_content(self, payload: Dict, user: Text, bot: Text):
+    def save_cognition_content(self, payload: Dict, user: Text, bot: Text):
         bot_settings = self.get_bot_settings(bot=bot, user=user)
         if not bot_settings["llm_settings"]['enable_faq']:
             raise AppException('Faq feature is disabled for the bot! Please contact support.')
-        payload_obj = BotContent()
+        payload_obj = CognitionData()
         payload_obj.data = payload.get('data')
         payload_obj.content_type = payload.get('content_type')
-        payload_obj.metadata = [PayloadMetadata(**meta) for meta in payload.get('metadata', [])]
+        payload_obj.metadata = [CongnitionMetadata(**meta) for meta in payload.get('metadata', [])]
         payload_obj.user = user
         payload_obj.bot = bot
         payload_id = payload_obj.save().to_mongo().to_dict()["_id"].__str__()
         return payload_id
 
-    def update_payload_content(self, payload_id: str, payload: Dict, user: Text, bot: Text):
+    def update_cognition_content(self, payload_id: str, payload: Dict, user: Text, bot: Text):
         data = payload['data']
         content_type = payload['content_type']
-        Utility.is_exist(BotContent, bot=bot, id__ne=payload_id, data=data,
+        Utility.is_exist(CognitionData, bot=bot, id__ne=payload_id, data=data,
                          exp_message="Payload data already exists!")
 
         try:
-            payload_obj = BotContent.objects(bot=bot, id=payload_id).get()
+            payload_obj = CognitionData.objects(bot=bot, id=payload_id).get()
             payload_obj.data = data
             payload_obj.content_type = content_type
-            payload_obj.metadata = [PayloadMetadata(**meta) for meta in payload.get('metadata', [])]
+            payload_obj.metadata = [CongnitionMetadata(**meta) for meta in payload.get('metadata', [])]
             payload_obj.user = user
             payload_obj.timestamp = datetime.utcnow()
             payload_obj.save()
         except DoesNotExist:
             raise AppException("Payload with given id not found!")
 
-    def delete_payload_content(self, payload_id: str, user: Text, bot: Text):
+    def delete_cognition_content(self, payload_id: str, bot: Text):
         try:
-            payload = BotContent.objects(bot=bot, id=payload_id).get()
+            payload = CognitionData.objects(bot=bot, id=payload_id).get()
             payload.delete()
         except DoesNotExist:
             raise AppException("Payload does not exists!")
 
-    def get_payload_content(self, bot: Text):
+    def get_cognition_content(self, bot: Text):
         """
         fetches content
 
         :param bot: bot id
         :return: yield dict
         """
-        for value in BotContent.objects(bot=bot):
+        for value in CognitionData.objects(bot=bot):
             final_data = {}
             item = value.to_mongo().to_dict()
             data = item.pop("data")

--- a/kairon/shared/data/processor.py
+++ b/kairon/shared/data/processor.py
@@ -5519,7 +5519,7 @@ class MongoProcessor:
         except DoesNotExist:
             raise AppException("Payload with given id not found!")
 
-    def delete_payload_content(self, payload_id: str, bot: Text):
+    def delete_payload_content(self, payload_id: str, user: Text, bot: Text):
         try:
             payload = BotContent.objects(bot=bot, id=payload_id).get()
             payload.delete()

--- a/kairon/shared/llm/gpt3.py
+++ b/kairon/shared/llm/gpt3.py
@@ -1,3 +1,5 @@
+import json
+
 from kairon.shared.admin.constants import BotSecretType
 from kairon.shared.admin.processor import Sysadmin
 from kairon.shared.constants import GPT3ResourceTypes
@@ -6,6 +8,7 @@ from kairon.shared.llm.base import LLMBase
 from typing import Text, Dict, List, Union
 
 from kairon.shared.llm.clients.factory import LLMClientFactory
+from kairon.shared.models import BotContentType
 from kairon.shared.utils import Utility
 import openai
 from kairon.shared.data.data_objects import BotContent
@@ -13,6 +16,7 @@ from urllib.parse import urljoin
 from kairon.exceptions import AppException
 from loguru import logger as logging
 from tqdm import tqdm
+
 
 class GPT3FAQEmbedding(LLMBase):
     __embedding__ = 1536
@@ -38,12 +42,32 @@ class GPT3FAQEmbedding(LLMBase):
         count = 0
         contents = list(BotContent.objects(bot=self.bot))
         for content in tqdm(contents, desc="Training FAQ"):
-            points = [{'id': content.vector_id,
-                       'vector': self.__get_embedding(content.data),
-                       'payload': {"content": content.data}}]
-            self.__collection_upsert__(self.bot + self.suffix, {'points': points},
-                                       err_msg="Unable to train faq! contact support")
-            count += 1
+            metadata_list = content['metadata'] or []
+            content_type = content.content_type
+            if not metadata_list and content_type in [BotContentType.json.value, BotContentType.text.value]:
+                vector = self.__get_embedding(
+                    json.dumps(content.data)) if content_type == BotContentType.json.value else self.__get_embedding(
+                    content.data)
+                points = [{'id': content.vector_id, 'vector': vector, 'payload': {"content": content.data}}]
+                self.__collection_upsert__(self.bot + self.suffix, {'points': points},
+                                           err_msg="Unable to train FAQ! Contact support")
+                count += 1
+            if content.metadata is not None:
+                for metadata in content.metadata:
+                    if metadata['enable_search']:
+                        points = [{'id': content.vector_id,
+                                   'payload': {"content": content.data}}]
+                        self.__collection_upsert__(self.bot + self.suffix, {'points': points},
+                                                   err_msg="Unable to train FAQ! Contact support")
+                        count += 1
+                    if metadata['create_embeddings'] and content_type in [BotContentType.json.value, BotContentType.text.value]:
+                        vector = self.__get_embedding(json.dumps(
+                            content.data)) if content_type == BotContentType.json.value else self.__get_embedding(
+                            content.data)
+                        points = [{'id': content.vector_id, 'vector': vector, 'payload': {"content": content.data}}]
+                        self.__collection_upsert__(self.bot + self.suffix, {'points': points},
+                                                   err_msg="Unable to train FAQ! Contact support")
+                        count += 1
         return {"faq": count}
 
     def predict(self, query: Text, *args, **kwargs) -> Dict:

--- a/kairon/shared/llm/gpt3.py
+++ b/kairon/shared/llm/gpt3.py
@@ -8,10 +8,10 @@ from kairon.shared.llm.base import LLMBase
 from typing import Text, Dict, List, Union
 
 from kairon.shared.llm.clients.factory import LLMClientFactory
-from kairon.shared.models import BotContentType
+from kairon.shared.models import CognitionDataType
 from kairon.shared.utils import Utility
 import openai
-from kairon.shared.data.data_objects import BotContent
+from kairon.shared.data.data_objects import CognitionData
 from urllib.parse import urljoin
 from kairon.exceptions import AppException
 from loguru import logger as logging
@@ -40,34 +40,38 @@ class GPT3FAQEmbedding(LLMBase):
         self.__create_collection__(self.bot + self.suffix)
         self.__create_collection__(self.bot + self.cached_resp_suffix)
         count = 0
-        contents = list(BotContent.objects(bot=self.bot))
+        contents = list(CognitionData.objects(bot=self.bot))
         for content in tqdm(contents, desc="Training FAQ"):
             metadata_list = content['metadata'] or []
             content_type = content.content_type
-            if not metadata_list and content_type in [BotContentType.json.value, BotContentType.text.value]:
-                vector = self.__get_embedding(
-                    json.dumps(content.data)) if content_type == BotContentType.json.value else self.__get_embedding(
-                    content.data)
-                points = [{'id': content.vector_id, 'vector': vector, 'payload': {"content": content.data}}]
+            if content_type == CognitionDataType.json.value:
+                if not metadata_list:
+                    vector = self.__get_embedding(json.dumps(content.data))
+                    points = [{'id': content.vector_id, 'vector': vector, 'payload': {"content": content.data}}]
+                    self.__collection_upsert__(self.bot + self.suffix, {'points': points},
+                                               err_msg="Unable to train FAQ! Contact support")
+                    count += 1
+                else:
+                    for metadata in content.metadata:
+                        if metadata['enable_search']:
+                            points = [{'id': content.vector_id,
+                                       'payload': {"content": content.data}}]
+                            self.__collection_upsert__(self.bot + self.suffix, {'points': points},
+                                                       err_msg="Unable to train FAQ! Contact support")
+                            count += 1
+                        if metadata['create_embeddings']:
+                            vector = self.__get_embedding(json.dumps(content.data))
+                            points = [{'id': content.vector_id, 'vector': vector, 'payload': {"content": content.data}}]
+                            self.__collection_upsert__(self.bot + self.suffix, {'points': points},
+                                                       err_msg="Unable to train FAQ! Contact support")
+                            count += 1
+            else:
+                points = [{'id': content.vector_id,
+                           'vector': self.__get_embedding(content.data),
+                           'payload': {"content": content.data}}]
                 self.__collection_upsert__(self.bot + self.suffix, {'points': points},
-                                           err_msg="Unable to train FAQ! Contact support")
+                                           err_msg="Unable to train faq! contact support")
                 count += 1
-            if content.metadata is not None:
-                for metadata in content.metadata:
-                    if metadata['enable_search']:
-                        points = [{'id': content.vector_id,
-                                   'payload': {"content": content.data}}]
-                        self.__collection_upsert__(self.bot + self.suffix, {'points': points},
-                                                   err_msg="Unable to train FAQ! Contact support")
-                        count += 1
-                    if metadata['create_embeddings'] and content_type in [BotContentType.json.value, BotContentType.text.value]:
-                        vector = self.__get_embedding(json.dumps(
-                            content.data)) if content_type == BotContentType.json.value else self.__get_embedding(
-                            content.data)
-                        points = [{'id': content.vector_id, 'vector': vector, 'payload': {"content": content.data}}]
-                        self.__collection_upsert__(self.bot + self.suffix, {'points': points},
-                                                   err_msg="Unable to train FAQ! Contact support")
-                        count += 1
         return {"faq": count}
 
     def predict(self, query: Text, *args, **kwargs) -> Dict:

--- a/kairon/shared/models.py
+++ b/kairon/shared/models.py
@@ -25,6 +25,7 @@ class StoryStepType(str, Enum):
     two_stage_fallback_action = "TWO_STAGE_FALLBACK_ACTION"
     prompt_action = "PROMPT_ACTION"
 
+
 class StoryType(str, Enum):
     story = "STORY"
     rule = "RULE"
@@ -96,3 +97,13 @@ class LlmPromptType(str, Enum):
     user = "user"
     system = "system"
     query = "query"
+
+
+class BotContentType(str, Enum):
+    text = "text"
+    json = "json"
+
+
+class MetadataDataType(str, Enum):
+    str = "str"
+    int = "int"

--- a/kairon/shared/models.py
+++ b/kairon/shared/models.py
@@ -99,11 +99,11 @@ class LlmPromptType(str, Enum):
     query = "query"
 
 
-class BotContentType(str, Enum):
+class CognitionDataType(str, Enum):
     text = "text"
     json = "json"
 
 
-class MetadataDataType(str, Enum):
+class CognitionMetadataType(str, Enum):
     str = "str"
     int = "int"

--- a/kairon/shared/vector_embeddings/db/base.py
+++ b/kairon/shared/vector_embeddings/db/base.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Dict, Text
 
 from kairon.exceptions import AppException
-from kairon.shared.actions.models import DbOperation
+from kairon.shared.actions.models import DbActionOperationType
 
 
 class VectorEmbeddingsDbBase(ABC):
@@ -16,8 +16,8 @@ class VectorEmbeddingsDbBase(ABC):
         raise NotImplementedError("Provider not implemented")
 
     def perform_operation(self, op_type: Text, request_body: Dict):
-        supported_ops = {DbOperation.payload_search.value: self.payload_search,
-                         DbOperation.embedding_search.value: self.embedding_search}
+        supported_ops = {DbActionOperationType.payload_search.value: self.payload_search,
+                         DbActionOperationType.embedding_search.value: self.embedding_search}
         if op_type not in supported_ops.keys():
             raise AppException("Operation type not supported")
         return supported_ops[op_type](request_body)

--- a/kairon/shared/vector_embeddings/db/base.py
+++ b/kairon/shared/vector_embeddings/db/base.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Dict, Text
 
 from kairon.exceptions import AppException
-from kairon.shared.actions.models import VectorDbOperationClass
+from kairon.shared.actions.models import DbOperation
 
 
 class VectorEmbeddingsDbBase(ABC):
@@ -16,8 +16,8 @@ class VectorEmbeddingsDbBase(ABC):
         raise NotImplementedError("Provider not implemented")
 
     def perform_operation(self, op_type: Text, request_body: Dict):
-        supported_ops = {VectorDbOperationClass.payload_search.value: self.payload_search,
-                         VectorDbOperationClass.embedding_search.value: self.embedding_search}
+        supported_ops = {DbOperation.payload_search.value: self.payload_search,
+                         DbOperation.embedding_search.value: self.embedding_search}
         if op_type not in supported_ops.keys():
             raise AppException("Operation type not supported")
         return supported_ops[op_type](request_body)

--- a/tests/integration_test/action_service_test.py
+++ b/tests/integration_test/action_service_test.py
@@ -8,7 +8,7 @@ from kairon.shared.actions.data_objects import HttpActionConfig, SlotSetAction, 
     EmailActionConfig, ActionServerLogs, GoogleSearchAction, JiraAction, ZendeskAction, PipedriveLeadsAction, SetSlots, \
     HubspotFormsAction, HttpActionResponse, HttpActionRequestBody, SetSlotsFromResponse, CustomActionRequestParameters, \
     KaironTwoStageFallbackAction, TwoStageFallbackTextualRecommendations, RazorpayAction, PromptAction, FormSlotSet, \
-    DatabaseAction, VectorDbOperation, VectorDbPayload
+    DatabaseAction, DbOperation, VectorDbPayload
 from kairon.shared.actions.models import ActionType, ActionParameterType, DispatchType
 from kairon.shared.admin.constants import BotSecretType
 from kairon.shared.admin.data_objects import BotSecrets
@@ -2015,7 +2015,7 @@ class TestActionServer(AsyncHTTPTestCase):
         payload_body = {"ids": [0], "with_payload": True, "with_vector": True}
         DatabaseAction(
             name=action_name,
-            operation=VectorDbOperation(type="from_value", value="embedding_search"),
+            operation=DbOperation(type="from_value", value="embedding_search"),
             payload=VectorDbPayload(type="from_value", value=payload_body),
             response=HttpActionResponse(value="The value of ${data.result.0.id} is ${data.result.0.vector}"),
             set_slots=[SetSlotsFromResponse(name="vector_value", value="${data.result.0.vector}")],
@@ -2105,7 +2105,7 @@ class TestActionServer(AsyncHTTPTestCase):
         }
         DatabaseAction(
             name=action_name,
-            operation=VectorDbOperation(type="from_value", value="payload_search"),
+            operation=DbOperation(type="from_value", value="payload_search"),
             payload=VectorDbPayload(type="from_value", value=payload_body),
             response=HttpActionResponse(value="The value of ${data.0.city} with color ${data.0.color} is ${data.0.id}"),
             set_slots=[SetSlotsFromResponse(name="city_value", value="${data.0.id}")],
@@ -2178,7 +2178,7 @@ class TestActionServer(AsyncHTTPTestCase):
 
         DatabaseAction(
             name=action_name,
-            operation=VectorDbOperation(type="from_value", value="embedding_search"),
+            operation=DbOperation(type="from_value", value="embedding_search"),
             payload=VectorDbPayload(type="from_slot", value='name'),
             response=HttpActionResponse(value="The value of ${data.result.0.id} is ${data.result.0.vector}"),
             set_slots=[SetSlotsFromResponse(name="vector_value", value="${data.result.0.vector}")],
@@ -2262,7 +2262,7 @@ class TestActionServer(AsyncHTTPTestCase):
 
         DatabaseAction(
             name=action_name,
-            operation=VectorDbOperation(type="from_value", value="payload_search"),
+            operation=DbOperation(type="from_value", value="payload_search"),
             payload=VectorDbPayload(type="from_slot", value='color'),
             response=HttpActionResponse(value="The name of the city with id ${data.0.id} is ${data.0.city}"),
             set_slots=[SetSlotsFromResponse(name="city_name", value="${data.0.city}")],
@@ -2332,7 +2332,7 @@ class TestActionServer(AsyncHTTPTestCase):
         payload_body = {"ids": [0], "with_payload": True, "with_vector": True}
         DatabaseAction(
             name=action_name,
-            operation=VectorDbOperation(type="from_value", value="embedding_search"),
+            operation=DbOperation(type="from_value", value="embedding_search"),
             payload=VectorDbPayload(type="from_value", value=payload_body),
             response=HttpActionResponse(value="The value of ${data.result.0.id} is ${data.result.0.vector}", dispatch=False),
             set_slots=[SetSlotsFromResponse(name="vector_value", value="${data.result.0.vector}")],
@@ -2415,7 +2415,7 @@ class TestActionServer(AsyncHTTPTestCase):
         payload_body = {"ids": [0], "with_payload": True, "with_vector": True}
         DatabaseAction(
             name=action_name,
-            operation=VectorDbOperation(type="from_value", value="vector_search"),
+            operation=DbOperation(type="from_value", value="vector_search"),
             payload=VectorDbPayload(type="from_value", value=payload_body),
             response=HttpActionResponse(value="The value of ${data.result.0.id} is ${data.result.0.vector}", dispatch=False),
             set_slots=[SetSlotsFromResponse(name="vector_value", value="${data.result.0.vector}")],
@@ -2473,7 +2473,7 @@ class TestActionServer(AsyncHTTPTestCase):
                          user="user")
         action_config = DatabaseAction(
             name=action_name,
-            operation=VectorDbOperation(type="from_value", value="embedding_search"),
+            operation=DbOperation(type="from_value", value="embedding_search"),
             payload=VectorDbPayload(type="from_value", value=payload_body),
             response=HttpActionResponse(value="The value of ${data.result.0.id} is ${data.result.0.vector"),
             bot="5f50fd0a56b697ca10d35d2e",

--- a/tests/integration_test/action_service_test.py
+++ b/tests/integration_test/action_service_test.py
@@ -8,7 +8,7 @@ from kairon.shared.actions.data_objects import HttpActionConfig, SlotSetAction, 
     EmailActionConfig, ActionServerLogs, GoogleSearchAction, JiraAction, ZendeskAction, PipedriveLeadsAction, SetSlots, \
     HubspotFormsAction, HttpActionResponse, HttpActionRequestBody, SetSlotsFromResponse, CustomActionRequestParameters, \
     KaironTwoStageFallbackAction, TwoStageFallbackTextualRecommendations, RazorpayAction, PromptAction, FormSlotSet, \
-    VectorEmbeddingDbAction, VectorDbOperation, VectorDbPayload
+    DatabaseAction, VectorDbOperation, VectorDbPayload
 from kairon.shared.actions.models import ActionType, ActionParameterType, DispatchType
 from kairon.shared.admin.constants import BotSecretType
 from kairon.shared.admin.data_objects import BotSecrets
@@ -2011,9 +2011,9 @@ class TestActionServer(AsyncHTTPTestCase):
 
     def test_vectordb_action_execution_embedding_search_from_value(self):
         action_name = "test_vectordb_action_execution"
-        Actions(name=action_name, type=ActionType.vector_embeddings_db_action.value, bot="5f50fd0a56b698ca10d75d2e", user="user").save()
+        Actions(name=action_name, type=ActionType.database_action.value, bot="5f50fd0a56b698ca10d75d2e", user="user").save()
         payload_body = {"ids": [0], "with_payload": True, "with_vector": True}
-        VectorEmbeddingDbAction(
+        DatabaseAction(
             name=action_name,
             operation=VectorDbOperation(type="from_value", value="embedding_search"),
             payload=VectorDbPayload(type="from_value", value=payload_body),
@@ -2094,7 +2094,7 @@ class TestActionServer(AsyncHTTPTestCase):
 
     def test_vectordb_action_execution_payload_search_from_value(self):
         action_name = "test_vectordb_action_execution"
-        Actions(name=action_name, type=ActionType.vector_embeddings_db_action.value, bot="5f50md0a56b698ca10d35d2e", user="user").save()
+        Actions(name=action_name, type=ActionType.database_action.value, bot="5f50md0a56b698ca10d35d2e", user="user").save()
         payload_body = {
             "filter": {
                 "should": [
@@ -2103,7 +2103,7 @@ class TestActionServer(AsyncHTTPTestCase):
                 ]
             }
         }
-        VectorEmbeddingDbAction(
+        DatabaseAction(
             name=action_name,
             operation=VectorDbOperation(type="from_value", value="payload_search"),
             payload=VectorDbPayload(type="from_value", value=payload_body),
@@ -2172,11 +2172,11 @@ class TestActionServer(AsyncHTTPTestCase):
 
     def test_vectordb_action_execution_embedding_search_from_slot(self):
         action_name = "test_vectordb_action_execution"
-        Actions(name=action_name, type=ActionType.vector_embeddings_db_action.value, bot="5f50fx0a56b698ca10d35d2e", user="user").save()
+        Actions(name=action_name, type=ActionType.database_action.value, bot="5f50fx0a56b698ca10d35d2e", user="user").save()
         slot = 'name'
         Slots(name=slot, type='text', bot='5f50fx0a56b698ca10d35d2e', user='user').save()
 
-        VectorEmbeddingDbAction(
+        DatabaseAction(
             name=action_name,
             operation=VectorDbOperation(type="from_value", value="embedding_search"),
             payload=VectorDbPayload(type="from_slot", value='name'),
@@ -2256,11 +2256,11 @@ class TestActionServer(AsyncHTTPTestCase):
 
     def test_vectordb_action_execution_payload_search_from_slot(self):
         action_name = "test_vectordb_action_execution"
-        Actions(name=action_name, type=ActionType.vector_embeddings_db_action.value, bot="5f50fx0a56v698ca10d39c2e", user="user").save()
+        Actions(name=action_name, type=ActionType.database_action.value, bot="5f50fx0a56v698ca10d39c2e", user="user").save()
         slot = 'color'
         Slots(name=slot, type='text', bot='5f50fx0a56v698ca10d39c2e', user='user').save()
 
-        VectorEmbeddingDbAction(
+        DatabaseAction(
             name=action_name,
             operation=VectorDbOperation(type="from_value", value="payload_search"),
             payload=VectorDbPayload(type="from_slot", value='color'),
@@ -2328,9 +2328,9 @@ class TestActionServer(AsyncHTTPTestCase):
 
     def test_vectordb_action_execution_no_response_dispatch(self):
         action_name = "test_vectordb_action_execution_no_response_dispatch"
-        Actions(name=action_name, type=ActionType.vector_embeddings_db_action.value, bot="5f50fd0a56v098ca10d75d2e", user="user").save()
+        Actions(name=action_name, type=ActionType.database_action.value, bot="5f50fd0a56v098ca10d75d2e", user="user").save()
         payload_body = {"ids": [0], "with_payload": True, "with_vector": True}
-        VectorEmbeddingDbAction(
+        DatabaseAction(
             name=action_name,
             operation=VectorDbOperation(type="from_value", value="embedding_search"),
             payload=VectorDbPayload(type="from_value", value=payload_body),
@@ -2411,9 +2411,9 @@ class TestActionServer(AsyncHTTPTestCase):
 
     def test_vectordb_action_execution_invalid_operation_type(self):
         action_name = "test_vectordb_action_execution_invalid_operation_type"
-        Actions(name=action_name, type=ActionType.vector_embeddings_db_action.value, bot="5f50fd0a56v908ca10d75d2e", user="user").save()
+        Actions(name=action_name, type=ActionType.database_action.value, bot="5f50fd0a56v908ca10d75d2e", user="user").save()
         payload_body = {"ids": [0], "with_payload": True, "with_vector": True}
-        VectorEmbeddingDbAction(
+        DatabaseAction(
             name=action_name,
             operation=VectorDbOperation(type="from_value", value="vector_search"),
             payload=VectorDbPayload(type="from_value", value=payload_body),
@@ -2465,13 +2465,13 @@ class TestActionServer(AsyncHTTPTestCase):
         log.pop('timestamp')
 
     @patch("kairon.shared.actions.utils.ActionUtility.get_action")
-    @patch("kairon.actions.definitions.vector_action.VectorEmbeddingsDbAction.retrieve_config")
+    @patch("kairon.actions.definitions.vector_action.DatabaseAction.retrieve_config")
     def test_vectordb_action_failed_execution(self, mock_action_config, mock_action):
         action_name = "test_run_with_get_action"
         payload_body = {"ids": [0], "with_payload": True, "with_vector": True}
-        action = Actions(name=action_name, type=ActionType.vector_embeddings_db_action.value, bot="5f50fd0a56b697ca10d35d2e",
+        action = Actions(name=action_name, type=ActionType.database_action.value, bot="5f50fd0a56b697ca10d35d2e",
                          user="user")
-        action_config = VectorEmbeddingDbAction(
+        action_config = DatabaseAction(
             name=action_name,
             operation=VectorDbOperation(type="from_value", value="embedding_search"),
             payload=VectorDbPayload(type="from_value", value=payload_body),
@@ -2597,6 +2597,8 @@ class TestActionServer(AsyncHTTPTestCase):
         response_json = json.loads(response.body.decode("utf8"))
         self.assertEqual(response.code, 200)
         self.assertEqual(response_json, {'events': [], 'responses': []})
+        log = ActionServerLogs.objects(action=action_name).get().to_mongo().to_dict()
+        assert log['exception'] == 'No action found for given bot and name'
 
     def test_slot_set_action_from_value(self):
         action_name = "test_slot_set_from_value"

--- a/tests/integration_test/action_service_test.py
+++ b/tests/integration_test/action_service_test.py
@@ -2465,7 +2465,7 @@ class TestActionServer(AsyncHTTPTestCase):
         log.pop('timestamp')
 
     @patch("kairon.shared.actions.utils.ActionUtility.get_action")
-    @patch("kairon.actions.definitions.vector_action.DatabaseAction.retrieve_config")
+    @patch("kairon.actions.definitions.vector_action.ActionDatabase.retrieve_config")
     def test_vectordb_action_failed_execution(self, mock_action_config, mock_action):
         action_name = "test_run_with_get_action"
         payload_body = {"ids": [0], "with_payload": True, "with_vector": True}

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -1175,7 +1175,7 @@ def test_payload_upload_api_with_gpt_feature_disabled():
             "metadata": [{"column_name": "Details", "data_type": "str", "enable_search": True,
                          "create_embeddings": True}]}
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/data/payload",
+        url=f"/api/bot/{pytest.bot}/data/cognition",
         json=payload,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token}
     )
@@ -1197,41 +1197,21 @@ def test_payload_upload_api(monkeypatch):
             "metadata": [{"column_name": "Details", "data_type": "str", "enable_search": True, "create_embeddings": True}]
     }
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/data/payload",
+        url=f"/api/bot/{pytest.bot}/data/cognition",
         json=payload,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token}
     )
     actual = response.json()
     print(actual)
     pytest.payload_id = actual["data"]["_id"]
-    assert actual["message"] == "Text saved!"
+    assert actual["message"] == "Cognition saved!"
     assert actual["data"]["_id"]
     assert actual["error_code"] == 0
 
 
-# def test_payload_upload_api_invalid(monkeypatch):
-#     def _mock_get_bot_settings(*args, **kwargs):
-#         return BotSettings(bot=pytest.bot, user="integration@demo.ai", llm_settings=LLMSettings(enable_faq=True))
-#
-#     monkeypatch.setattr(MongoProcessor, 'get_bot_settings', _mock_get_bot_settings)
-#     response = client.post(
-#         url=f"/api/bot/{pytest.bot}/data/payload/faq",
-#         json={
-#             "data": "Data"
-#         },
-#         headers={"Authorization": pytest.token_type + " " + pytest.access_token}
-#
-#     )
-#     actual = response.json()
-#     assert actual["message"] == "Content should contain atleast 10 words."
-#     assert not actual["success"]
-#     assert actual["data"] is None
-#     assert actual["error_code"] == 422
-
-
 def test_payload_updated_api():
     response = client.put(
-        url=f"/api/bot/{pytest.bot}/data/payload/{pytest.payload_id}",
+        url=f"/api/bot/{pytest.bot}/data/cognition/{pytest.payload_id}",
         json={
             "payload_id": pytest.payload_id,
             "data": "A transformer is an encoder decoder model that uses the attention mechanism.",
@@ -1244,7 +1224,7 @@ def test_payload_updated_api():
     actual = response.json()
     print(actual)
     assert actual["success"]
-    assert actual["message"] == "Text updated!"
+    assert actual["message"] == "Cognition updated!"
     assert actual["error_code"] == 0
 
 
@@ -1255,7 +1235,7 @@ def test_payload_content_update_api_already_exists(monkeypatch):
 
     monkeypatch.setattr(MongoProcessor, 'get_bot_settings', _mock_get_bot_settings)
     response = client.put(
-        url=f"/api/bot/{pytest.bot}/data/payload/{payload_id}",
+        url=f"/api/bot/{pytest.bot}/data/cognition/{payload_id}",
         json={
             "payload_id": payload_id,
             "data": "A transformer is an encoder decoder model that uses the attention mechanism.",
@@ -1277,7 +1257,7 @@ def test_payload_content_update_api_already_exists(monkeypatch):
 def test_payload_content_update_api_id_not_found():
     payload_id = '594ced02ed345b2b049222c5'
     response = client.put(
-        url=f"/api/bot/{pytest.bot}/data/payload/{payload_id}",
+        url=f"/api/bot/{pytest.bot}/data/cognition/{payload_id}",
         json={
             "text_id": payload_id,
             "data": "It can take advantage of pluralization.",
@@ -1297,7 +1277,7 @@ def test_payload_content_update_api_id_not_found():
 
 def test_get_payload_content():
     response = client.get(
-        url=f"/api/bot/{pytest.bot}/data/payload",
+        url=f"/api/bot/{pytest.bot}/data/cognition",
         headers={"Authorization": pytest.token_type + " " + pytest.access_token}
     )
     actual = response.json()
@@ -1308,7 +1288,7 @@ def test_get_payload_content():
 
 def test_delete_payload_content():
     response = client.delete(
-        url=f"/api/bot/{pytest.bot}/data/payload/{pytest.payload_id}",
+        url=f"/api/bot/{pytest.bot}/data/cognition/{pytest.payload_id}",
         json={
             "text_id": pytest.payload_id,
         },
@@ -1317,7 +1297,7 @@ def test_delete_payload_content():
     actual = response.json()
     print(actual)
     assert actual["success"]
-    assert actual["message"] == "Text deleted!"
+    assert actual["message"] == "Cognition deleted!"
     assert actual["data"] is None
     assert actual["error_code"] == 0
 
@@ -1325,7 +1305,7 @@ def test_delete_payload_content():
 def test_delete_payload_content_does_not_exist():
     payload_id = '61f3a2c0aef88d5b4c58e90f'
     response = client.delete(
-        url=f"/api/bot/{pytest.bot}/data/payload/{payload_id}",
+        url=f"/api/bot/{pytest.bot}/data/cognition/{payload_id}",
         json={
             "text_id": payload_id,
         },
@@ -1340,7 +1320,7 @@ def test_delete_payload_content_does_not_exist():
 
 def test_get_payload_content_not_exists():
     response = client.get(
-        url=f"/api/bot/{pytest.bot}/data/payload",
+        url=f"/api/bot/{pytest.bot}/data/cognition",
         headers={"Authorization": pytest.token_type + " " + pytest.access_token}
     )
     actual = response.json()
@@ -6354,7 +6334,7 @@ def test_add_vectordb_action_empty_name():
         "response": {"value": "0"}
     }
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
@@ -6374,7 +6354,7 @@ def test_add_vectordb_action_empty_operation_value():
         "response": {"value": "0"}
     }
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
@@ -6399,7 +6379,7 @@ def test_add_vectordb_action_empty_operation_type():
         "response": {"value": "0"}
     }
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
@@ -6423,7 +6403,7 @@ def test_add_vectordb_action_empty_payload_type():
         "response": {"value": "0"}
     }
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
@@ -6447,7 +6427,7 @@ def test_add_vectordb_action_empty_payload_value():
         "response": {"value": "0"}
     }
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
@@ -6474,7 +6454,7 @@ def test_add_vectordb_action():
         "response": {"value": "0"}
     }
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
@@ -6502,7 +6482,7 @@ def test_add_vectordb_action_case_insensitivity():
     }
 
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
@@ -6513,7 +6493,7 @@ def test_add_vectordb_action_case_insensitivity():
     assert actual["success"]
 
     response = client.get(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db/VECTORDB_ACTION_CASE_INSENSITIVE",
+        url=f"/api/bot/{pytest.bot}/action/db/VECTORDB_ACTION_CASE_INSENSITIVE",
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
     actual = response.json()
@@ -6521,7 +6501,7 @@ def test_add_vectordb_action_case_insensitivity():
     assert not actual['data']
 
     response = client.get(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db/vectordb_action_case_insensitive",
+        url=f"/api/bot/{pytest.bot}/action/db/vectordb_action_case_insensitive",
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
     actual = response.json()
@@ -6541,7 +6521,7 @@ def test_add_vectordb_action_existing():
     }
 
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
@@ -6549,7 +6529,7 @@ def test_add_vectordb_action_existing():
     assert actual["error_code"] == 0
 
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
@@ -6582,7 +6562,7 @@ def test_add_vectordb_action_with_slots():
         "response": {"value": "0"}
     }
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
@@ -6610,7 +6590,7 @@ def test_add_vectordb_action_with_invalid_operation_type():
     }
 
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
@@ -6639,7 +6619,7 @@ def test_update_vectordb_action():
     }
 
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
@@ -6654,7 +6634,7 @@ def test_update_vectordb_action():
         "set_slots": [{"name": "bot", "value": "${RESPONSE}", "evaluation_type": "script"}]
     }
     response = client.put(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
@@ -6664,7 +6644,7 @@ def test_update_vectordb_action():
     assert actual["message"] == 'Action updated!'
 
     response = client.get(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db/test_update_vectordb_action",
+        url=f"/api/bot/{pytest.bot}/action/db/test_update_vectordb_action",
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
     actual = response.json()
@@ -6682,7 +6662,7 @@ def test_update_vectordb_action_non_existing():
     }
 
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
@@ -6695,7 +6675,7 @@ def test_update_vectordb_action_non_existing():
         "set_slots": [{"name": "age", "value": "${RESPONSE}", "evaluation_type": "script"}]
     }
     response = client.put(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
@@ -6716,7 +6696,7 @@ def test_update_vector_action_wrong_parameter():
     }
 
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
@@ -6731,7 +6711,7 @@ def test_update_vector_action_wrong_parameter():
         "set_slots": [{"name": "bot", "value": "${RESPONSE}", "evaluation_type": "expression"}]
     }
     response = client.put(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
@@ -6744,7 +6724,7 @@ def test_update_vector_action_wrong_parameter():
 
 def test_get_vectordb_action():
     response = client.get(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db/test_add_vectordb_action_with_slots",
+        url=f"/api/bot/{pytest.bot}/action/db/test_add_vectordb_action_with_slots",
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
     actual = response.json()
@@ -6754,7 +6734,7 @@ def test_get_vectordb_action():
 
 def test_get_vector_action_non_exisitng():
     response = client.get(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db/never_added_vectordb_action",
+        url=f"/api/bot/{pytest.bot}/action/db/never_added_vectordb_action",
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
     actual = response.json()
@@ -6765,7 +6745,7 @@ def test_get_vector_action_non_exisitng():
 
 def test_list_vector_db_action():
     response = client.get(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
     actual = response.json()
@@ -6791,7 +6771,7 @@ def test_delete_vectordb_action():
     }
 
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
@@ -6806,9 +6786,9 @@ def test_delete_vectordb_action():
     assert actual["success"]
 
 
-def test_delete_http_action_non_existing():
+def test_delete_vectordb_action_non_existing():
     request_body = {
-        "name": "test_delete_http_action_non_existing",
+        "name": "test_delete_vectordb_action_non_existing",
         "operation": {"type": "from_value", "value": "payload_search"},
         "payload": {"type": "from_value", "value": {
             "filter": {
@@ -6822,7 +6802,7 @@ def test_delete_http_action_non_existing():
     }
 
     client.post(
-        url=f"/api/bot/{pytest.bot}/action/embeddings/db",
+        url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
@@ -7689,21 +7669,20 @@ def test_list_actions():
     assert Utility.check_empty_string(actual["message"])
     print(actual['data'])
     assert actual['data'] == {'actions': ['action_greet'],
+                              'database_action': ['vectordb_action_test', 'vectordb_action_case_insensitive',
+                                                  'test_add_vectordb_action_existing', 'test_add_vectordb_action_with_slots',
+                                                  'test_update_vectordb_action', 'test_update_vectordb_action_non_existing',
+                                                  'test_update_vector_action_1', 'test_delete_vectordb_action_non_existing'],
                               'http_action': ['test_add_http_action_no_token', 'test_add_http_action_with_valid_dispatch_type',
                                               'test_add_http_action_with_dynamic_params', 'test_update_http_action_with_dynamic_params',
                                               'test_add_http_action_with_sender_id_parameter_type', 'test_add_http_action_with_token_and_story',
                                               'test_add_http_action_no_params', 'test_add_http_action_existing', 'test_update_http_action',
                                               'test_update_http_action_6', 'test_update_http_action_non_existing', 'new_http_action4'],
-                              'database_action': ['vectordb_action_test', 'vectordb_action_case_insensitive',
-                                                              'test_add_vectordb_action_existing', 'test_add_vectordb_action_with_slots',
-                                                              'test_update_vectordb_action', 'test_update_vectordb_action_non_existing',
-                                                              'test_update_vector_action_1'],
                               'utterances': ['utter_greet', 'utter_cheer_up', 'utter_did_that_help', 'utter_happy', 'utter_goodbye',
                                              'utter_iamabot', 'utter_default', 'utter_please_rephrase'],
-                              'slot_set_action': [], 'form_validation_action': [], 'email_action': [],
-                              'google_search_action': [], 'jira_action': [], 'zendesk_action': [], 'pipedrive_leads_action': [],
-                              'hubspot_forms_action': [], 'two_stage_fallback': [], 'kairon_bot_response': [], 'razorpay_action': [],
-                              'prompt_action': []}
+                              'slot_set_action': [], 'form_validation_action': [], 'email_action': [], 'google_search_action': [],
+                              'jira_action': [], 'zendesk_action': [], 'pipedrive_leads_action': [], 'hubspot_forms_action': [],
+                              'two_stage_fallback': [], 'kairon_bot_response': [], 'razorpay_action': [], 'prompt_action': []}
 
     assert actual["success"]
 

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -2195,32 +2195,32 @@ def test_model_testing_no_existing_models():
     assert not actual["success"]
 
 
-# @responses.activate
-# def test_train(monkeypatch):
-#     def mongo_store(*arge, **kwargs):
-#         return None
-#
-#     def _mock_training_limit(*arge, **kwargs):
-#         return False
-#
-#     monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
-#     monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
-#
-#     event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
-#     responses.add(
-#         "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
-#     )
-#
-#     response = client.post(
-#         f"/api/bot/{pytest.bot}/train",
-#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-#     )
-#     actual = response.json()
-#     assert actual["success"]
-#     assert actual["error_code"] == 0
-#     assert actual["data"] is None
-#     assert actual["message"] == "Model training started."
-#     complete_end_to_end_event_execution(pytest.bot, "integration@demo.ai", EventClass.model_training)
+@responses.activate
+def test_train(monkeypatch):
+    def mongo_store(*arge, **kwargs):
+        return None
+
+    def _mock_training_limit(*arge, **kwargs):
+        return False
+
+    monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
+    monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
+
+    event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
+    responses.add(
+        "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
+    )
+
+    response = client.post(
+        f"/api/bot/{pytest.bot}/train",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["message"] == "Model training started."
+    complete_end_to_end_event_execution(pytest.bot, "integration@demo.ai", EventClass.model_training)
 
 
 def test_upload_limit_exceeded(monkeypatch):
@@ -4115,32 +4115,32 @@ def test_get_utterance_from_not_exist_intent():
     assert Utility.check_empty_string(actual["message"])
 
 
-# @responses.activate
-# def test_train_on_updated_data(monkeypatch):
-#     def mongo_store(*arge, **kwargs):
-#         return None
-#
-#     def _mock_training_limit(*arge, **kwargs):
-#         return False
-#
-#     monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
-#     monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
-#
-#     event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
-#     responses.add(
-#         "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
-#     )
-#
-#     response = client.post(
-#         f"/api/bot/{pytest.bot}/train",
-#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-#     )
-#     actual = response.json()
-#     assert actual["success"]
-#     assert actual["error_code"] == 0
-#     assert actual["data"] is None
-#     assert actual["message"] == "Model training started."
-#     complete_end_to_end_event_execution(pytest.bot, "integration@demo.ai", EventClass.model_training)
+@responses.activate
+def test_train_on_updated_data(monkeypatch):
+    def mongo_store(*arge, **kwargs):
+        return None
+
+    def _mock_training_limit(*arge, **kwargs):
+        return False
+
+    monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
+    monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
+
+    event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
+    responses.add(
+        "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
+    )
+
+    response = client.post(
+        f"/api/bot/{pytest.bot}/train",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["message"] == "Model training started."
+    complete_end_to_end_event_execution(pytest.bot, "integration@demo.ai", EventClass.model_training)
 
 
 def test_download_model_training_logs(monkeypatch):
@@ -4161,16 +4161,16 @@ def mock_is_training_inprogress_exception(monkeypatch):
     monkeypatch.setattr(ModelProcessor, "is_training_inprogress", _inprogress_execption_response)
 
 
-# def test_train_inprogress(mock_is_training_inprogress_exception):
-#     response = client.post(
-#         f"/api/bot/{pytest.bot}/train",
-#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-#     )
-#     actual = response.json()
-#     assert actual["success"] is False
-#     assert actual["error_code"] == 422
-#     assert actual["data"] is None
-#     assert actual["message"] == "Previous model training in progress."
+def test_train_inprogress(mock_is_training_inprogress_exception):
+    response = client.post(
+        f"/api/bot/{pytest.bot}/train",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert actual["success"] is False
+    assert actual["error_code"] == 422
+    assert actual["data"] is None
+    assert actual["message"] == "Previous model training in progress."
 
 
 @pytest.fixture
@@ -4181,19 +4181,19 @@ def mock_is_training_inprogress(monkeypatch):
     monkeypatch.setattr(ModelProcessor, "is_training_inprogress", _inprogress_response)
 
 
-# def test_train_daily_limit_exceed(mock_is_training_inprogress, monkeypatch):
-#     bot_settings = BotSettings.objects(bot=pytest.bot).get()
-#     bot_settings.training_limit_per_day = 2
-#     bot_settings.save()
-#     response = client.post(
-#         f"/api/bot/{pytest.bot}/train",
-#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-#     )
-#     actual = response.json()
-#     assert not actual["success"]
-#     assert actual["error_code"] == 422
-#     assert actual["data"] is None
-#     assert actual["message"] == "Daily model training limit exceeded."
+def test_train_daily_limit_exceed(mock_is_training_inprogress, monkeypatch):
+    bot_settings = BotSettings.objects(bot=pytest.bot).get()
+    bot_settings.training_limit_per_day = 2
+    bot_settings.save()
+    response = client.post(
+        f"/api/bot/{pytest.bot}/train",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+    assert actual["data"] is None
+    assert actual["message"] == "Daily model training limit exceeded."
 
 
 def test_get_model_training_history():
@@ -5775,85 +5775,85 @@ def test_add_story_to_different_bot():
     assert actual["error_code"] == 0
 
 
-# @responses.activate
-# def test_train_on_different_bot(monkeypatch):
-#     def mongo_store(*arge, **kwargs):
-#         return None
-#
-#     def _mock_training_limit(*arge, **kwargs):
-#         return False
-#
-#     monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
-#     monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
-#     monkeypatch.setattr(DataUtility, "validate_existing_data_train", mongo_store)
-#
-#     event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
-#     responses.add(
-#         "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
-#     )
-#
-#     response = client.post(
-#         f"/api/bot/{pytest.bot_2}/train",
-#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-#     )
-#     actual = response.json()
-#     assert actual["success"]
-#     assert actual["error_code"] == 0
-#     assert actual["data"] is None
-#     assert actual["message"] == "Model training started."
-#     complete_end_to_end_event_execution(pytest.bot_2, "integration@demo.ai", EventClass.model_training)
+@responses.activate
+def test_train_on_different_bot(monkeypatch):
+    def mongo_store(*arge, **kwargs):
+        return None
+
+    def _mock_training_limit(*arge, **kwargs):
+        return False
+
+    monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
+    monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
+    monkeypatch.setattr(DataUtility, "validate_existing_data_train", mongo_store)
+
+    event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
+    responses.add(
+        "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
+    )
+
+    response = client.post(
+        f"/api/bot/{pytest.bot_2}/train",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["message"] == "Model training started."
+    complete_end_to_end_event_execution(pytest.bot_2, "integration@demo.ai", EventClass.model_training)
 
 
-# def test_train_insufficient_data(monkeypatch):
-#     def mongo_store(*arge, **kwargs):
-#         return None
-#
-#     def _mock_training_limit(*arge, **kwargs):
-#         return False
-#
-#     monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
-#     monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
-#
-#     response = client.post(
-#         "/api/account/bot",
-#         json={"data": "sample-bot"},
-#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-#     )
-#
-#     response = client.get(
-#         "/api/account/bot",
-#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-#     ).json()
-#     pytest.bot_sample = response['data']['account_owned'][3]['_id']
-#
-#     response_story = client.get(
-#         f"/api/bot/{pytest.bot_sample}/stories",
-#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-#     )
-#     actual = response_story.json()
-#     print(actual['data'])
-#     rule_one = actual['data'][1]['_id']
-#     rule_two = actual['data'][2]['_id']
-#
-#     response_delete_story_one = client.delete(
-#         f"/api/bot/{pytest.bot_sample}/stories/{rule_one}/RULE",
-#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-#     )
-#
-#     response_delete_story_two = client.delete(
-#         f"/api/bot/{pytest.bot_sample}/stories/{rule_two}/RULE",
-#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-#     )
-#
-#     response = client.post(
-#         f"/api/bot/{pytest.bot_sample}/train",
-#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-#     )
-#     actual = response.json()
-#     assert not actual["success"]
-#     assert actual["error_code"] == 422
-#     assert actual["data"] is None
-#     assert actual["message"] == "Please add at least 2 flows and 2 intents before training the bot!"
+def test_train_insufficient_data(monkeypatch):
+    def mongo_store(*arge, **kwargs):
+        return None
+
+    def _mock_training_limit(*arge, **kwargs):
+        return False
+
+    monkeypatch.setattr(Utility, "get_local_mongo_store", mongo_store)
+    monkeypatch.setattr(ModelProcessor, "is_daily_training_limit_exceeded", _mock_training_limit)
+
+    response = client.post(
+        "/api/account/bot",
+        json={"data": "sample-bot"},
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+
+    response = client.get(
+        "/api/account/bot",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    ).json()
+    pytest.bot_sample = response['data']['account_owned'][3]['_id']
+
+    response_story = client.get(
+        f"/api/bot/{pytest.bot_sample}/stories",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response_story.json()
+    print(actual['data'])
+    rule_one = actual['data'][1]['_id']
+    rule_two = actual['data'][2]['_id']
+
+    response_delete_story_one = client.delete(
+        f"/api/bot/{pytest.bot_sample}/stories/{rule_one}/RULE",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+
+    response_delete_story_two = client.delete(
+        f"/api/bot/{pytest.bot_sample}/stories/{rule_two}/RULE",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+
+    response = client.post(
+        f"/api/bot/{pytest.bot_sample}/train",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+    assert actual["data"] is None
+    assert actual["message"] == "Please add at least 2 flows and 2 intents before training the bot!"
 
 
 def test_delete_bot():
@@ -7708,22 +7708,22 @@ def test_list_actions():
     assert actual["success"]
 
 
-# @responses.activate
-# def test_train_using_event(monkeypatch):
-#     event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
-#     responses.add(
-#         "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
-#     )
-#     response = client.post(
-#         f"/api/bot/{pytest.bot}/train",
-#         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
-#     )
-#     actual = response.json()
-#     assert actual["success"]
-#     assert actual["error_code"] == 0
-#     assert actual["data"] is None
-#     assert actual["message"] == "Model training started."
-#     complete_end_to_end_event_execution(pytest.bot, "integration@demo.ai", EventClass.model_training)
+@responses.activate
+def test_train_using_event(monkeypatch):
+    event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_training}")
+    responses.add(
+        "POST", event_url, json={"success": True, "message": "Event triggered successfully!"}
+    )
+    response = client.post(
+        f"/api/bot/{pytest.bot}/train",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["message"] == "Model training started."
+    complete_end_to_end_event_execution(pytest.bot, "integration@demo.ai", EventClass.model_training)
 
 
 def test_update_training_data_generator_status(monkeypatch):

--- a/tests/unit_test/data_processor/data_processor_test.py
+++ b/tests/unit_test/data_processor/data_processor_test.py
@@ -36,14 +36,14 @@ from starlette.requests import Request
 
 from kairon.api import models
 from kairon.api.models import HttpActionParameters, HttpActionConfigRequest, ActionResponseEvaluation, \
-    SetSlotsUsingActionResponse, PromptActionConfigRequest, VectorEmbeddingActionRequest, OperationConfig, PayloadConfig
+    SetSlotsUsingActionResponse, PromptActionConfigRequest, DatabaseActionRequest, OperationConfig, PayloadConfig
 from kairon.chat.agent_processor import AgentProcessor
 from kairon.exceptions import AppException
 from kairon.shared.account.processor import AccountProcessor
 from kairon.shared.actions.data_objects import HttpActionConfig, ActionServerLogs, Actions, SlotSetAction, \
     FormValidationAction, GoogleSearchAction, JiraAction, PipedriveLeadsAction, HubspotFormsAction, HttpActionResponse, \
     HttpActionRequestBody, EmailActionConfig, CustomActionRequestParameters, ZendeskAction, RazorpayAction, \
-    VectorEmbeddingDbAction, SetSlotsFromResponse
+    DatabaseAction, SetSlotsFromResponse
 from kairon.shared.actions.models import ActionType, DispatchType
 from kairon.shared.admin.constants import BotSecretType
 from kairon.shared.admin.data_objects import BotSecrets
@@ -8999,14 +8999,14 @@ class TestMongoProcessor:
             "with_vector": True
         }
         payload = {'type': 'from_value', 'value': payload_body}
-        vectordb_action_config = VectorEmbeddingActionRequest(
+        vectordb_action_config = DatabaseActionRequest(
             name=action,
             operation=operation,
             payload=payload,
             response=ActionResponseEvaluation(value=response)
         )
         processor.add_vector_embedding_db_action(vectordb_action_config.dict(), user, bot)
-        actual_vectordb_action = VectorEmbeddingDbAction.objects(name=action, bot=bot, status=True).get()
+        actual_vectordb_action = DatabaseAction.objects(name=action, bot=bot, status=True).get()
         assert actual_vectordb_action is not None
         assert Actions.objects(name=action, status=True, bot=bot).get()
         assert actual_vectordb_action['name'] == action
@@ -9032,14 +9032,14 @@ class TestMongoProcessor:
             }
         }
         payload = {'type': 'from_value', 'value': payload_body}
-        vectordb_action_config = VectorEmbeddingActionRequest(
+        vectordb_action_config = DatabaseActionRequest(
             name=action,
             operation=operation,
             payload=payload,
             response=ActionResponseEvaluation(value=response)
         )
         processor.add_vector_embedding_db_action(vectordb_action_config.dict(), user, bot)
-        actual_vectordb_action = VectorEmbeddingDbAction.objects(name=action, bot=bot, status=True).get()
+        actual_vectordb_action = DatabaseAction.objects(name=action, bot=bot, status=True).get()
         assert actual_vectordb_action is not None
         assert Actions.objects(name=action, status=True, bot=bot).get()
         assert actual_vectordb_action['name'] == action
@@ -9059,7 +9059,7 @@ class TestMongoProcessor:
         payload = {'type': 'from_slot', 'value': 'email'}
         processor.add_slot({"name": "email", "type": "text", "initial_value": "nupur.khare@digite.com", "influence_conversation": True}, bot, user,
                            raise_exception_if_exists=False)
-        vectordb_action_config = VectorEmbeddingActionRequest(
+        vectordb_action_config = DatabaseActionRequest(
             name=action,
             operation=operation,
             payload=payload,
@@ -9067,7 +9067,7 @@ class TestMongoProcessor:
             set_slots=[SetSlotsUsingActionResponse(name="age", value="${data.age}", evaluation_type="expression")]
         )
         processor.add_vector_embedding_db_action(vectordb_action_config.dict(), user, bot)
-        actual_vectordb_action = VectorEmbeddingDbAction.objects(name=action, bot=bot, status=True).get()
+        actual_vectordb_action = DatabaseAction.objects(name=action, bot=bot, status=True).get()
         assert actual_vectordb_action is not None
         assert Actions.objects(name=action, status=True, bot=bot).get()
         assert actual_vectordb_action['name'] == action
@@ -9085,7 +9085,7 @@ class TestMongoProcessor:
         response = 'nupur.khare'
         operation = {'type': 'from_value', 'value': 'embedding_search'}
         payload = {'type': 'from_slot', 'value': 'cuisine'}
-        vectordb_action_config = VectorEmbeddingActionRequest(
+        vectordb_action_config = DatabaseActionRequest(
             name=action,
             operation=operation,
             payload=payload,
@@ -9110,7 +9110,7 @@ class TestMongoProcessor:
             "with_vector": True
         }
         payload = {'type': 'from_value', 'value': payload_body}
-        vectordb_action_config = VectorEmbeddingActionRequest(
+        vectordb_action_config = DatabaseActionRequest(
             name=action,
             operation=operation,
             payload=payload,
@@ -9134,7 +9134,7 @@ class TestMongoProcessor:
             "with_vector": True
         }
         payload = {'type': 'from_value', 'value': payload_body}
-        vectordb_action_config = VectorEmbeddingActionRequest(
+        vectordb_action_config = DatabaseActionRequest(
             name=action,
             operation=operation,
             payload=payload,
@@ -9144,7 +9144,7 @@ class TestMongoProcessor:
         vectordb_action['name'] = ''
         with pytest.raises(ValidationError, match="Action name cannot be empty"):
             processor.add_vector_embedding_db_action(vectordb_action, user, bot)
-        vectordb_action_config_two = VectorEmbeddingActionRequest(
+        vectordb_action_config_two = DatabaseActionRequest(
             name=action,
             operation=operation,
             payload=payload,
@@ -9154,7 +9154,7 @@ class TestMongoProcessor:
         vectordb_action_two['payload']['value'] = ''
         with pytest.raises(ValidationError, match="payload value is required"):
             processor.add_vector_embedding_db_action(vectordb_action_two, user, bot)
-        vectordb_action_config_three = VectorEmbeddingActionRequest(
+        vectordb_action_config_three = DatabaseActionRequest(
             name=action,
             operation=operation,
             payload=payload,
@@ -9180,7 +9180,7 @@ class TestMongoProcessor:
             "with_vector": True
         }
         payload = {'type': 'from_value', 'value': payload_body}
-        vectordb_action_config = VectorEmbeddingActionRequest(
+        vectordb_action_config = DatabaseActionRequest(
             name=action,
             operation=operation,
             payload=payload,
@@ -9190,7 +9190,7 @@ class TestMongoProcessor:
         vectordb_action['name'] = ''
         with pytest.raises(ValidationError, match="Action name cannot be empty"):
             processor.add_vector_embedding_db_action(vectordb_action, user, bot)
-        vectordb_action_config_two = VectorEmbeddingActionRequest(
+        vectordb_action_config_two = DatabaseActionRequest(
             name=action,
             operation=operation,
             payload=payload,
@@ -9200,7 +9200,7 @@ class TestMongoProcessor:
         vectordb_action_two['operation']['value'] = ''
         with pytest.raises(ValidationError, match="operation value is required"):
             processor.add_vector_embedding_db_action(vectordb_action_two, user, bot)
-        vectordb_action_config_three = VectorEmbeddingActionRequest(
+        vectordb_action_config_three = DatabaseActionRequest(
             name=action,
             operation=operation,
             payload=payload,
@@ -9220,7 +9220,7 @@ class TestMongoProcessor:
 
         operation = {'type': 'from_value', 'value': 'embedding_search'}
         payload = {'type': 'from_slot', 'value': 'email'}
-        VectorEmbeddingDbAction(
+        DatabaseAction(
             name=action,
             operation=operation,
             payload=payload,
@@ -9248,7 +9248,7 @@ class TestMongoProcessor:
 
         operation = {'type': 'from_value', 'value': 'embedding_search'}
         payload = {'type': 'from_slot', 'value': 'email'}
-        VectorEmbeddingDbAction(
+        DatabaseAction(
             name=action,
             operation=operation,
             payload=payload,
@@ -9286,14 +9286,14 @@ class TestMongoProcessor:
             }
         }
         payload = {'type': 'from_value', 'value': payload_body}
-        vectordb_action_config = VectorEmbeddingActionRequest(
+        vectordb_action_config = DatabaseActionRequest(
             name=action,
             operation=operation,
             payload=payload,
             response=ActionResponseEvaluation(value=response)
         )
         processor.add_vector_embedding_db_action(vectordb_action_config.dict(), user, bot)
-        actual = VectorEmbeddingDbAction.objects(name=action, bot=bot, status=True).get()
+        actual = DatabaseAction.objects(name=action, bot=bot, status=True).get()
         assert actual is not None
         assert actual['name'] == action
         assert actual['response']['value'] == '15'
@@ -9303,7 +9303,7 @@ class TestMongoProcessor:
                             "influence_conversation": True}, bot, user,
                            raise_exception_if_exists=False)
         payload_two = {'type': 'from_value', 'value': 'name'}
-        vectordb_action_config_updated = VectorEmbeddingActionRequest(
+        vectordb_action_config_updated = DatabaseActionRequest(
             name=action,
             operation=operation,
             payload=payload_two,
@@ -9311,7 +9311,7 @@ class TestMongoProcessor:
             set_slots=[SetSlotsUsingActionResponse(name="name", value="${data.name}", evaluation_type="expression")]
         )
         processor.update_vector_embedding_db_action(vectordb_action_config_updated.dict(), user, bot)
-        actual_two = VectorEmbeddingDbAction.objects(name=action, bot=bot, status=True).get()
+        actual_two = DatabaseAction.objects(name=action, bot=bot, status=True).get()
         assert actual_two is not None
         assert actual_two['name'] == action
         assert actual_two['response']['value'] == 'nimble'
@@ -9332,7 +9332,7 @@ class TestMongoProcessor:
             "with_vector": True
         }
         payload = {'type': 'from_value', 'value': payload_body}
-        vectordb_action_config = VectorEmbeddingActionRequest(
+        vectordb_action_config = DatabaseActionRequest(
             name=action,
             operation=operation,
             payload=payload,
@@ -9356,8 +9356,8 @@ class TestMongoProcessor:
             "with_vector": True
         }
         payload = {'type': 'from_value', 'value': payload_body}
-        Actions(name=action, type=ActionType.vector_embeddings_db_action.value, bot=bot, user=user).save()
-        VectorEmbeddingDbAction(
+        Actions(name=action, type=ActionType.database_action.value, bot=bot, user=user).save()
+        DatabaseAction(
             name=action,
             operation=operation,
             payload=payload,
@@ -9388,7 +9388,7 @@ class TestMongoProcessor:
             "with_vector": True
         }
         payload = {'type': 'from_value', 'value': payload_body}
-        VectorEmbeddingDbAction(
+        DatabaseAction(
             name=action,
             operation=operation,
             payload=payload,
@@ -10049,7 +10049,7 @@ class TestMongoProcessor:
             'email_action': [], 'google_search_action': [], 'jira_action': [], 'zendesk_action': [],
             'pipedrive_leads_action': [], 'hubspot_forms_action': [], 'two_stage_fallback': [],
             'kairon_bot_response': [], 'razorpay_action': [], 'prompt_action': [], 'actions': [],
-            'vector_embeddings_db_action': []
+            'database_action': []
         }
 
     def test_add_complex_story_with_action(self):
@@ -10071,7 +10071,7 @@ class TestMongoProcessor:
             'actions': ['action_check'], 'utterances': [], 'http_action': [], 'slot_set_action': [],
             'form_validation_action': [], 'email_action': [], 'google_search_action': [], 'jira_action': [],
             'zendesk_action': [], 'pipedrive_leads_action': [], 'hubspot_forms_action': [], 'two_stage_fallback': [],
-            'kairon_bot_response': [], 'razorpay_action': [], 'prompt_action': [], 'vector_embeddings_db_action': []
+            'kairon_bot_response': [], 'razorpay_action': [], 'prompt_action': [], 'database_action': []
         }
 
     def test_add_complex_story(self):
@@ -10095,7 +10095,7 @@ class TestMongoProcessor:
                            'slot_set_action': [], 'email_action': [], 'form_validation_action': [],
                            'kairon_bot_response': [],
                            'razorpay_action': [], 'prompt_action': ['gpt_llm_faq'],
-                           'vector_embeddings_db_action': [],
+                           'database_action': [],
                            'utterances': ['utter_greet',
                                           'utter_cheer_up',
                                           'utter_did_that_help',
@@ -11837,7 +11837,7 @@ class TestMongoProcessor:
             'actions': ['reset_slot'], 'google_search_action': [], 'jira_action': [], 'pipedrive_leads_action': [],
             'http_action': ['action_performanceuser1000@digite.com'], 'zendesk_action': [], 'slot_set_action': [],
             'hubspot_forms_action': [], 'two_stage_fallback': [], 'kairon_bot_response': [], 'razorpay_action': [],
-            'email_action': [], 'form_validation_action': [], 'prompt_action': [], 'vector_embeddings_db_action': [],
+            'email_action': [], 'form_validation_action': [], 'prompt_action': [], 'database_action': [],
             'utterances': ['utter_offer_help', 'utter_default', 'utter_please_rephrase']}
 
     def test_delete_non_existing_complex_story(self):
@@ -11945,7 +11945,7 @@ class TestMongoProcessor:
             'http_action': [], 'google_search_action': [], 'pipedrive_leads_action': [], 'kairon_bot_response': [],
             'razorpay_action': [], 'prompt_action': ['gpt_llm_faq'],
             'slot_set_action': [], 'email_action': [], 'form_validation_action': [], 'jira_action': [],
-            'vector_embeddings_db_action': [],
+            'database_action': [],
             'utterances': ['utter_greet',
                            'utter_cheer_up',
                            'utter_did_that_help',
@@ -13666,6 +13666,163 @@ class TestMongoProcessor:
         bot = 'test'
         user = 'testUser'
         processor.delete_content(pytest.content_id, user, bot)
+
+    def test_save_payload_content_with_gpt_feature_disabled(self):
+        processor = MongoProcessor()
+        bot = 'test_bot_payload'
+        user = 'testUser'
+        payload = {
+            "data": "A transformer is an encoder decoder model that uses the attention mechanism. It can take advantage of pluralization and also process a large amount of data at the same time because of its model architecture.",
+            "content_type": "text",
+            "metadata": [{"column_name": "Details", "data_type": "str", "enable_search": True,
+                         "create_embeddings": True}]}
+
+        with pytest.raises(AppException, match="Faq feature is disabled for the bot! Please contact support."):
+            processor.save_payload_content(payload, user, bot)
+
+        settings = BotSettings.objects(bot=bot).get()
+        settings.llm_settings = LLMSettings(enable_faq=True)
+        settings.save()
+
+    def test_save_payload_content_as_text(self):
+        processor = MongoProcessor()
+        bot = 'test_bot_payload'
+        user = 'testUser'
+        payload = {
+            "data": "A transformer is an encoder decoder model that uses the attention mechanism. It can take advantage of pluralization and also process a large amount of data at the same time because of its model architecture.",
+            "content_type": "text",
+            "metadata": [{"column_name": "Details", "data_type": "str", "enable_search": True,
+                         "create_embeddings": True}]}
+        pytest.payload_id = processor.save_payload_content(payload, user, bot)
+        payload_id = '64b0f2e66707e9282a13f6cd'
+        with pytest.raises(AppException, match="Payload data already exists!"):
+            processor.update_payload_content(payload_id, payload, user, bot)
+
+    def test_save_payload_content_metadata_int(self):
+        processor = MongoProcessor()
+        bot = 'test_bot_payload'
+        user = 'testUser'
+        payload = {
+            "data": 100,
+            "content_type": "text",
+            "metadata": [{"column_name": "Number", "data_type": "int", "enable_search": True,
+                         "create_embeddings": True}]}
+        actual = processor.save_payload_content(payload, user, bot)
+        assert actual
+
+    def test_save_payload_content_as_json(self):
+        processor = MongoProcessor()
+        bot = 'test_bot_payload'
+        user = 'testUser'
+        payload = {
+            "data": {
+                "filter": {
+                    "should": [
+                        {"key": "city", "match": {"value": "London"}},
+                        {"key": "color", "match": {"value": "red"}}
+                    ]
+                }
+            },
+            "content_type": "json",
+            "metadata": [{"column_name": "details", "data_type": "str", "enable_search": True,
+                         "create_embeddings": True}]}
+        actual = processor.save_payload_content(payload, user, bot)
+        assert actual
+
+    def test_save_payload_content_column_name_empty(self):
+        processor = MongoProcessor()
+        bot = 'test_bot_payload'
+        user = 'testUser'
+        payload = {
+            "data": 100,
+            "content_type": "text",
+            "metadata": [{"column_name": "", "data_type": "int", "enable_search": True,
+                          "create_embeddings": True}],
+            "bot": bot,
+            "user": user}
+        # metadata = [{"column_name": "", "data_type": "int", "enable_search": True,
+        #                  "create_embeddings": True}]
+        with pytest.raises(ValidationError, match="Column name cannot be empty"):
+            BotContent(**payload).save()
+
+    def test_save_payload_content_data_type_invalid(self):
+        processor = MongoProcessor()
+        bot = 'test_bot_payload'
+        user = 'testUser'
+        payload = {
+            "data": 100,
+            "content_type": "text",
+            "metadata": [{"column_name": "Number", "data_type": "bool", "enable_search": True,
+                         "create_embeddings": True}],
+            "bot": bot,
+            "user": user
+        }
+        with pytest.raises(ValidationError, match="Only str and int data types are supported"):
+            BotContent(**payload).save()
+
+    def test_update_payload_content(self):
+        processor = MongoProcessor()
+        bot = 'test_bot_payload'
+        user = 'testUser'
+        payload = {
+            "data": "A transformer is an encoder decoder model that uses the attention mechanism.",
+            "content_type": "text",
+            "metadata": [{"column_name": "Details", "data_type": "str", "enable_search": True,
+                         "create_embeddings": True}]}
+        processor.update_payload_content(pytest.payload_id, payload, user, bot)
+
+    def test_update_payload_content_not_found(self):
+        processor = MongoProcessor()
+        bot = 'test_bot_payload'
+        user = 'testUser'
+        payload_id = '5349b4ddd2719d08c09890f3'
+        payload = {
+            "data": {
+                "filter": {
+                    "should": [
+                        {"key": "language", "match": {"value": "Hindi"}},
+                    ]
+                }
+            },
+            "content_type": "json",
+            "metadata": [{"column_name": "language", "data_type": "str", "enable_search": True,
+                         "create_embeddings": True}]}
+        with pytest.raises(AppException, match="Payload with given id not found!"):
+            processor.update_payload_content(payload_id, payload, user, bot)
+
+    def test_delete_payload_content(self):
+        processor = MongoProcessor()
+        bot = 'test_bot_payload'
+        user = 'testUser'
+        processor.delete_payload_content(pytest.payload_id, user, bot)
+
+    def test_delete_payload_content_does_not_exists(self):
+        processor = MongoProcessor()
+        bot = 'test_bot_payload'
+        user = 'testUser'
+        with pytest.raises(AppException, match="Payload does not exists!"):
+            processor.delete_payload_content("507f191e050c19729de860ea", user, bot)
+
+    def test_get_payload_content_not_exists(self):
+        processor = MongoProcessor()
+        bot = 'testing'
+        assert list(processor.get_payload_content(bot)) == []
+
+    def test_get_payload_content(self):
+        processor = MongoProcessor()
+        bot = 'test_bot_payload'
+        user = 'testUser'
+        payload = {
+            "data": "LLM is short for Large Language Model, which is a recent innovation in AI and machine learning.",
+            "content_type": "text",
+            "metadata": [{"column_name": "Details", "data_type": "str", "enable_search": True,
+                         "create_embeddings": True}]}
+        pytest.content_id = processor.save_payload_content(payload, user, bot)
+        data = list(processor.get_payload_content(bot))
+        print(data)
+        assert data[0][
+                   'content'] == 100
+        assert data[0]['_id']
 
 
 class TestTrainingDataProcessor:

--- a/tests/unit_test/data_processor/data_processor_test.py
+++ b/tests/unit_test/data_processor/data_processor_test.py
@@ -13740,8 +13740,6 @@ class TestMongoProcessor:
                           "create_embeddings": True}],
             "bot": bot,
             "user": user}
-        # metadata = [{"column_name": "", "data_type": "int", "enable_search": True,
-        #                  "create_embeddings": True}]
         with pytest.raises(ValidationError, match="Column name cannot be empty"):
             BotContent(**payload).save()
 

--- a/tests/unit_test/data_processor/data_processor_test.py
+++ b/tests/unit_test/data_processor/data_processor_test.py
@@ -65,7 +65,7 @@ from kairon.shared.data.data_objects import (TrainingExamples,
                                              TrainingDataGenerator, TrainingDataGeneratorResponse,
                                              TrainingExamplesTrainingDataGenerator, Rules, Configs,
                                              Utterances, BotSettings, ChatClientConfig, LookupTables, Forms,
-                                             SlotMapping, KeyVault, MultiflowStories, BotContent, LLMSettings,
+                                             SlotMapping, KeyVault, MultiflowStories, CognitionData, LLMSettings,
                                              MultiflowStoryEvents, Synonyms,
                                              Lookup
                                              )
@@ -2196,10 +2196,10 @@ class TestMongoProcessor:
         bot = "tests"
         user = "testUser"
         value = "nupurk"
-        BotContent(
+        CognitionData(
             data="Welcome! Are you completely new to programming? If not then we presume you will be looking for information about why and how to get started with Python",
             bot=bot, user=user).save()
-        BotContent(
+        CognitionData(
             data="Java is a high-level, class-based, object-oriented programming language that is designed to have as few implementation dependencies as possible.",
             bot=bot, user=user).save()
         BotSecrets(secret_type=BotSecretType.gpt_key.value, value=value, bot=bot, user=user).save()
@@ -13678,7 +13678,7 @@ class TestMongoProcessor:
                          "create_embeddings": True}]}
 
         with pytest.raises(AppException, match="Faq feature is disabled for the bot! Please contact support."):
-            processor.save_payload_content(payload, user, bot)
+            processor.save_cognition_content(payload, user, bot)
 
         settings = BotSettings.objects(bot=bot).get()
         settings.llm_settings = LLMSettings(enable_faq=True)
@@ -13693,10 +13693,10 @@ class TestMongoProcessor:
             "content_type": "text",
             "metadata": [{"column_name": "Details", "data_type": "str", "enable_search": True,
                          "create_embeddings": True}]}
-        pytest.payload_id = processor.save_payload_content(payload, user, bot)
+        pytest.payload_id = processor.save_cognition_content(payload, user, bot)
         payload_id = '64b0f2e66707e9282a13f6cd'
         with pytest.raises(AppException, match="Payload data already exists!"):
-            processor.update_payload_content(payload_id, payload, user, bot)
+            processor.update_cognition_content(payload_id, payload, user, bot)
 
     def test_save_payload_content_metadata_int(self):
         processor = MongoProcessor()
@@ -13707,7 +13707,7 @@ class TestMongoProcessor:
             "content_type": "text",
             "metadata": [{"column_name": "Number", "data_type": "int", "enable_search": True,
                          "create_embeddings": True}]}
-        actual = processor.save_payload_content(payload, user, bot)
+        actual = processor.save_cognition_content(payload, user, bot)
         assert actual
 
     def test_save_payload_content_as_json(self):
@@ -13726,7 +13726,7 @@ class TestMongoProcessor:
             "content_type": "json",
             "metadata": [{"column_name": "details", "data_type": "str", "enable_search": True,
                          "create_embeddings": True}]}
-        actual = processor.save_payload_content(payload, user, bot)
+        actual = processor.save_cognition_content(payload, user, bot)
         assert actual
 
     def test_save_payload_content_column_name_empty(self):
@@ -13741,7 +13741,7 @@ class TestMongoProcessor:
             "bot": bot,
             "user": user}
         with pytest.raises(ValidationError, match="Column name cannot be empty"):
-            BotContent(**payload).save()
+            CognitionData(**payload).save()
 
     def test_save_payload_content_data_type_invalid(self):
         processor = MongoProcessor()
@@ -13756,7 +13756,7 @@ class TestMongoProcessor:
             "user": user
         }
         with pytest.raises(ValidationError, match="Only str and int data types are supported"):
-            BotContent(**payload).save()
+            CognitionData(**payload).save()
 
     def test_update_payload_content(self):
         processor = MongoProcessor()
@@ -13767,7 +13767,7 @@ class TestMongoProcessor:
             "content_type": "text",
             "metadata": [{"column_name": "Details", "data_type": "str", "enable_search": True,
                          "create_embeddings": True}]}
-        processor.update_payload_content(pytest.payload_id, payload, user, bot)
+        processor.update_cognition_content(pytest.payload_id, payload, user, bot)
 
     def test_update_payload_content_not_found(self):
         processor = MongoProcessor()
@@ -13786,25 +13786,25 @@ class TestMongoProcessor:
             "metadata": [{"column_name": "language", "data_type": "str", "enable_search": True,
                          "create_embeddings": True}]}
         with pytest.raises(AppException, match="Payload with given id not found!"):
-            processor.update_payload_content(payload_id, payload, user, bot)
+            processor.update_cognition_content(payload_id, payload, user, bot)
 
     def test_delete_payload_content(self):
         processor = MongoProcessor()
         bot = 'test_bot_payload'
         user = 'testUser'
-        processor.delete_payload_content(pytest.payload_id, user, bot)
+        processor.delete_cognition_content(pytest.payload_id, user, bot)
 
     def test_delete_payload_content_does_not_exists(self):
         processor = MongoProcessor()
         bot = 'test_bot_payload'
         user = 'testUser'
         with pytest.raises(AppException, match="Payload does not exists!"):
-            processor.delete_payload_content("507f191e050c19729de860ea", user, bot)
+            processor.delete_cognition_content("507f191e050c19729de860ea", user, bot)
 
     def test_get_payload_content_not_exists(self):
         processor = MongoProcessor()
         bot = 'testing'
-        assert list(processor.get_payload_content(bot)) == []
+        assert list(processor.get_cognition_content(bot)) == []
 
     def test_get_payload_content(self):
         processor = MongoProcessor()
@@ -13815,8 +13815,8 @@ class TestMongoProcessor:
             "content_type": "text",
             "metadata": [{"column_name": "Details", "data_type": "str", "enable_search": True,
                          "create_embeddings": True}]}
-        pytest.content_id = processor.save_payload_content(payload, user, bot)
-        data = list(processor.get_payload_content(bot))
+        pytest.content_id = processor.save_cognition_content(payload, user, bot)
+        data = list(processor.get_cognition_content(bot))
         print(data)
         assert data[0][
                    'content'] == 100

--- a/tests/unit_test/data_processor/data_processor_test.py
+++ b/tests/unit_test/data_processor/data_processor_test.py
@@ -13792,14 +13792,14 @@ class TestMongoProcessor:
         processor = MongoProcessor()
         bot = 'test_bot_payload'
         user = 'testUser'
-        processor.delete_cognition_content(pytest.payload_id, user, bot)
+        processor.delete_cognition_content(pytest.payload_id, bot)
 
     def test_delete_payload_content_does_not_exists(self):
         processor = MongoProcessor()
         bot = 'test_bot_payload'
         user = 'testUser'
         with pytest.raises(AppException, match="Payload does not exists!"):
-            processor.delete_cognition_content("507f191e050c19729de860ea", user, bot)
+            processor.delete_cognition_content("507f191e050c19729de860ea", bot)
 
     def test_get_payload_content_not_exists(self):
         processor = MongoProcessor()

--- a/tests/unit_test/llm_test.py
+++ b/tests/unit_test/llm_test.py
@@ -11,7 +11,7 @@ from mongoengine import connect
 from kairon.shared.admin.constants import BotSecretType
 from kairon.shared.admin.data_objects import BotSecrets
 from kairon.shared.data.constant import DEFAULT_SYSTEM_PROMPT
-from kairon.shared.data.data_objects import BotContent, LLMSettings
+from kairon.shared.data.data_objects import CognitionData, LLMSettings
 from kairon.shared.llm.factory import LLMFactory
 from kairon.shared.llm.gpt3 import GPT3FAQEmbedding, LLMBase
 from kairon.shared.utils import Utility
@@ -58,7 +58,7 @@ class TestLLM:
         bot = "test_embed_faq"
         user = "test"
         value = "nupurkhare"
-        test_content = BotContent(
+        test_content = CognitionData(
             data="Welcome! Are you completely new to programming? If not then we presume you will be looking for information about why and how to get started with Python",
             bot=bot, user=user).save()
         secret = BotSecrets(secret_type=BotSecretType.gpt_key.value, value=value, bot=bot, user=user).save()
@@ -127,7 +127,7 @@ class TestLLM:
         bot = "test_embed_faq_text"
         user = "test"
         value = "nupurkhare"
-        test_content = BotContent(
+        test_content = CognitionData(
             data="A large language model refers to a type of artificial intelligence (AI) model that is designed to "
                  "generate and understand human language. It is trained on vast amounts of text data and uses sophisticated "
                  "algorithms to process and generate coherent and contextually relevant responses.",
@@ -207,14 +207,14 @@ class TestLLM:
 
             response = gpt3.train()
 
-            assert response['faq'] == 4
+            assert response['faq'] == 1
 
     @responses.activate
     def test_gpt3_faq_embedding_train_payload_json(self):
         bot = "test_embed_faq_json"
         user = "test"
         value = "nupurkhare"
-        test_content = BotContent(
+        test_content = CognitionData(
             data={
                 "filter": {
                     "should": [
@@ -317,7 +317,7 @@ class TestLLM:
         bot = "test_embed_faq_json_no_metadata"
         user = "test"
         value = "nupurkhare"
-        test_content = BotContent(
+        test_content = CognitionData(
             data={
                 "filter": {
                     "should": [
@@ -422,7 +422,7 @@ class TestLLM:
         bot = "test_embed_faq_not_exists"
         user = "test"
         value = "nupurk"
-        test_content = BotContent(
+        test_content = CognitionData(
             data="Welcome! Are you completely new to programming? If not then we presume you will be looking for information about why and how to get started with Python",
             bot=bot, user=user).save()
         secret = BotSecrets(secret_type=BotSecretType.gpt_key.value, value=value, bot=bot, user=user).save()
@@ -485,7 +485,7 @@ class TestLLM:
                       "time": 0.003612634}
             )
 
-            with pytest.raises(AppException, match="Unable to train FAQ! Contact support"):
+            with pytest.raises(AppException, match="Unable to train faq! contact support"):
                 gpt3.train()
 
     @responses.activate
@@ -493,7 +493,7 @@ class TestLLM:
         bot = "test_embed_faq_payload_upsert_error"
         user = "test"
         value = "nupurk"
-        test_content = BotContent(
+        test_content = CognitionData(
             data={
                 "filter": {
                     "should": [
@@ -597,7 +597,7 @@ class TestLLM:
         bot = "test_embed_faq_predict"
         user = "test"
         value = "knupur"
-        test_content = BotContent(
+        test_content = CognitionData(
             data="Python is a high-level, general-purpose programming language. Its design philosophy emphasizes code readability with the use of significant indentation. Python is dynamically typed and garbage-collected.",
             bot=bot, user=user).save()
         secret = BotSecrets(secret_type=BotSecretType.gpt_key.value, value=value, bot=bot, user=user).save()
@@ -681,7 +681,7 @@ class TestLLM:
     def test_gpt3_faq_embedding_predict_with_values(self):
         embedding = list(np.random.random(GPT3FAQEmbedding.__embedding__))
 
-        test_content = BotContent(
+        test_content = CognitionData(
             data="Python is a high-level, general-purpose programming language. Its design philosophy emphasizes code readability with the use of significant indentation. Python is dynamically typed and garbage-collected.",
             bot="test_embed_faq_predict", user="test").save()
 
@@ -776,7 +776,7 @@ class TestLLM:
     def test_gpt3_faq_embedding_predict_completion_connection_error(self, mock_embedding, mock_completion):
         embedding = list(np.random.random(GPT3FAQEmbedding.__embedding__))
 
-        test_content = BotContent(
+        test_content = CognitionData(
             data="Python is a high-level, general-purpose programming language. Its design philosophy emphasizes code readability with the use of significant indentation. Python is dynamically typed and garbage-collected.",
             bot="test_embed_faq_predict", user="test").save()
 
@@ -858,7 +858,7 @@ Instructions on how to use Similarity Prompt: Answer according to this context.
     def test_gpt3_faq_embedding_predict_exact_match(self, mock_embedding):
         embedding = list(np.random.random(GPT3FAQEmbedding.__embedding__))
 
-        test_content = BotContent(
+        test_content = CognitionData(
             data="Python is a high-level, general-purpose programming language. Its design philosophy emphasizes code readability with the use of significant indentation. Python is dynamically typed and garbage-collected.",
             bot="test_embed_faq_predict", user="test").save()
 
@@ -900,7 +900,7 @@ Instructions on how to use Similarity Prompt: Answer according to this context.
 
         embedding = list(np.random.random(GPT3FAQEmbedding.__embedding__))
 
-        test_content = BotContent(
+        test_content = CognitionData(
             data="Python is a high-level, general-purpose programming language. Its design philosophy emphasizes code readability with the use of significant indentation. Python is dynamically typed and garbage-collected.",
             bot="test_embed_faq_predict", user="test").save()
 
@@ -944,7 +944,7 @@ Instructions on how to use Similarity Prompt: Answer according to this context.
     def test_gpt3_faq_embedding_predict_completion_connection_error_query_not_cached(self, mock_embedding, mock_completion):
         embedding = list(np.random.random(GPT3FAQEmbedding.__embedding__))
 
-        test_content = BotContent(
+        test_content = CognitionData(
             data="Python is a high-level, general-purpose programming language. Its design philosophy emphasizes code readability with the use of significant indentation. Python is dynamically typed and garbage-collected.",
             bot="test_embed_faq_predict", user="test").save()
 
@@ -1004,7 +1004,7 @@ Instructions on how to use Similarity Prompt: Answer according to this context.
 
         bot = "test_embed_faq_predict"
         user = "test"
-        test_content = BotContent(
+        test_content = CognitionData(
             data="Python is a high-level, general-purpose programming language. Its design philosophy emphasizes code readability with the use of significant indentation. Python is dynamically typed and garbage-collected.",
             bot=bot, user=user).save()
 
@@ -1085,7 +1085,7 @@ Instructions on how to use Similarity Prompt: Answer according to this context.
 
         bot = "test_embed_faq_predict"
         user = "test"
-        test_content = BotContent(
+        test_content = CognitionData(
             data="Python is a high-level, general-purpose programming language. Its design philosophy emphasizes code readability with the use of significant indentation. Python is dynamically typed and garbage-collected.",
             bot=bot, user=user).save()
 

--- a/tests/unit_test/llm_test.py
+++ b/tests/unit_test/llm_test.py
@@ -1,3 +1,4 @@
+import json
 import os
 from urllib.parse import urljoin
 
@@ -121,6 +122,297 @@ class TestLLM:
             response = gpt3.train()
             assert response['faq'] == 1
 
+    @responses.activate
+    def test_gpt3_faq_embedding_train_payload_text(self):
+        bot = "test_embed_faq_text"
+        user = "test"
+        value = "nupurkhare"
+        test_content = BotContent(
+            data="A large language model refers to a type of artificial intelligence (AI) model that is designed to "
+                 "generate and understand human language. It is trained on vast amounts of text data and uses sophisticated "
+                 "algorithms to process and generate coherent and contextually relevant responses.",
+            content_type="text",
+            metadata=[{"column_name": "Details", "data_type": "str", "enable_search": True, "create_embeddings": True},
+                      {"column_name": "LLM", "data_type": "str", "enable_search": False, "create_embeddings": True},
+                      {"column_name": "encoder", "data_type": "str", "enable_search": True, "create_embeddings": False}],
+            bot=bot, user=user).save()
+        secret = BotSecrets(secret_type=BotSecretType.gpt_key.value, value=value, bot=bot, user=user).save()
+
+        embedding = list(np.random.random(GPT3FAQEmbedding.__embedding__))
+        request_header = {"Authorization": "Bearer nupurkhare"}
+
+        responses.add(
+            url="https://api.openai.com/v1/embeddings",
+            method="POST",
+            status=200,
+            match=[
+                responses.matchers.json_params_matcher({"model": "text-embedding-ada-002", "input": test_content.data}),
+                responses.matchers.header_matcher(request_header)],
+            json={'data': [{'embedding': embedding}]}
+        )
+
+        with mock.patch.dict(Utility.environment, {'llm': {"faq": "GPT3_FAQ_EMBED", 'api_key': secret}}):
+            gpt3 = GPT3FAQEmbedding(test_content.bot, LLMSettings(provider="openai").to_mongo().to_dict())
+
+            responses.add(
+                "DELETE",
+                urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.suffix}"),
+                adding_headers={}
+            )
+
+            responses.add(
+                "DELETE",
+                urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.cached_resp_suffix}"),
+                adding_headers={}
+            )
+
+            responses.add(
+                url=urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.suffix}"),
+                method="PUT",
+                adding_headers={},
+                match=[responses.matchers.json_params_matcher(
+                    {'name': gpt3.bot + gpt3.suffix, 'vectors': gpt3.vector_config})],
+                status=200
+            )
+
+            responses.add(
+                url=urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.cached_resp_suffix}"),
+                method="PUT",
+                adding_headers={},
+                match=[responses.matchers.json_params_matcher(
+                    {'name': gpt3.bot + gpt3.cached_resp_suffix, 'vectors': gpt3.vector_config})],
+                status=200
+            )
+
+            responses.add(
+                url=urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.suffix}/points"),
+                method="PUT",
+                adding_headers={},
+                match=[responses.matchers.json_params_matcher({'points': [{'id': test_content.vector_id,
+                                                                           'vector': embedding,
+                                                                           'payload': {'content': test_content.data}
+                                                                           }]})],
+                json={"result": {"operation_id": 0, "status": "acknowledged"}, "status": "ok", "time": 0.003612634}
+            )
+
+            responses.add(
+                url=urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.suffix}/points"),
+                method="PUT",
+                adding_headers={},
+                match=[responses.matchers.json_params_matcher({'points': [{'id': test_content.vector_id,
+                                                                           'payload': {'content': test_content.data}
+                                                                           }]})],
+                json={"result": {"operation_id": 0, "status": "acknowledged"}, "status": "ok", "time": 0.003612634}
+            )
+
+            response = gpt3.train()
+
+            assert response['faq'] == 4
+
+    @responses.activate
+    def test_gpt3_faq_embedding_train_payload_json(self):
+        bot = "test_embed_faq_json"
+        user = "test"
+        value = "nupurkhare"
+        test_content = BotContent(
+            data={
+                "filter": {
+                    "should": [
+                        {"key": "city", "match": {"value": "London"}},
+                        {"key": "color", "match": {"value": "red"}}
+                    ]
+                }
+            },
+            content_type="json",
+            metadata=[{"column_name": "Details", "data_type": "str", "enable_search": True, "create_embeddings": True},
+                      {"column_name": "LLM", "data_type": "str", "enable_search": False, "create_embeddings": True},
+                      {"column_name": "encoder", "data_type": "str", "enable_search": True,
+                       "create_embeddings": False}],
+            bot=bot, user=user).save()
+        secret = BotSecrets(secret_type=BotSecretType.gpt_key.value, value=value, bot=bot, user=user).save()
+
+        embedding = list(np.random.random(GPT3FAQEmbedding.__embedding__))
+        request_header = {"Authorization": "Bearer nupurkhare"}
+
+        responses.add(
+            url="https://api.openai.com/v1/embeddings",
+            method="POST",
+            status=200,
+            match=[
+                responses.matchers.json_params_matcher({"model": "text-embedding-ada-002", "input": json.dumps(test_content.data)}),
+                responses.matchers.header_matcher(request_header)],
+            json={'data': [{'embedding': embedding}]}
+        )
+
+        responses.add(
+            url="https://api.openai.com/v1/embeddings",
+            method="POST",
+            status=200,
+            match=[
+                responses.matchers.json_params_matcher({"model": "text-embedding-ada-002", "input": test_content.data}),
+                responses.matchers.header_matcher(request_header)],
+            json={'data': [{'embedding': embedding}]}
+        )
+
+        with mock.patch.dict(Utility.environment, {'llm': {"faq": "GPT3_FAQ_EMBED", 'api_key': secret}}):
+            gpt3 = GPT3FAQEmbedding(test_content.bot, LLMSettings(provider="openai").to_mongo().to_dict())
+
+            responses.add(
+                "DELETE",
+                urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.suffix}"),
+                adding_headers={}
+            )
+
+            responses.add(
+                "DELETE",
+                urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.cached_resp_suffix}"),
+                adding_headers={}
+            )
+
+            responses.add(
+                url=urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.suffix}"),
+                method="PUT",
+                adding_headers={},
+                match=[responses.matchers.json_params_matcher(
+                    {'name': gpt3.bot + gpt3.suffix, 'vectors': gpt3.vector_config})],
+                status=200
+            )
+
+            responses.add(
+                url=urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.cached_resp_suffix}"),
+                method="PUT",
+                adding_headers={},
+                match=[responses.matchers.json_params_matcher(
+                    {'name': gpt3.bot + gpt3.cached_resp_suffix, 'vectors': gpt3.vector_config})],
+                status=200
+            )
+
+            responses.add(
+                url=urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.suffix}/points"),
+                method="PUT",
+                adding_headers={},
+                match=[responses.matchers.json_params_matcher({'points': [{'id': test_content.vector_id,
+                                                                           'vector': embedding,
+                                                                           'payload': {'content': test_content.data}
+                                                                           }]})],
+                json={"result": {"operation_id": 0, "status": "acknowledged"}, "status": "ok", "time": 0.003612634}
+            )
+
+            responses.add(
+                url=urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.suffix}/points"),
+                method="PUT",
+                adding_headers={},
+                match=[responses.matchers.json_params_matcher({'points': [{'id': test_content.vector_id,
+                                                                           'payload': {'content': test_content.data}
+                                                                           }]})],
+                json={"result": {"operation_id": 0, "status": "acknowledged"}, "status": "ok", "time": 0.003612634}
+            )
+
+            response = gpt3.train()
+
+            assert response['faq'] == 4
+
+    @responses.activate
+    def test_gpt3_faq_embedding_train_payload_json_no_metadata(self):
+        bot = "test_embed_faq_json_no_metadata"
+        user = "test"
+        value = "nupurkhare"
+        test_content = BotContent(
+            data={
+                "filter": {
+                    "should": [
+                        {"key": "city", "match": {"value": "London"}},
+                        {"key": "color", "match": {"value": "red"}}
+                    ]
+                }
+            },
+            content_type="json",
+            metadata=[],
+            bot=bot, user=user).save()
+        secret = BotSecrets(secret_type=BotSecretType.gpt_key.value, value=value, bot=bot, user=user).save()
+
+        embedding = list(np.random.random(GPT3FAQEmbedding.__embedding__))
+        request_header = {"Authorization": "Bearer nupurkhare"}
+
+        responses.add(
+            url="https://api.openai.com/v1/embeddings",
+            method="POST",
+            status=200,
+            match=[
+                responses.matchers.json_params_matcher(
+                    {"model": "text-embedding-ada-002", "input": json.dumps(test_content.data)}),
+                responses.matchers.header_matcher(request_header)],
+            json={'data': [{'embedding': embedding}]}
+        )
+
+        responses.add(
+            url="https://api.openai.com/v1/embeddings",
+            method="POST",
+            status=200,
+            match=[
+                responses.matchers.json_params_matcher({"model": "text-embedding-ada-002", "input": test_content.data}),
+                responses.matchers.header_matcher(request_header)],
+            json={'data': [{'embedding': embedding}]}
+        )
+
+        with mock.patch.dict(Utility.environment, {'llm': {"faq": "GPT3_FAQ_EMBED", 'api_key': secret}}):
+            gpt3 = GPT3FAQEmbedding(test_content.bot, LLMSettings(provider="openai").to_mongo().to_dict())
+
+            responses.add(
+                "DELETE",
+                urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.suffix}"),
+                adding_headers={}
+            )
+
+            responses.add(
+                "DELETE",
+                urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.cached_resp_suffix}"),
+                adding_headers={}
+            )
+
+            responses.add(
+                url=urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.suffix}"),
+                method="PUT",
+                adding_headers={},
+                match=[responses.matchers.json_params_matcher(
+                    {'name': gpt3.bot + gpt3.suffix, 'vectors': gpt3.vector_config})],
+                status=200
+            )
+
+            responses.add(
+                url=urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.cached_resp_suffix}"),
+                method="PUT",
+                adding_headers={},
+                match=[responses.matchers.json_params_matcher(
+                    {'name': gpt3.bot + gpt3.cached_resp_suffix, 'vectors': gpt3.vector_config})],
+                status=200
+            )
+
+            responses.add(
+                url=urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.suffix}/points"),
+                method="PUT",
+                adding_headers={},
+                match=[responses.matchers.json_params_matcher({'points': [{'id': test_content.vector_id,
+                                                                           'vector': embedding,
+                                                                           'payload': {'content': test_content.data}
+                                                                           }]})],
+                json={"result": {"operation_id": 0, "status": "acknowledged"}, "status": "ok", "time": 0.003612634}
+            )
+
+            responses.add(
+                url=urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.suffix}/points"),
+                method="PUT",
+                adding_headers={},
+                match=[responses.matchers.json_params_matcher({'points': [{'id': test_content.vector_id,
+                                                                           'payload': {'content': test_content.data}
+                                                                           }]})],
+                json={"result": {"operation_id": 0, "status": "acknowledged"}, "status": "ok", "time": 0.003612634}
+            )
+
+            response = gpt3.train()
+
+            assert response['faq'] == 1
+
     def test_gpt3_faq_embedding_train_failure(self):
         with pytest.raises(AppException, match=f"Bot secret '{BotSecretType.gpt_key.value}' not configured!"):
             GPT3FAQEmbedding('test_failure', LLMSettings(provider="openai").to_mongo().to_dict())
@@ -193,7 +485,109 @@ class TestLLM:
                       "time": 0.003612634}
             )
 
-            with pytest.raises(AppException, match="Unable to train faq! contact support"):
+            with pytest.raises(AppException, match="Unable to train FAQ! Contact support"):
+                gpt3.train()
+
+    @responses.activate
+    def test_gpt3_faq_embedding_train_payload_upsert_error_json(self):
+        bot = "test_embed_faq_payload_upsert_error"
+        user = "test"
+        value = "nupurk"
+        test_content = BotContent(
+            data={
+                "filter": {
+                    "should": [
+                        {"key": "city", "match": {"value": "London"}},
+                        {"key": "color", "match": {"value": "red"}}
+                    ]
+                }
+            },
+            content_type="json",
+            metadata=[],
+            bot=bot, user=user).save()
+        secret = BotSecrets(secret_type=BotSecretType.gpt_key.value, value=value, bot=bot, user=user).save()
+
+        embedding = list(np.random.random(GPT3FAQEmbedding.__embedding__))
+
+        request_header = {"Authorization": "Bearer nupurk"}
+
+        responses.add(
+            url="https://api.openai.com/v1/embeddings",
+            method="POST",
+            status=200,
+            match=[
+                responses.matchers.json_params_matcher(
+                    {"model": "text-embedding-ada-002", "input": json.dumps(test_content.data)}),
+                responses.matchers.header_matcher(request_header)],
+            json={'data': [{'embedding': embedding}]}
+        )
+
+        responses.add(
+            url="https://api.openai.com/v1/embeddings",
+            method="POST",
+            status=200,
+            match=[
+                responses.matchers.json_params_matcher({"model": "text-embedding-ada-002", "input": test_content.data}),
+                responses.matchers.header_matcher(request_header)],
+            json={'data': [{'embedding': embedding}]}
+        )
+
+        with mock.patch.dict(Utility.environment, {'llm': {"faq": "GPT3_FAQ_EMBED", 'api_key': secret}}):
+            gpt3 = GPT3FAQEmbedding(test_content.bot, LLMSettings(provider="openai").to_mongo().to_dict())
+
+            responses.add(
+                "DELETE",
+                urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.suffix}"),
+                adding_headers={}
+            )
+
+            responses.add(
+                "DELETE",
+                urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.cached_resp_suffix}"),
+                adding_headers={}
+            )
+
+            responses.add(
+                url=urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.suffix}"),
+                method="PUT",
+                adding_headers={},
+                match=[responses.matchers.json_params_matcher(
+                    {'name': gpt3.bot + gpt3.suffix, 'vectors': gpt3.vector_config})],
+                status=200
+            )
+
+            responses.add(
+                url=urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.cached_resp_suffix}"),
+                method="PUT",
+                adding_headers={},
+                match=[responses.matchers.json_params_matcher(
+                    {'name': gpt3.bot + gpt3.cached_resp_suffix, 'vectors': gpt3.vector_config})],
+                status=200
+            )
+
+            responses.add(
+                url=urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.suffix}/points"),
+                method="PUT",
+                adding_headers={},
+                match=[responses.matchers.json_params_matcher({'points': [{'id': test_content.vector_id,
+                                                                           'vector': embedding,
+                                                                           'payload': {'content': test_content.data}
+                                                                           }]})],
+                json={"result": None,
+                      'status': {'error': 'Json deserialize error: missing field `vectors` at line 1 column 34779'},
+                      "time": 0.003612634}
+            )
+
+            responses.add(
+                url=urljoin(Utility.environment['vector']['db'], f"/collections/{gpt3.bot}{gpt3.suffix}/points"),
+                method="PUT",
+                adding_headers={},
+                match=[responses.matchers.json_params_matcher({'points': [{'id': test_content.vector_id,
+                                                                           'payload': {'content': test_content.data}
+                                                                           }]})],
+                json={"result": {"operation_id": 0, "status": "acknowledged"}, "status": "ok", "time": 0.003612634}
+            )
+            with pytest.raises(AppException, match="Unable to train FAQ! Contact support"):
                 gpt3.train()
 
     @responses.activate


### PR DESCRIPTION
1. Written API to add, delete, update and get payload.
2. Added the provision that embeddings for the payload should be created at the time of training.
3. Added unit and integration test cases for the same.
4. Fixed test cases.