### PR TITLE
Login limit on wrong password.

### DIFF
--- a/kairon/shared/account/activity_log.py
+++ b/kairon/shared/account/activity_log.py
@@ -94,7 +94,7 @@ class UserActivityLogger:
         ).order_by("timestamp"))
         if logins_within_cutoff >= login_request_limit:
             raise AppException(f'Account frozen due to too many unsuccessful login attempts. '
-                               f'Please come back in {str(timedelta(seconds=(datetime.utcnow() - first_login_within_cutoff[0].timestamp).seconds))} minutes!')
+                               f'Please come back in {str(timedelta(seconds=(datetime.utcnow() - first_login_within_cutoff[0].timestamp).seconds))}')
 
     @staticmethod
     def is_token_alread_used(uuid_value, email):

--- a/kairon/shared/account/activity_log.py
+++ b/kairon/shared/account/activity_log.py
@@ -87,10 +87,10 @@ class UserActivityLogger:
         login_request_limit = Utility.environment['user']['login_limit']
         cutoff_time = datetime.utcnow() - timedelta(minutes=login_cooldown_period)
         logins_within_cutoff = AuditLogData.objects(
-            user=email, action=AuditlogActions.ACTIVITY.value, entity=UserActivityType.login.value, timestamp__gte=cutoff_time
+            user=email, action=AuditlogActions.ACTIVITY.value, entity=UserActivityType.invalid_login.value, timestamp__gte=cutoff_time
         ).count()
         first_login_within_cutoff = list(AuditLogData.objects(
-            user=email, action=AuditlogActions.ACTIVITY.value, entity=UserActivityType.login.value, timestamp__gte=cutoff_time
+            user=email, action=AuditlogActions.ACTIVITY.value, entity=UserActivityType.invalid_login.value, timestamp__gte=cutoff_time
         ).order_by("timestamp"))
         if logins_within_cutoff >= login_request_limit:
             raise AppException(f'Only {login_request_limit} logins are allowed within {login_cooldown_period} minutes. '

--- a/kairon/shared/account/activity_log.py
+++ b/kairon/shared/account/activity_log.py
@@ -93,7 +93,7 @@ class UserActivityLogger:
             user=email, action=AuditlogActions.ACTIVITY.value, entity=UserActivityType.invalid_login.value, timestamp__gte=cutoff_time
         ).order_by("timestamp"))
         if logins_within_cutoff >= login_request_limit:
-            raise AppException(f'Only {login_request_limit} logins are allowed within {login_cooldown_period} minutes. '
+            raise AppException(f'Account frozen due to too many unsuccessful login attempts. '
                                f'Please come back in {str(timedelta(seconds=(datetime.utcnow() - first_login_within_cutoff[0].timestamp).seconds))} minutes!')
 
     @staticmethod

--- a/kairon/shared/auth.py
+++ b/kairon/shared/auth.py
@@ -155,9 +155,9 @@ class Authentication:
 
     @staticmethod
     def __authenticate_user(username: str, password: str):
+        UserActivityLogger.is_login_within_cooldown_period(username)
         user = AccountProcessor.get_user_details(username, is_login_request=True)
         if not user or not Utility.verify_password(password, user["password"]):
-            UserActivityLogger.is_login_within_cooldown_period(username)
             data = {"username": username}
             message = ["Incorrect username or password"]
             UserActivityLogger.add_log(a_type=UserActivityType.invalid_login.value, account=user["account"], email=username.lower(), message=message, data=data)

--- a/kairon/shared/auth.py
+++ b/kairon/shared/auth.py
@@ -157,9 +157,10 @@ class Authentication:
     def __authenticate_user(username: str, password: str):
         user = AccountProcessor.get_user_details(username, is_login_request=True)
         if not user or not Utility.verify_password(password, user["password"]):
+            UserActivityLogger.is_login_within_cooldown_period(username)
             data = {"username": username}
             message = ["Incorrect username or password"]
-            UserActivityLogger.add_log(a_type=UserActivityType.invalid_login.value, account=user["account"], message=message, data=data)
+            UserActivityLogger.add_log(a_type=UserActivityType.invalid_login.value, account=user["account"], email=username.lower(), message=message, data=data)
             return False
         return user
 
@@ -185,7 +186,6 @@ class Authentication:
     def generate_login_tokens(user: dict, is_login: bool):
         username = user["email"]
         account = user["account"]
-        UserActivityLogger.is_login_within_cooldown_period(user.get('email'))
         access_token = Authentication.create_access_token(data={"sub": username, "account": account})
         claims = Utility.decode_limited_access_token(access_token)
         access_token_iat = datetime.fromtimestamp(claims['iat'])

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -558,6 +558,7 @@ def test_api_wrong_password():
     assert not actual["success"]
     assert actual["message"] == "Incorrect username or password"
     value = list(AuditLogData.objects(user="integration@demo.ai", action='activity', entity='invalid_login'))
+    print(value)
     assert value[0]["entity"] == "invalid_login"
     assert value[0]["timestamp"]
     assert len(value) == 1
@@ -611,12 +612,7 @@ def test_api_login_with_recaptcha_failed(monkeypatch):
         assert actual == {'success': False, 'message': 'recaptcha_response is required', 'data': None, 'error_code': 422}
 
 
-@mock.patch('kairon.shared.account.activity_log.UserActivityLogger.is_login_within_cooldown_period', autospec=True)
-def test_api_login(mock_password_reset):
-    def _password_reset(*args, **kwargs):
-        return
-
-    mock_password_reset.return_value = _password_reset
+def test_api_login():
     email = "integration@demo.ai"
     response = client.post(
         "/api/auth/login",
@@ -5550,12 +5546,7 @@ def test_add_member_as_owner(monkeypatch):
     assert not response['success']
 
 
-@mock.patch('kairon.shared.account.activity_log.UserActivityLogger.is_login_within_cooldown_period', autospec=True)
-def test_list_bot_invites(mock_password_reset):
-    def _password_reset(*args, **kwargs):
-        return
-
-    mock_password_reset.return_value = _password_reset
+def test_list_bot_invites():
     response = client.post(
         "/api/auth/login",
         data={"username": "integration@demo.ai", "password": "Welcome@10"},
@@ -5573,9 +5564,21 @@ def test_list_bot_invites(mock_password_reset):
 
 
 def test_login_limit_exceeded():
+    response_one = client.post(
+        "/api/auth/login",
+        data={"username": "integration@demo.ai", "password": "Welcome@3010"},
+    ).json()
+    response_two = client.post(
+        "/api/auth/login",
+        data={"username": "integration@demo.ai", "password": "Welcome@3010"},
+    ).json()
+    response_three = client.post(
+        "/api/auth/login",
+        data={"username": "integration@demo.ai", "password": "Welcome@3010"},
+    ).json()
     response = client.post(
         "/api/auth/login",
-        data={"username": "integration@demo.ai", "password": "Welcome@10"},
+        data={"username": "integration@demo.ai", "password": "Welcome@3010"},
     ).json()
     print(response)
     assert not response['success']
@@ -5630,12 +5633,7 @@ def test_accept_bot_invite(monkeypatch):
     assert response['success']
 
 
-@mock.patch('kairon.shared.account.activity_log.UserActivityLogger.is_login_within_cooldown_period', autospec=True)
-def test_accept_bot_invite_logged_in_user_with_email_enabled(mock_password_reset, monkeypatch):
-    def _password_reset(*args, **kwargs):
-        return
-
-    mock_password_reset.return_value = _password_reset
+def test_accept_bot_invite_logged_in_user_with_email_enabled(monkeypatch):
     response = client.post(
         "/api/auth/login",
         data={"username": "integrationtest@demo.ai", "password": "Welcome@10"},
@@ -5666,12 +5664,7 @@ def test_accept_bot_invite_logged_in_user_with_email_enabled(mock_password_reset
     assert response['success']
 
 
-@mock.patch('kairon.shared.account.activity_log.UserActivityLogger.is_login_within_cooldown_period', autospec=True)
-def test_accept_bot_invite_logged_in_user(mock_password_reset):
-    def _password_reset(*args, **kwargs):
-        return
-
-    mock_password_reset.return_value = _password_reset
+def test_accept_bot_invite_logged_in_user():
     response = client.post(
         "/api/auth/login",
         data={"username": "integration2@demo.ai", "password": "Welcome@10"},
@@ -6151,12 +6144,7 @@ def test_delete_bot():
     assert response['success']
 
 
-@mock.patch('kairon.shared.account.activity_log.UserActivityLogger.is_login_within_cooldown_period', autospec=True)
-def test_login_for_verified(mock_password_reset):
-    def _password_reset(*args, **kwargs):
-        return
-
-    mock_password_reset.return_value = _password_reset
+def test_login_for_verified():
     Utility.email_conf["email"]["enable"] = True
     response = client.post(
         "/api/auth/login",
@@ -16021,12 +16009,7 @@ def test_get_auditlog_for_bot():
     assert counter.get(AuditlogActions.UPDATE.value) > 5
 
 
-@mock.patch('kairon.shared.account.activity_log.UserActivityLogger.is_login_within_cooldown_period', autospec=True)
-def test_get_auditlog_for_user_2(mock_password_reset):
-    def _password_reset(*args, **kwargs):
-        return
-
-    mock_password_reset.return_value = _password_reset
+def test_get_auditlog_for_user_2():
     email = "integration@demo.ai"
     response = client.post(
         "/api/auth/login",
@@ -16439,12 +16422,7 @@ def test_idp_provider_fields():
 
 
 @responses.activate
-@mock.patch('kairon.shared.account.activity_log.UserActivityLogger.is_login_within_cooldown_period', autospec=True)
-def test_add_organization(mock_password_reset):
-    def _password_reset(*args, **kwargs):
-        return
-
-    mock_password_reset.return_value = _password_reset
+def test_add_organization():
     email = "integration1234567890@demo.ai"
     response = client.post(
         "/api/auth/login",
@@ -16462,12 +16440,7 @@ def test_add_organization(mock_password_reset):
 
 
 @responses.activate
-@mock.patch('kairon.shared.account.activity_log.UserActivityLogger.is_login_within_cooldown_period', autospec=True)
-def test_get_organization(mock_password_reset):
-    def _password_reset(*args, **kwargs):
-        return
-
-    mock_password_reset.return_value = _password_reset
+def test_get_organization():
     email = "integration1234567890@demo.ai"
     response = client.post(
         "/api/auth/login",
@@ -16485,12 +16458,7 @@ def test_get_organization(mock_password_reset):
 
 
 @responses.activate
-@mock.patch('kairon.shared.account.activity_log.UserActivityLogger.is_login_within_cooldown_period', autospec=True)
-def test_update_organization(mock_password_reset):
-    def _password_reset(*args, **kwargs):
-        return
-
-    mock_password_reset.return_value = _password_reset
+def test_update_organization():
     email = "integration1234567890@demo.ai"
     response = client.post(
         "/api/auth/login",
@@ -16507,12 +16475,7 @@ def test_update_organization(mock_password_reset):
 
 
 @responses.activate
-@mock.patch('kairon.shared.account.activity_log.UserActivityLogger.is_login_within_cooldown_period', autospec=True)
-def test_get_organization_after_update(mock_password_reset):
-    def _password_reset(*args, **kwargs):
-        return
-
-    mock_password_reset.return_value = _password_reset
+def test_get_organization_after_update():
     email = "integration1234567890@demo.ai"
     response = client.post(
         "/api/auth/login",
@@ -16530,12 +16493,7 @@ def test_get_organization_after_update(mock_password_reset):
 
 
 @responses.activate
-@mock.patch('kairon.shared.account.activity_log.UserActivityLogger.is_login_within_cooldown_period', autospec=True)
-def test_delete_organization(mock_password_reset, monkeypatch):
-    def _password_reset(*args, **kwargs):
-        return
-
-    mock_password_reset.return_value = _password_reset
+def test_delete_organization(monkeypatch):
     def _delete_idp(*args, **kwargs):
         return
 
@@ -16565,12 +16523,7 @@ def test_get_model_testing_logs_accuracy():
     assert response["error_code"] == 0
 
 
-@mock.patch('kairon.shared.account.activity_log.UserActivityLogger.is_login_within_cooldown_period', autospec=True)
-def test_delete_account(mock_password_reset):
-    def _password_reset(*args, **kwargs):
-        return
-
-    mock_password_reset.return_value = _password_reset
+def test_delete_account():
     response_log = client.post(
         "/api/auth/login",
         data={"username": "integration@demo.ai", "password": "Welcome@10"},
@@ -16680,12 +16633,7 @@ def test_overwrite_password_for_matching_passwords(monkeypatch):
     assert actual['data'] is None
 
 
-@mock.patch('kairon.shared.account.activity_log.UserActivityLogger.is_login_within_cooldown_period', autospec=True)
-def test_login_new_password(mock_password_reset):
-    def _password_reset(*args, **kwargs):
-        return
-
-    mock_password_reset.return_value = _password_reset
+def test_login_new_password():
     response = client.post(
         "/api/auth/login",
         data={"username": "integ1@gmail.com", "password": "Welcome@20"},
@@ -16698,12 +16646,7 @@ def test_login_new_password(mock_password_reset):
     pytest.token_type = actual["data"]["token_type"]
 
 
-@mock.patch('kairon.shared.account.activity_log.UserActivityLogger.is_login_within_cooldown_period', autospec=True)
-def test_login_old_password(mock_password_reset):
-    def _password_reset(*args, **kwargs):
-        return
-
-    mock_password_reset.return_value = _password_reset
+def test_login_old_password():
     response = client.post(
         "/api/auth/login",
         data={"username": "integ1@gmail.com", "password": "Welcome@10"},

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -5582,7 +5582,7 @@ def test_login_limit_exceeded():
     ).json()
     print(response)
     assert not response['success']
-    assert response['message'].__contains__("Only 3 logins are allowed within 120 minutes.")
+    assert response['message'].__contains__("Account frozen due to too many unsuccessful login attempts.")
     assert response['data'] is None
     assert response['error_code'] == 422
 
@@ -16009,7 +16009,12 @@ def test_get_auditlog_for_bot():
     assert counter.get(AuditlogActions.UPDATE.value) > 5
 
 
-def test_get_auditlog_for_user_2():
+@mock.patch('kairon.shared.account.activity_log.UserActivityLogger.is_login_within_cooldown_period', autospec=True)
+def test_get_auditlog_for_user_2(mock_password_reset):
+    def _password_reset(*args, **kwargs):
+        return
+
+    mock_password_reset.return_value = _password_reset
     email = "integration@demo.ai"
     response = client.post(
         "/api/auth/login",
@@ -16523,7 +16528,12 @@ def test_get_model_testing_logs_accuracy():
     assert response["error_code"] == 0
 
 
-def test_delete_account():
+@mock.patch('kairon.shared.account.activity_log.UserActivityLogger.is_login_within_cooldown_period', autospec=True)
+def test_delete_account(mock_password_reset):
+    def _password_reset(*args, **kwargs):
+        return
+
+    mock_password_reset.return_value = _password_reset
     response_log = client.post(
         "/api/auth/login",
         data={"username": "integration@demo.ai", "password": "Welcome@10"},

--- a/tests/unit_test/api/api_processor_test.py
+++ b/tests/unit_test/api/api_processor_test.py
@@ -1540,7 +1540,7 @@ class TestAccountProcessor:
             Authentication.authenticate(username, password)
         with pytest.raises(HTTPException):
             Authentication.authenticate(username, password)
-        with pytest.raises(AppException, match='Only 3 logins are allowed within 120 minutes. '
+        with pytest.raises(AppException, match='Account frozen due to too many unsuccessful login attempts. '
                                                f'Please come back in *'):
             Authentication.authenticate(username, password)
 

--- a/tests/unit_test/api/api_processor_test.py
+++ b/tests/unit_test/api/api_processor_test.py
@@ -1533,12 +1533,16 @@ class TestAccountProcessor:
 
     def test_authenticate_method_login_within_cooldown_period(self):
         username = "nupur.khare@digite.com"
-        password = "Welcome@15"
-        Authentication.authenticate(username, password)
-        user = AccountProcessor.get_user(username)
+        password = "HelloWorld"
+        with pytest.raises(HTTPException):
+            Authentication.authenticate(username, password)
+        with pytest.raises(HTTPException):
+            Authentication.authenticate(username, password)
+        with pytest.raises(HTTPException):
+            Authentication.authenticate(username, password)
         with pytest.raises(AppException, match='Only 3 logins are allowed within 120 minutes. '
                                                f'Please come back in *'):
-            Authentication.generate_login_tokens(user, True)
+            Authentication.authenticate(username, password)
 
     def test_generate_integration_token_name_exists(self, monkeypatch):
         bot = 'test'


### PR DESCRIPTION
1. Fixed VAPT security issue - Login limit to 3 if the password is wrong.
2. Fixed test cases.