### PR TITLE
Campaign analytics api

### DIFF
--- a/kairon/api/app/routers/bot/channels.py
+++ b/kairon/api/app/routers/bot/channels.py
@@ -11,7 +11,7 @@ from kairon.shared.channels.whatsapp.bsp.factory import BusinessServiceProviderF
 from kairon.shared.chat.broadcast.processor import MessageBroadcastProcessor
 from kairon.shared.chat.models import ChannelRequest, MessageBroadcastRequest
 from kairon.shared.chat.processor import ChatDataProcessor
-from kairon.shared.constants import TESTER_ACCESS, DESIGNER_ACCESS, WhatsappBSPTypes, EventRequestType
+from kairon.shared.constants import TESTER_ACCESS, DESIGNER_ACCESS, WhatsappBSPTypes, EventRequestType, ChannelTypes
 from kairon.shared.data.processor import MongoProcessor
 from kairon.shared.models import User
 
@@ -237,15 +237,12 @@ async def retrieve_scheduled_message_broadcast_logs(
     return Response(data={"logs": logs, "total_count": total_count})
 
 
-@router.get("/whatsapp/logs", response_model=Response)
-async def get_channel_logs_count(
+@router.get("/{channel_type}/metrics", response_model=Response)
+async def get_channel_metrics(
+        channel_type: ChannelTypes,
         current_user: User = Security(Authentication.get_current_user_and_bot, scopes=TESTER_ACCESS)
 ):
     """
-    Get Channel logs count.
+    Get Channel metrics (Failures/Successes).
     """
-    channel_logs_count = MessageBroadcastProcessor.get_channel_logs_count(current_user.get_bot())
-    data = {
-        'count': channel_logs_count
-    }
-    return Response(data=data)
+    return Response(data=MessageBroadcastProcessor.get_channel_metrics(channel_type, current_user.get_bot()))

--- a/kairon/api/app/routers/bot/channels.py
+++ b/kairon/api/app/routers/bot/channels.py
@@ -235,3 +235,17 @@ async def retrieve_scheduled_message_broadcast_logs(
     log_filters = request.query_params._dict.copy()
     logs, total_count = MessageBroadcastProcessor.get_broadcast_logs(current_user.get_bot(), **log_filters)
     return Response(data={"logs": logs, "total_count": total_count})
+
+
+@router.get("/whatsapp/logs", response_model=Response)
+async def get_channel_logs_count(
+        current_user: User = Security(Authentication.get_current_user_and_bot, scopes=TESTER_ACCESS)
+):
+    """
+    Get Channel logs count.
+    """
+    channel_logs_count = MessageBroadcastProcessor.get_channel_logs_count(current_user.get_bot())
+    data = {
+        'count': channel_logs_count
+    }
+    return Response(data=data)

--- a/kairon/chat/agent/message_processor.py
+++ b/kairon/chat/agent/message_processor.py
@@ -1,6 +1,8 @@
 from typing import Tuple, Optional, Text
+
 import rasa
-from rasa.core.actions.action import Action, ActionRetrieveResponse, ActionEndToEndResponse, RemoteAction, default_actions
+from rasa.core.actions.action import Action, ActionRetrieveResponse, ActionEndToEndResponse, RemoteAction, \
+    default_actions
 from rasa.core.channels import UserMessage, OutputChannel, CollectingOutputChannel
 from rasa.core.policies.policy import PolicyPrediction
 from rasa.core.processor import MessageProcessor, logger

--- a/kairon/chat/handlers/channels/whatsapp.py
+++ b/kairon/chat/handlers/channels/whatsapp.py
@@ -74,7 +74,7 @@ class Whatsapp:
                     statuses = changes.get("value", {}).get("statuses")
                     user = metadata.get('display_phone_number')
                     for status_data in statuses:
-                        ChatDataProcessor.save_whatsapp_audit_log(status_data, bot, user)
+                        ChatDataProcessor.save_whatsapp_audit_log(status_data, bot, user, ChannelTypes.WHATSAPP.value)
                 for message in messages or []:
                     await self.message(message, metadata, bot)
 

--- a/kairon/shared/chat/broadcast/processor.py
+++ b/kairon/shared/chat/broadcast/processor.py
@@ -135,3 +135,31 @@ class MessageBroadcastProcessor:
         broadcast_logs = MessageBroadcastProcessor.extract_message_ids_from_broadcast_logs(reference_id)
         if broadcast_logs:
             MessageBroadcastProcessor.__add_broadcast_logs_status_and_errors(reference_id, broadcast_logs)
+
+    @staticmethod
+    def get_channel_logs_count(bot: Text):
+        result = list(ChannelLogs.objects.aggregate([
+            {
+                '$match': {
+                    'bot': bot
+                }
+            }, {
+                '$group': {
+                    '_id': {
+                        'campaign_id': '$campaign_id',
+                        'status': '$status'
+                    },
+                    'count': {
+                        '$sum': 1
+                    }
+                }
+            }, {
+                '$project': {
+                    'status': '$_id.status',
+                    'campaign_id': '$_id.campaign_id',
+                    'cnt': '$count',
+                    '_id': 0
+                }
+            }
+        ]))
+        return result

--- a/kairon/shared/chat/broadcast/processor.py
+++ b/kairon/shared/chat/broadcast/processor.py
@@ -12,6 +12,7 @@ from kairon.shared.chat.broadcast.constants import MessageBroadcastLogType
 from kairon.shared.chat.broadcast.data_objects import MessageBroadcastSettings, SchedulerConfiguration, \
     RecipientsConfiguration, TemplateConfiguration, MessageBroadcastLogs
 from kairon.shared.chat.data_objects import Channels, ChannelLogs
+from kairon.shared.constants import ChannelTypes
 
 
 class MessageBroadcastProcessor:
@@ -123,12 +124,13 @@ class MessageBroadcastProcessor:
     @staticmethod
     def __add_broadcast_logs_status_and_errors(reference_id: Text, broadcast_logs: Dict[Text, Document]):
         message_ids = list(broadcast_logs.keys())
-        channel_logs = ChannelLogs.objects(message_id__in=message_ids)
+        channel_logs = ChannelLogs.objects(message_id__in=message_ids, type=ChannelTypes.WHATSAPP.value)
         for log in channel_logs:
             if log['errors']:
                 msg_id = log["message_id"]
                 broadcast_logs[msg_id].update(errors=log['errors'], status="Failed")
-            log.update(campaign_id=reference_id)
+
+        ChannelLogs.objects(message_id__in=message_ids, type=ChannelTypes.WHATSAPP.value).update(campaign_id=reference_id)
 
     @staticmethod
     def insert_status_received_on_channel_webhook(reference_id: Text):
@@ -137,29 +139,10 @@ class MessageBroadcastProcessor:
             MessageBroadcastProcessor.__add_broadcast_logs_status_and_errors(reference_id, broadcast_logs)
 
     @staticmethod
-    def get_channel_logs_count(bot: Text):
+    def get_channel_metrics(channel_type: Text, bot: Text):
         result = list(ChannelLogs.objects.aggregate([
-            {
-                '$match': {
-                    'bot': bot
-                }
-            }, {
-                '$group': {
-                    '_id': {
-                        'campaign_id': '$campaign_id',
-                        'status': '$status'
-                    },
-                    'count': {
-                        '$sum': 1
-                    }
-                }
-            }, {
-                '$project': {
-                    'status': '$_id.status',
-                    'campaign_id': '$_id.campaign_id',
-                    'cnt': '$count',
-                    '_id': 0
-                }
-            }
+            {'$match': {'bot': bot, "type": channel_type}},
+            {'$group': {'_id': {'campaign_id': '$campaign_id', 'status': '$status'}, 'count': {'$sum': 1}}},
+            {'$project': {'status': '$_id.status', 'campaign_id': '$_id.campaign_id', 'count': '$count', '_id': 0}}
         ]))
         return result

--- a/kairon/shared/chat/data_objects.py
+++ b/kairon/shared/chat/data_objects.py
@@ -41,7 +41,9 @@ class Channels(Auditlog):
 @auditlogger.log
 @push_notification.apply
 class ChannelLogs(DynamicDocument):
-    data = DictField(default=None)
+    type = StringField()
+    data = DictField()
+    campaign_id = StringField()
     status = StringField(required=True)
     message_id = StringField(required=True)
     errors = ListField(DictField(default=[]))
@@ -49,3 +51,5 @@ class ChannelLogs(DynamicDocument):
     bot = StringField(required=True)
     user = StringField(required=True)
     timestamp = DateTimeField(default=datetime.utcnow)
+
+    meta = {"indexes": [{"fields": ["bot", ("bot", "type", "campaign_id")]}]}

--- a/kairon/shared/chat/processor.py
+++ b/kairon/shared/chat/processor.py
@@ -1,10 +1,11 @@
+from datetime import datetime
 from typing import Dict, Text
 
-from mongoengine import DoesNotExist
 from loguru import logger
-from .data_objects import Channels, ChannelLogs
-from datetime import datetime
+from mongoengine import DoesNotExist
+
 from kairon.shared.utils import Utility
+from .data_objects import Channels, ChannelLogs
 from ..constants import ChannelTypes
 from ..data.utils import DataUtility
 from ...exceptions import AppException

--- a/kairon/shared/chat/processor.py
+++ b/kairon/shared/chat/processor.py
@@ -127,15 +127,17 @@ class ChatDataProcessor:
             raise AppException('Channel not configured')
 
     @staticmethod
-    def save_whatsapp_audit_log(status_data: Dict, bot: Text, user: Text):
+    def save_whatsapp_audit_log(status_data: Dict, bot: Text, user: Text, channel_type: Text):
         """
         save or updates channel configuration
         :param status_data: status_data dict
         :param bot: bot id
         :param user: user id
+        :param channel_type: channel type
         :return: None
         """
         ChannelLogs(
+            type=channel_type,
             status=status_data.get('status'),
             data=status_data.get('conversation'),
             initiator=status_data.get('conversation', {}).get('origin', {}).get('type'),

--- a/tests/integration_test/chat_service_test.py
+++ b/tests/integration_test/chat_service_test.py
@@ -1758,7 +1758,7 @@ def test_whatsapp_valid_statuses_with_read_request():
     assert actual == 'success'
     log = ChannelLogs.objects(
         bot=bot, message_id='wamid.HBgLMTIxMTU1NTc5NDcVAgARGBIyRkQxREUxRDJFQUJGMkQ3NDIC').get().to_mongo().to_dict()
-    assert log.get('data') is None
+    assert log.get('data') == {}
     assert log.get('initiator') is None
     assert log.get('status') == 'read'
 
@@ -1834,7 +1834,7 @@ def test_whatsapp_valid_statuses_with_errors_request():
     assert ChannelLogs.objects(bot=bot, message_id='wamid.HBgLMTIxMTU1NTc5NDcVAgARGBIyRkQxREUxRDJFQUJGMkQ3NDIZ')
     log = ChannelLogs.objects(bot=bot, user='919876543219').get().to_mongo().to_dict()
     assert log.get('status') == 'failed'
-    assert log.get('data') is None
+    assert log.get('data') == {}
     assert log.get('errors') == [{
         'code': 130472, 'title': "User's number is part of an experiment",
         'message': "User's number is part of an experiment",

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -14097,9 +14097,9 @@ def test_get_channel_logs():
     print(actual)
     assert actual["success"]
     assert actual["error_code"] == 0
-    assert actual["data"] == [{'status': 'delivered', 'campaign_id': '6779002886649302', 'cnt': 1},
-                              {'status': 'read', 'campaign_id': '6779002886649302', 'cnt': 1},
-                              {'status': 'sent', 'campaign_id': '6779002886649302', 'cnt': 1}]
+    assert actual["data"] == [{'status': 'delivered', 'campaign_id': '6779002886649302', 'count': 1},
+                              {'status': 'read', 'campaign_id': '6779002886649302', 'count': 1},
+                              {'status': 'sent', 'campaign_id': '6779002886649302', 'count': 1}]
 
 
 @responses.activate

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -14054,6 +14054,51 @@ def test_list_whatsapp_templates_error():
     assert actual["message"] == "Channel not found!"
 
 
+def test_get_channel_logs():
+    from kairon.shared.chat.data_objects import ChannelLogs
+    ChannelLogs(
+        status='read',
+        data={'id': 'CONVERSATION_ID', 'expiration_timestamp': '1691598412',
+              'origin': {'type': 'business_initated'}},
+        initiator='business_initated',
+        campaign_id='6779002886649302',
+        message_id='wamid.HBgLMTIxMTU1NTc5NDcVAgARGBIyRkQxREUxRDJFQUJGMkQ3NDIZ',
+        bot=pytest.bot,
+        user='integration@demo.ai'
+    ).save()
+    ChannelLogs(
+        status='delivered',
+        data={'id': 'CONVERSATION_ID', 'expiration_timestamp': '1621598412',
+              'origin': {'type': 'business_initated'}},
+        initiator='business_initated',
+        campaign_id='6779002886649302',
+        message_id='wamid.HBgLMTIxMTU1NTc5NDcVAgARGBIyRkQxREUxRDJFQUJGMkQ3NDIZ',
+        bot=pytest.bot,
+        user='integration@demo.ai'
+    ).save()
+    ChannelLogs(
+        status='sent',
+        data={'id': 'CONVERSATION_ID', 'expiration_timestamp': '1631598412',
+              'origin': {'type': 'business_initated'}},
+        initiator='business_initated',
+        campaign_id='6779002886649302',
+        message_id='wamid.HBgLMTIxMTU1NTc5NDcVAgARGBIyRkQxREUxRDJFQUJGMkQ3NDIZ',
+        bot=pytest.bot,
+        user='integration@demo.ai'
+    ).save()
+    response = client.get(
+        f"/api/bot/{pytest.bot}/channels/whatsapp/logs",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    print(actual)
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["data"] == {'count': [{'status': 'delivered', 'campaign_id': '6779002886649302', 'cnt': 1},
+                                        {'status': 'read', 'campaign_id': '6779002886649302', 'cnt': 1},
+                                        {'status': 'sent', 'campaign_id': '6779002886649302', 'cnt': 1}]}
+
+
 @responses.activate
 def test_initiate_bsp_onboarding_without_channels(monkeypatch):
     def _mock_get_bot_settings(*args, **kwargs):

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -14057,6 +14057,7 @@ def test_list_whatsapp_templates_error():
 def test_get_channel_logs():
     from kairon.shared.chat.data_objects import ChannelLogs
     ChannelLogs(
+        type=ChannelTypes.WHATSAPP.value,
         status='read',
         data={'id': 'CONVERSATION_ID', 'expiration_timestamp': '1691598412',
               'origin': {'type': 'business_initated'}},
@@ -14067,6 +14068,7 @@ def test_get_channel_logs():
         user='integration@demo.ai'
     ).save()
     ChannelLogs(
+        type=ChannelTypes.WHATSAPP.value,
         status='delivered',
         data={'id': 'CONVERSATION_ID', 'expiration_timestamp': '1621598412',
               'origin': {'type': 'business_initated'}},
@@ -14077,6 +14079,7 @@ def test_get_channel_logs():
         user='integration@demo.ai'
     ).save()
     ChannelLogs(
+        type=ChannelTypes.WHATSAPP.value,
         status='sent',
         data={'id': 'CONVERSATION_ID', 'expiration_timestamp': '1631598412',
               'origin': {'type': 'business_initated'}},
@@ -14087,16 +14090,16 @@ def test_get_channel_logs():
         user='integration@demo.ai'
     ).save()
     response = client.get(
-        f"/api/bot/{pytest.bot}/channels/whatsapp/logs",
+        f"/api/bot/{pytest.bot}/channels/whatsapp/metrics",
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
     actual = response.json()
     print(actual)
     assert actual["success"]
     assert actual["error_code"] == 0
-    assert actual["data"] == {'count': [{'status': 'delivered', 'campaign_id': '6779002886649302', 'cnt': 1},
-                                        {'status': 'read', 'campaign_id': '6779002886649302', 'cnt': 1},
-                                        {'status': 'sent', 'campaign_id': '6779002886649302', 'cnt': 1}]}
+    assert actual["data"] == [{'status': 'delivered', 'campaign_id': '6779002886649302', 'cnt': 1},
+                              {'status': 'read', 'campaign_id': '6779002886649302', 'cnt': 1},
+                              {'status': 'sent', 'campaign_id': '6779002886649302', 'cnt': 1}]
 
 
 @responses.activate

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -34,7 +34,7 @@ from kairon.shared.actions.data_objects import ActionServerLogs
 from kairon.shared.actions.utils import ActionUtility
 from kairon.shared.auth import Authentication
 from kairon.shared.cloud.utils import CloudUtility
-from kairon.shared.constants import EventClass
+from kairon.shared.constants import EventClass, ChannelTypes
 from kairon.shared.data.audit.data_objects import AuditLogData
 from kairon.shared.data.constant import UTTERANCE_TYPE, EVENT_STATUS, TOKEN_TYPE, AuditlogActions, \
     KAIRON_TWO_STAGE_FALLBACK, FeatureMappings, DEFAULT_NLU_FALLBACK_RESPONSE

--- a/tests/unit_test/events/events_test.py
+++ b/tests/unit_test/events/events_test.py
@@ -1287,6 +1287,9 @@ class TestEventExecution:
                     'details': "Failed to send message because this user's phone number is part of an experiment"},
                  'href': 'https://developers.facebook.com/docs/whatsapp/cloud-api/support/error-codes/'}]}
         assert ChannelLogs.objects(bot=bot, message_id='wamid.HBgLMTIxMTU1NTc5NDcVAgARGBIyRkQxREUxRDJFQUJGMkQ3NDIZ').get().campaign_id == reference_id
+        result = MessageBroadcastProcessor.get_channel_logs_count(bot)
+        print(result)
+        assert result == [{'status': 'Failed', 'campaign_id': reference_id, 'cnt': 1}]
 
     @responses.activate
     @mongomock.patch(servers=(('localhost', 27017),))

--- a/tests/unit_test/events/events_test.py
+++ b/tests/unit_test/events/events_test.py
@@ -89,7 +89,8 @@ class TestEventExecution:
 
         monkeypatch.setattr(Utility, "get_latest_file", _path)
 
-        DataImporterLogProcessor.add_log(bot, user, files_received=REQUIREMENTS-{"http_actions", "chat_client_config"})
+        DataImporterLogProcessor.add_log(bot, user,
+                                         files_received=REQUIREMENTS - {"http_actions", "chat_client_config"})
         TrainingDataImporterEvent(bot, user, import_data=True, overwrite=False).execute()
         logs = list(DataImporterLogProcessor.get_logs(bot))
         assert len(logs) == 1
@@ -336,7 +337,8 @@ class TestEventExecution:
     def test_trigger_data_importer_validate_event(self, monkeypatch):
         bot = 'test_events_bot'
         user = 'test_user'
-        event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.data_importer}")
+        event_url = urljoin(Utility.environment['events']['server_url'],
+                            f"/api/events/execute/{EventClass.data_importer}")
         BotSettings(bot="test_events_bot", user="test_user").save()
 
         responses.add("POST",
@@ -346,7 +348,8 @@ class TestEventExecution:
                       match=[
                           responses.matchers.json_params_matcher(
                               {"cron_exp": None, "data": {"bot": "test_events_bot", "event_type": "data_importer",
-                                                          "import_data": "--import-data", "overwrite": "", "user": "test_user"}, "timezone": None})],
+                                                          "import_data": "--import-data", "overwrite": "",
+                                                          "user": "test_user"}, "timezone": None})],
                       )
         event = TrainingDataImporterEvent(bot, user, import_data=True)
         event.validate()
@@ -372,7 +375,8 @@ class TestEventExecution:
     def test_trigger_data_importer_validate_and_save_event_overwrite(self, monkeypatch):
         bot = 'test_events_bot_1'
         user = 'test_user'
-        event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.data_importer}")
+        event_url = urljoin(Utility.environment['events']['server_url'],
+                            f"/api/events/execute/{EventClass.data_importer}")
         BotSettings(bot="test_events_bot_1", user="test_user").save()
         responses.add("POST",
                       event_url,
@@ -407,7 +411,8 @@ class TestEventExecution:
     def test_trigger_data_importer_validate_only_event(self, monkeypatch):
         bot = 'test_events_bot_2'
         user = 'test_user'
-        event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.data_importer}")
+        event_url = urljoin(Utility.environment['events']['server_url'],
+                            f"/api/events/execute/{EventClass.data_importer}")
         BotSettings(bot="test_events_bot_2", user="test_user").save()
 
         responses.add("POST",
@@ -416,7 +421,7 @@ class TestEventExecution:
                       status=200,
                       match=[
                           responses.matchers.json_params_matcher(
-                              {"data": {'bot': bot, 'user': user, 'import_data': '', 
+                              {"data": {'bot': bot, 'user': user, 'import_data': '',
                                         'event_type': EventClass.data_importer, 'overwrite': ''},
                                "cron_exp": None, "timezone": None})],
                       )
@@ -459,7 +464,8 @@ class TestEventExecution:
         nlu_path = os.path.join(test_data_path, 'data')
         Utility.make_dirs(nlu_path)
         shutil.copy2('tests/testing_data/validator/valid/data/nlu.yml', nlu_path)
-        nlu, story_graph, domain, config, http_actions, multiflow_stories = asyncio.run(get_training_data('tests/testing_data/validator/valid'))
+        nlu, story_graph, domain, config, http_actions, multiflow_stories = asyncio.run(
+            get_training_data('tests/testing_data/validator/valid'))
         mongo_processor = MongoProcessor()
         mongo_processor.save_domain(domain, bot, user)
         mongo_processor.save_stories(story_graph.story_steps, bot, user)
@@ -557,7 +563,8 @@ class TestEventExecution:
         data_path = os.path.join(test_data_path, 'data')
         Utility.make_dirs(data_path)
         shutil.copy2('tests/testing_data/validator/valid/data/stories.yml', data_path)
-        nlu, story_graph, domain, config, http_actions, multiflow_stories = asyncio.run(get_training_data('tests/testing_data/validator/valid'))
+        nlu, story_graph, domain, config, http_actions, multiflow_stories = asyncio.run(
+            get_training_data('tests/testing_data/validator/valid'))
         mongo_processor = MongoProcessor()
         mongo_processor.save_domain(domain, bot, user)
         mongo_processor.save_nlu(nlu, bot, user)
@@ -603,7 +610,8 @@ class TestEventExecution:
         data_path = os.path.join(test_data_path, 'data')
         Utility.make_dirs(data_path)
         shutil.copy2('tests/testing_data/validator/valid/data/rules.yml', data_path)
-        nlu, story_graph, domain, config, http_actions, multiflow_stories = asyncio.run(get_training_data('tests/testing_data/validator/valid'))
+        nlu, story_graph, domain, config, http_actions, multiflow_stories = asyncio.run(
+            get_training_data('tests/testing_data/validator/valid'))
         mongo_processor = MongoProcessor()
         mongo_processor.save_domain(domain, bot, user)
         mongo_processor.save_nlu(nlu, bot, user)
@@ -648,7 +656,8 @@ class TestEventExecution:
         test_data_path = os.path.join(pytest.tmp_dir, str(uuid.uuid4()))
         Utility.make_dirs(test_data_path)
         shutil.copy2('tests/testing_data/validator/valid/domain.yml', test_data_path)
-        nlu, story_graph, domain, config, http_actions, multiflow_stories = asyncio.run(get_training_data('tests/testing_data/validator/valid'))
+        nlu, story_graph, domain, config, http_actions, multiflow_stories = asyncio.run(
+            get_training_data('tests/testing_data/validator/valid'))
         mongo_processor = MongoProcessor()
         mongo_processor.save_stories(story_graph.story_steps, bot, user)
         mongo_processor.save_nlu(nlu, bot, user)
@@ -834,6 +843,7 @@ class TestEventExecution:
     def test_trigger_faq_importer_validate_only(self, monkeypatch):
         def _mock_execution(*args, **kwargs):
             return None
+
         def _mock_aggregation(*args, **kwargs):
             return {}
 
@@ -865,6 +875,7 @@ class TestEventExecution:
     def test_trigger_faq_importer_overwrite(self, monkeypatch):
         def _mock_execution(*args, **kwargs):
             return None
+
         def _mock_aggregation(*args, **kwargs):
             return {}
 
@@ -911,6 +922,7 @@ class TestEventExecution:
     def test_trigger_faq_importer_validate_only_append_mode(self, monkeypatch):
         def _mock_execution(*args, **kwargs):
             return None
+
         def _mock_aggregation(*args, **kwargs):
             return {}
 
@@ -978,7 +990,7 @@ class TestEventExecution:
 
             processor = MongoProcessor()
             processor.save_training_data(bot, user, config, domain, story_graph, nlu, overwrite=True,
-                                         what=REQUIREMENTS.copy()-{"chat_client_config"})
+                                         what=REQUIREMENTS.copy() - {"chat_client_config"})
 
         return _read_and_get_data
 
@@ -1068,6 +1080,7 @@ class TestEventExecution:
                 "intent_evaluation": [],
             }
             return nlu, stories
+
         monkeypatch.setattr(ModelTester, "run_tests_on_model", _mock_test_result)
         ModelTestingEvent(bot, user).execute()
         config_path = 'tests/testing_data/model_tester/config.yml'
@@ -1090,14 +1103,16 @@ class TestEventExecution:
     def test_trigger_model_testing_event(self):
         bot = 'test_events_bot'
         user = 'test_user'
-        event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_testing}")
+        event_url = urljoin(Utility.environment['events']['server_url'],
+                            f"/api/events/execute/{EventClass.model_testing}")
         responses.add("POST",
                       event_url,
                       json={"success": True, "message": "Event triggered successfully!"},
                       status=200,
                       match=[
                           responses.matchers.json_params_matcher(
-                              {"data": {'bot': bot, 'user': user, 'augment_data': '--augment'}, "cron_exp": None, "timezone": None})],
+                              {"data": {'bot': bot, 'user': user, 'augment_data': '--augment'}, "cron_exp": None,
+                               "timezone": None})],
                       )
         ModelTestingEvent(bot, user).enqueue()
         responses.reset()
@@ -1116,14 +1131,16 @@ class TestEventExecution:
     def test_trigger_model_testing_event_2(self):
         bot = 'test_events_bot_2'
         user = 'test_user'
-        event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.model_testing}")
+        event_url = urljoin(Utility.environment['events']['server_url'],
+                            f"/api/events/execute/{EventClass.model_testing}")
         responses.add("POST",
                       event_url,
                       json={"success": True, "message": "Event triggered successfully!"},
                       status=200,
                       match=[
                           responses.matchers.json_params_matcher(
-                              {"data": {'bot': bot, 'user': user, 'augment_data': ''}, "cron_exp": None, "timezone": None})],
+                              {"data": {'bot': bot, 'user': user, 'augment_data': ''}, "cron_exp": None,
+                               "timezone": None})],
                       )
         ModelTestingEvent(bot, user, augment_data=False).enqueue()
         responses.reset()
@@ -1144,7 +1161,8 @@ class TestEventExecution:
         user = 'test_user'
         till_date = datetime.utcnow().date()
         sender_id = ""
-        event_url = urljoin(Utility.environment['events']['server_url'], f"/api/events/execute/{EventClass.delete_history}")
+        event_url = urljoin(Utility.environment['events']['server_url'],
+                            f"/api/events/execute/{EventClass.delete_history}")
         responses.reset()
         responses.add("POST",
                       event_url,
@@ -1152,8 +1170,9 @@ class TestEventExecution:
                       status=200,
                       match=[
                           responses.matchers.json_params_matcher(
-                              {"data": {'bot': bot, 'user': user, 'till_date': Utility.convert_date_to_string(till_date),
-                               'sender_id': sender_id}, "cron_exp": None, "timezone": None})],
+                              {"data": {'bot': bot, 'user': user,
+                                        'till_date': Utility.convert_date_to_string(till_date),
+                                        'sender_id': sender_id}, "cron_exp": None, "timezone": None})],
                       )
         responses.start()
         event = DeleteHistoryEvent(bot, user, till_date=till_date, sender_id=None)
@@ -1176,8 +1195,8 @@ class TestEventExecution:
     @patch("kairon.shared.chat.processor.ChatDataProcessor.get_channel_config")
     @patch("kairon.shared.utils.Utility.is_exist", autospec=True)
     def test_execute_message_broadcast_with_logs_modification(self, mock_is_exist, mock_channel_config,
-                                                          mock_get_bot_settings, mock_send,
-                                                          mock_get_partner_auth_token):
+                                                              mock_get_bot_settings, mock_send,
+                                                              mock_get_partner_auth_token):
         bot = 'test_execute_message_broadcast_with_logs_modification'
         user = 'test_user'
         config = {
@@ -1236,10 +1255,12 @@ class TestEventExecution:
             "config": {"access_token": "shjkjhrefdfghjkl", "from_phone_number_id": "918958030415",
                        "waba_account_id": "asdfghjk"}}
         mock_send.return_value = {"contacts": [{"input": "+55123456789", "status": "valid", "wa_id": "55123456789"}],
-                                  "messages": [{"id": 'wamid.HBgLMTIxMTU1NTc5NDcVAgARGBIyRkQxREUxRDJFQUJGMkQ3NDIZ', "message_status": 'accepted'}]}
+                                  "messages": [{"id": 'wamid.HBgLMTIxMTU1NTc5NDcVAgARGBIyRkQxREUxRDJFQUJGMkQ3NDIZ',
+                                                "message_status": 'accepted'}]}
         mock_get_partner_auth_token.return_value = None
 
         ChannelLogs(
+            type=ChannelTypes.WHATSAPP.value,
             status='Failed',
             data={'id': 'CONVERSATION_ID', 'expiration_timestamp': '1691598412',
                   'origin': {'type': 'business_initated'}},
@@ -1271,22 +1292,23 @@ class TestEventExecution:
         reference_id = logs[0][0].get("reference_id")
         logged_config = logs[0][0]
         print(logged_config)
-        assert logged_config == {'reference_id': reference_id, 'log_type': 'send', 'bot': 'test_execute_message_broadcast_with_logs_modification',
-                                 'status': 'Failed', 'api_response': {
-                'contacts': [{'input': '+55123456789', 'status': 'valid', 'wa_id': '55123456789'}], 'messages': [
-                    {'id': 'wamid.HBgLMTIxMTU1NTc5NDcVAgARGBIyRkQxREUxRDJFQUJGMkQ3NDIZ',
-                     'message_status': 'accepted'}]}, 'recipient': '918958030541', 'template_params': None,
-                                 'template': [
-                                     {'format': 'TEXT', 'text': 'Kisan Suvidha Program Follow-up', 'type': 'HEADER'}, {
-                                         'text': 'Hello! As a part of our Kisan Suvidha program, I am dedicated to supporting farmers like you in maximizing your crop productivity and overall yield.\n\nI wanted to reach out to inquire if you require any assistance with your current farming activities. Our team of experts, including our skilled agronomists, are here to lend a helping hand wherever needed.',
-                                         'type': 'BODY'}, {'text': 'reply with STOP to unsubscribe', 'type': 'FOOTER'},
-                                     {'buttons': [{'text': 'Connect to Agronomist', 'type': 'QUICK_REPLY'}],
-                                      'type': 'BUTTONS'}], 'errors': [
+        assert logged_config == {'reference_id': reference_id, 'log_type': 'send',
+                                 'bot': 'test_execute_message_broadcast_with_logs_modification', 'status': 'Failed',
+                                 'api_response': {
+                                     'contacts': [{'input': '+55123456789', 'status': 'valid', 'wa_id': '55123456789'}],
+                                     'messages': [{'id': 'wamid.HBgLMTIxMTU1NTc5NDcVAgARGBIyRkQxREUxRDJFQUJGMkQ3NDIZ',
+                                                   'message_status': 'accepted'}]}, 'recipient': '918958030541',
+                                 'template_params': None, 'template': [
+                {'format': 'TEXT', 'text': 'Kisan Suvidha Program Follow-up', 'type': 'HEADER'}, {
+                    'text': 'Hello! As a part of our Kisan Suvidha program, I am dedicated to supporting farmers like you in maximizing your crop productivity and overall yield.\n\nI wanted to reach out to inquire if you require any assistance with your current farming activities. Our team of experts, including our skilled agronomists, are here to lend a helping hand wherever needed.',
+                    'type': 'BODY'}, {'text': 'reply with STOP to unsubscribe', 'type': 'FOOTER'},
+                {'buttons': [{'text': 'Connect to Agronomist', 'type': 'QUICK_REPLY'}], 'type': 'BUTTONS'}], 'errors': [
                 {'code': 130472, 'title': "User's number is part of an experiment",
                  'message': "User's number is part of an experiment", 'error_data': {
                     'details': "Failed to send message because this user's phone number is part of an experiment"},
                  'href': 'https://developers.facebook.com/docs/whatsapp/cloud-api/support/error-codes/'}]}
-        assert ChannelLogs.objects(bot=bot, message_id='wamid.HBgLMTIxMTU1NTc5NDcVAgARGBIyRkQxREUxRDJFQUJGMkQ3NDIZ').get().campaign_id == reference_id
+        assert ChannelLogs.objects(bot=bot,
+                                   message_id='wamid.HBgLMTIxMTU1NTc5NDcVAgARGBIyRkQxREUxRDJFQUJGMkQ3NDIZ').get().campaign_id == reference_id
         result = MessageBroadcastProcessor.get_channel_metrics(ChannelTypes.WHATSAPP.value, bot)
         assert result == [{'status': 'Failed', 'campaign_id': reference_id, 'count': 1}]
 
@@ -1298,7 +1320,8 @@ class TestEventExecution:
     @patch("kairon.shared.chat.processor.ChatDataProcessor.get_channel_config")
     @patch("kairon.shared.utils.Utility.is_exist", autospec=True)
     def test_execute_message_broadcast_with_static_values(self, mock_is_exist, mock_channel_config,
-                                                           mock_get_bot_settings, mock_send, mock_get_partner_auth_token):
+                                                          mock_get_bot_settings, mock_send,
+                                                          mock_get_partner_auth_token):
         bot = 'test_execute_message_broadcast'
         user = 'test_user'
         config = {
@@ -1351,7 +1374,8 @@ class TestEventExecution:
                 {"category": "MARKETING", "components": template, "name": "agronomy_support", "language": "hi"}]}
         )
 
-        mock_get_bot_settings.return_value = {"whatsapp": "360dialog", "notification_scheduling_limit": 4, "dynamic_broadcast_execution_timeout": 21600}
+        mock_get_bot_settings.return_value = {"whatsapp": "360dialog", "notification_scheduling_limit": 4,
+                                              "dynamic_broadcast_execution_timeout": 21600}
         mock_channel_config.return_value = {
             "config": {"access_token": "shjkjhrefdfghjkl", "from_phone_number_id": "918958030415",
                        "waba_account_id": "asdfghjk"}}
@@ -1400,10 +1424,11 @@ class TestEventExecution:
     @patch("kairon.shared.chat.processor.ChatDataProcessor.get_channel_config")
     @patch("kairon.shared.utils.Utility.is_exist", autospec=True)
     def test_execute_message_broadcast_with_dynamic_values(self, mock_is_exist, mock_channel_config,
-                                                           mock_get_bot_settings, mock_send, mock_get_partner_auth_token):
+                                                           mock_get_bot_settings, mock_send,
+                                                           mock_get_partner_auth_token):
         bot = 'test_execute_dynamic_message_broadcast'
         user = 'test_user'
-        params = [{"type": "header","parameters": [{"type": "document","document":
+        params = [{"type": "header", "parameters": [{"type": "document", "document":
             {"link": "https://drive.google.com/uc?export=download&id=1GXQ43jilSDelRvy1kr3PNNpl1e21dRXm",
              "filename": "Brochure.pdf"}}]}]
         template = [
@@ -1432,7 +1457,7 @@ class TestEventExecution:
         ]
 
         config = {
-            "name": "one_time_schedule","broadcast_type": "static",
+            "name": "one_time_schedule", "broadcast_type": "static",
             "connector_type": "whatsapp",
             "recipients_config": {
                 "recipients": "9876543210, 876543212345",
@@ -1459,8 +1484,11 @@ class TestEventExecution:
                 {"category": "MARKETING", "components": template, "name": "agronomy_support", "language": "hi"}]}
         )
 
-        mock_get_bot_settings.return_value = {"whatsapp": "360dialog", "notification_scheduling_limit": 4, "dynamic_broadcast_execution_timeout": 21600}
-        mock_channel_config.return_value = {"config": {"access_token": "shjkjhrefdfghjkl", "from_phone_number_id": "918958030415", "waba_account_id": "asdfghjk"}}
+        mock_get_bot_settings.return_value = {"whatsapp": "360dialog", "notification_scheduling_limit": 4,
+                                              "dynamic_broadcast_execution_timeout": 21600}
+        mock_channel_config.return_value = {
+            "config": {"access_token": "shjkjhrefdfghjkl", "from_phone_number_id": "918958030415",
+                       "waba_account_id": "asdfghjk"}}
         mock_send.return_value = {"contacts": [{"input": "+55123456789", "status": "valid", "wa_id": "55123456789"}]}
         mock_get_partner_auth_token.return_value = None
 
@@ -1498,19 +1526,19 @@ class TestEventExecution:
         logs[0][0].pop("recipient")
         assert logs[0][1] == {'reference_id': reference_id, 'log_type': 'send', 'bot': bot, 'status': 'Success',
                               'api_response': {
-                'contacts': [{'input': '+55123456789', 'status': 'valid', 'wa_id': '55123456789'}]},
+                                  'contacts': [{'input': '+55123456789', 'status': 'valid', 'wa_id': '55123456789'}]},
                               'template_params': [{'type': 'header', 'parameters': [
-                {'type': 'document', 'document': {
-                    'link': 'https://drive.google.com/uc?export=download&id=1GXQ43jilSDelRvy1kr3PNNpl1e21dRXm',
-                    'filename': 'Brochure.pdf'}}]}], "template": template}
+                                  {'type': 'document', 'document': {
+                                      'link': 'https://drive.google.com/uc?export=download&id=1GXQ43jilSDelRvy1kr3PNNpl1e21dRXm',
+                                      'filename': 'Brochure.pdf'}}]}], "template": template}
         logs[0][0].pop("timestamp")
         assert logs[0][0] == {'reference_id': reference_id, 'log_type': 'send', 'bot': bot, 'status': 'Success',
                               'api_response': {
-                'contacts': [{'input': '+55123456789', 'status': 'valid', 'wa_id': '55123456789'}]},
+                                  'contacts': [{'input': '+55123456789', 'status': 'valid', 'wa_id': '55123456789'}]},
                               'template_params': [{'type': 'header', 'parameters': [
-                {'type': 'document', 'document': {
-                    'link': 'https://drive.google.com/uc?export=download&id=1GXQ43jilSDelRvy1kr3PNNpl1e21dRXm',
-                    'filename': 'Brochure.pdf'}}]}], "template": template}
+                                  {'type': 'document', 'document': {
+                                      'link': 'https://drive.google.com/uc?export=download&id=1GXQ43jilSDelRvy1kr3PNNpl1e21dRXm',
+                                      'filename': 'Brochure.pdf'}}]}], "template": template}
         with pytest.raises(AppException, match="Notification settings not found!"):
             MessageBroadcastProcessor.get_settings(event_id, bot)
 
@@ -1526,7 +1554,7 @@ class TestEventExecution:
     @patch("kairon.shared.chat.processor.ChatDataProcessor.get_channel_config")
     @patch("kairon.shared.utils.Utility.is_exist", autospec=True)
     def test_execute_message_broadcast_with_recipient_evaluation_failure(self, mock_is_exist, mock_channel_config,
-                                                           mock_get_bot_settings, mock_send):
+                                                                         mock_get_bot_settings, mock_send):
         bot = 'test_execute_dynamic_message_broadcast_recipient_evaluation_failure'
         user = 'test_user'
         config = {
@@ -1551,7 +1579,8 @@ class TestEventExecution:
             json={"message": "Event Triggered!", "success": True, "error_code": 0, "data": None}
         )
 
-        mock_get_bot_settings.return_value = {"whatsapp": "360dialog", "notification_scheduling_limit": 4, "dynamic_broadcast_execution_timeout": 21600}
+        mock_get_bot_settings.return_value = {"whatsapp": "360dialog", "notification_scheduling_limit": 4,
+                                              "dynamic_broadcast_execution_timeout": 21600}
         mock_channel_config.return_value = {
             "config": {"access_token": "shjkjhrefdfghjkl", "from_phone_number_id": "918958030415"}}
         mock_send.return_value = {"contacts": [{"input": "+55123456789", "status": "valid", "wa_id": "55123456789"}]}
@@ -1585,7 +1614,8 @@ class TestEventExecution:
     @patch("kairon.shared.chat.processor.ChatDataProcessor.get_channel_config")
     @patch("kairon.shared.data.processor.MongoProcessor.get_bot_settings")
     @patch("kairon.shared.utils.Utility.is_exist", autospec=True)
-    def test_execute_message_broadcast_expression_evaluation_failure(self, mock_is_exist, mock_get_bot_settings, mock_channel_config):
+    def test_execute_message_broadcast_expression_evaluation_failure(self, mock_is_exist, mock_get_bot_settings,
+                                                                     mock_channel_config):
         bot = 'test_execute_message_broadcast_expression_evaluation_failure'
         user = 'test_user'
         config = {
@@ -1609,7 +1639,8 @@ class TestEventExecution:
             json={"message": "Event Triggered!", "success": True, "error_code": 0, "data": None}
         )
 
-        mock_get_bot_settings.return_value = {"whatsapp": "360dialog", "notification_scheduling_limit": 4, "dynamic_broadcast_execution_timeout": 21600}
+        mock_get_bot_settings.return_value = {"whatsapp": "360dialog", "notification_scheduling_limit": 4,
+                                              "dynamic_broadcast_execution_timeout": 21600}
         mock_channel_config.return_value = {
             "config": {"access_token": "shjkjhrefdfghjkl", "from_phone_number_id": "918958030415"}}
 
@@ -1652,7 +1683,8 @@ class TestEventExecution:
             json={"message": "Event Triggered!", "success": True, "error_code": 0, "data": None}
         )
 
-        mock_get_bot_settings.return_value = {"whatsapp": "360dialog", "notification_scheduling_limit": 4, "dynamic_broadcast_execution_timeout": 21600}
+        mock_get_bot_settings.return_value = {"whatsapp": "360dialog", "notification_scheduling_limit": 4,
+                                              "dynamic_broadcast_execution_timeout": 21600}
         mock_send.return_value = {"contacts": [{"input": "+55123456789", "status": "valid", "wa_id": "55123456789"}]}
 
         event = MessageBroadcastEvent(bot, user)
@@ -1679,7 +1711,8 @@ class TestEventExecution:
         assert logged_config == config
         exception = logs[0][0].pop("exception")
         assert exception.startswith("Whatsapp channel config not found!")
-        assert logs[0][0] == {'log_type': 'common', 'bot': bot, 'status': 'Fail', 'user': user, 'broadcast_id': event_id,
+        assert logs[0][0] == {'log_type': 'common', 'bot': bot, 'status': 'Fail', 'user': user,
+                              'broadcast_id': event_id,
                               'recipients': ['918958030541']}
 
         with pytest.raises(AppException, match="Notification settings not found!"):
@@ -1692,7 +1725,8 @@ class TestEventExecution:
     @patch("kairon.shared.chat.processor.ChatDataProcessor.get_channel_config")
     @patch("kairon.chat.handlers.channels.clients.whatsapp.dialog360.BSP360Dialog.send_template_message")
     @patch("kairon.shared.utils.Utility.is_exist", autospec=True)
-    def test_execute_message_broadcast_evaluate_template_parameters(self, mock_is_exist, mock_send, mock_channel_config, mock_get_bot_settings, mock_bsp_auth_token):
+    def test_execute_message_broadcast_evaluate_template_parameters(self, mock_is_exist, mock_send, mock_channel_config,
+                                                                    mock_get_bot_settings, mock_bsp_auth_token):
         bot = 'test_execute_message_broadcast_evaluate_template_parameters'
         user = 'test_user'
         template_script = str([[{'body': 'Udit Pandey'}]])
@@ -1712,29 +1746,29 @@ class TestEventExecution:
             ]
         }
         template = [
-                {
-                    "format": "TEXT",
-                    "text": "Kisan Suvidha Program Follow-up",
-                    "type": "HEADER"
-                },
-                {
-                    "text": "Hello! As a part of our Kisan Suvidha program, I am dedicated to supporting farmers like you in maximizing your crop productivity and overall yield.\n\nI wanted to reach out to inquire if you require any assistance with your current farming activities. Our team of experts, including our skilled agronomists, are here to lend a helping hand wherever needed.",
-                    "type": "BODY"
-                },
-                {
-                    "text": "reply with STOP to unsubscribe",
-                    "type": "FOOTER"
-                },
-                {
-                    "buttons": [
-                        {
-                            "text": "Connect to Agronomist",
-                            "type": "QUICK_REPLY"
-                        }
-                    ],
-                    "type": "BUTTONS"
-                }
-            ]
+            {
+                "format": "TEXT",
+                "text": "Kisan Suvidha Program Follow-up",
+                "type": "HEADER"
+            },
+            {
+                "text": "Hello! As a part of our Kisan Suvidha program, I am dedicated to supporting farmers like you in maximizing your crop productivity and overall yield.\n\nI wanted to reach out to inquire if you require any assistance with your current farming activities. Our team of experts, including our skilled agronomists, are here to lend a helping hand wherever needed.",
+                "type": "BODY"
+            },
+            {
+                "text": "reply with STOP to unsubscribe",
+                "type": "FOOTER"
+            },
+            {
+                "buttons": [
+                    {
+                        "text": "Connect to Agronomist",
+                        "type": "QUICK_REPLY"
+                    }
+                ],
+                "type": "BUTTONS"
+            }
+        ]
 
         mock_bsp_auth_token.return_value = "kdjfnskjksjfksjf"
         url = f"http://localhost:5001/api/events/execute/{EventClass.message_broadcast}?is_scheduled=False"
@@ -1748,8 +1782,11 @@ class TestEventExecution:
             json={"waba_templates": [
                 {"category": "MARKETING", "components": template, "name": "agronomy_support", "language": "hi"}]}
         )
-        mock_channel_config.return_value = {"config": {"access_token": "shjkjhrefdfghjkl", "from_phone_number_id": "918958030415", "waba_account_id": "asdfghjk"}}
-        mock_get_bot_settings.return_value = {"whatsapp": "360dialog", "notification_scheduling_limit": 10, "dynamic_broadcast_execution_timeout": 21600}
+        mock_channel_config.return_value = {
+            "config": {"access_token": "shjkjhrefdfghjkl", "from_phone_number_id": "918958030415",
+                       "waba_account_id": "asdfghjk"}}
+        mock_get_bot_settings.return_value = {"whatsapp": "360dialog", "notification_scheduling_limit": 10,
+                                              "dynamic_broadcast_execution_timeout": 21600}
         mock_send.return_value = {"contacts": [{"input": "+55123456789", "status": "valid", "wa_id": "55123456789"}]}
 
         with patch.dict(Utility.environment["channels"]["360dialog"], {"partner_id": "sdfghjkjhgfddfghj"}):
@@ -1768,7 +1805,7 @@ class TestEventExecution:
         history[0].pop("conversation_id")
         assert history == [{
             'type': 'broadcast', 'sender_id': '918958030541',
-            'data': {'name': 'agronomy_support', 'template': template, 'template_params': [{'body': 'Udit Pandey'}],}}]
+            'data': {'name': 'agronomy_support', 'template': template, 'template_params': [{'body': 'Udit Pandey'}], }}]
 
         assert len(logs[0]) == logs[1] == 2
         logs[0][1].pop("timestamp")
@@ -1813,7 +1850,7 @@ class TestEventExecution:
     @patch("kairon.shared.chat.processor.ChatDataProcessor.get_channel_config")
     @patch("kairon.shared.utils.Utility.is_exist", autospec=True)
     def test_execute_message_broadcast_with_pyscript(self, mock_is_exist, mock_channel_config,
-                                                           mock_get_bot_settings, mock_send, mock_get_partner_auth_token):
+                                                     mock_get_bot_settings, mock_send, mock_get_partner_auth_token):
         bot = 'test_execute_message_broadcast_with_pyscript'
         user = 'test_user'
         script = """
@@ -1836,29 +1873,29 @@ class TestEventExecution:
             "pyscript": script
         }
         template = [
-                {
-                    "format": "TEXT",
-                    "text": "Kisan Suvidha Program Follow-up",
-                    "type": "HEADER"
-                },
-                {
-                    "text": "Hello! As a part of our Kisan Suvidha program, I am dedicated to supporting farmers like you in maximizing your crop productivity and overall yield.\n\nI wanted to reach out to inquire if you require any assistance with your current farming activities. Our team of experts, including our skilled agronomists, are here to lend a helping hand wherever needed.",
-                    "type": "BODY"
-                },
-                {
-                    "text": "reply with STOP to unsubscribe",
-                    "type": "FOOTER"
-                },
-                {
-                    "buttons": [
-                        {
-                            "text": "Connect to Agronomist",
-                            "type": "QUICK_REPLY"
-                        }
-                    ],
-                    "type": "BUTTONS"
-                }
-            ]
+            {
+                "format": "TEXT",
+                "text": "Kisan Suvidha Program Follow-up",
+                "type": "HEADER"
+            },
+            {
+                "text": "Hello! As a part of our Kisan Suvidha program, I am dedicated to supporting farmers like you in maximizing your crop productivity and overall yield.\n\nI wanted to reach out to inquire if you require any assistance with your current farming activities. Our team of experts, including our skilled agronomists, are here to lend a helping hand wherever needed.",
+                "type": "BODY"
+            },
+            {
+                "text": "reply with STOP to unsubscribe",
+                "type": "FOOTER"
+            },
+            {
+                "buttons": [
+                    {
+                        "text": "Connect to Agronomist",
+                        "type": "QUICK_REPLY"
+                    }
+                ],
+                "type": "BUTTONS"
+            }
+        ]
 
         url = f"http://localhost:5001/api/events/execute/{EventClass.message_broadcast}?is_scheduled=False"
         template_url = 'https://hub.360dialog.io/api/v2/partners/sdfghjkjhgfddfghj/waba_accounts/asdfghjk/waba_templates?filters={"business_templates.name": "brochure_pdf"}&sort=business_templates.name'
@@ -1878,9 +1915,11 @@ class TestEventExecution:
                 {"category": "MARKETING", "components": template, "name": "brochure_pdf", "language": "hi"}]}
         )
 
-        mock_get_bot_settings.return_value = {"whatsapp": "360dialog", "notification_scheduling_limit": 4, "dynamic_broadcast_execution_timeout": 21600}
+        mock_get_bot_settings.return_value = {"whatsapp": "360dialog", "notification_scheduling_limit": 4,
+                                              "dynamic_broadcast_execution_timeout": 21600}
         mock_channel_config.return_value = {
-            "config": {"access_token": "shjkjhrefdfghjkl", "from_phone_number_id": "918958030415", "waba_account_id": "asdfghjk"}}
+            "config": {"access_token": "shjkjhrefdfghjkl", "from_phone_number_id": "918958030415",
+                       "waba_account_id": "asdfghjk"}}
         mock_send.return_value = {"contacts": [{"input": "+55123456789", "status": "valid", "wa_id": "55123456789"}]}
         mock_get_partner_auth_token.return_value = None
 
@@ -1932,12 +1971,12 @@ class TestEventExecution:
         [log.pop("timestamp") for log in logs[0]]
         reference_id = logs[0][0].get("reference_id")
         expected_logs = [{'reference_id': reference_id, 'log_type': 'common', 'bot': bot, 'status': 'Completed',
-             'user': 'test_user', 'broadcast_id': event_id, 'failure_cnt': 0, 'total': 0,
-             'components': [{'type': 'header', 'parameters': [{'type': 'document', 'document': {
-                 'link': 'https://drive.google.com/uc?export=download&id=1GXQ43jilSDelRvy1kr3PNNpl1e21dRXm',
-                 'filename': 'Brochure.pdf'}}]}], 'i': 0, 'contact': '876543212345',
-             'api_response': {'contacts': ['9876543210', '876543212345']},
-             'resp': {'contacts': [{'input': '+55123456789', 'status': 'valid', 'wa_id': '55123456789'}]}}]
+                          'user': 'test_user', 'broadcast_id': event_id, 'failure_cnt': 0, 'total': 0,
+                          'components': [{'type': 'header', 'parameters': [{'type': 'document', 'document': {
+                              'link': 'https://drive.google.com/uc?export=download&id=1GXQ43jilSDelRvy1kr3PNNpl1e21dRXm',
+                              'filename': 'Brochure.pdf'}}]}], 'i': 0, 'contact': '876543212345',
+                          'api_response': {'contacts': ['9876543210', '876543212345']},
+                          'resp': {'contacts': [{'input': '+55123456789', 'status': 'valid', 'wa_id': '55123456789'}]}}]
         for log in logs[0]:
             if log.get("config"):
                 logged_config = log.pop("config")
@@ -1964,7 +2003,8 @@ class TestEventExecution:
     @patch("kairon.shared.data.processor.MongoProcessor.get_bot_settings")
     @patch("kairon.shared.chat.processor.ChatDataProcessor.get_channel_config")
     @patch("kairon.shared.utils.Utility.is_exist", autospec=True)
-    def test_execute_message_broadcast_with_pyscript_failure(self, mock_is_exist, mock_channel_config, mock_get_bot_settings):
+    def test_execute_message_broadcast_with_pyscript_failure(self, mock_is_exist, mock_channel_config,
+                                                             mock_get_bot_settings):
         bot = 'test_execute_message_broadcast_with_pyscript_failure'
         user = 'test_user'
         script = """
@@ -1984,7 +2024,8 @@ class TestEventExecution:
             json={"message": "Event Triggered!", "success": True, "error_code": 0, "data": None}
         )
 
-        mock_get_bot_settings.return_value = {"whatsapp": "360dialog", "notification_scheduling_limit": 4, "dynamic_broadcast_execution_timeout": 21600}
+        mock_get_bot_settings.return_value = {"whatsapp": "360dialog", "notification_scheduling_limit": 4,
+                                              "dynamic_broadcast_execution_timeout": 21600}
         mock_channel_config.return_value = {
             "config": {"access_token": "shjkjhrefdfghjkl", "from_phone_number_id": "918958030415"}}
 
@@ -2039,7 +2080,8 @@ class TestEventExecution:
             json={"message": "Event Triggered!", "success": True, "error_code": 0, "data": None}
         )
 
-        mock_get_bot_settings.return_value = {"whatsapp": "360dialog", "notification_scheduling_limit": 4, "dynamic_broadcast_execution_timeout": 1}
+        mock_get_bot_settings.return_value = {"whatsapp": "360dialog", "notification_scheduling_limit": 4,
+                                              "dynamic_broadcast_execution_timeout": 1}
         mock_channel_config.return_value = {
             "config": {"access_token": "shjkjhrefdfghjkl", "from_phone_number_id": "918958030415"}}
 

--- a/tests/unit_test/events/events_test.py
+++ b/tests/unit_test/events/events_test.py
@@ -32,7 +32,7 @@ from kairon.events.definitions.history_delete import DeleteHistoryEvent
 from kairon.events.definitions.model_testing import ModelTestingEvent
 from kairon.events.definitions.model_training import ModelTrainingEvent
 from kairon.exceptions import AppException
-from kairon.shared.constants import EventClass, EventRequestType
+from kairon.shared.constants import EventClass, EventRequestType, ChannelTypes
 from kairon.shared.data.constant import EVENT_STATUS, REQUIREMENTS
 from kairon.shared.data.data_objects import Configs, BotSettings
 from kairon.shared.data.history_log_processor import HistoryDeletionLogProcessor
@@ -1287,9 +1287,8 @@ class TestEventExecution:
                     'details': "Failed to send message because this user's phone number is part of an experiment"},
                  'href': 'https://developers.facebook.com/docs/whatsapp/cloud-api/support/error-codes/'}]}
         assert ChannelLogs.objects(bot=bot, message_id='wamid.HBgLMTIxMTU1NTc5NDcVAgARGBIyRkQxREUxRDJFQUJGMkQ3NDIZ').get().campaign_id == reference_id
-        result = MessageBroadcastProcessor.get_channel_logs_count(bot)
-        print(result)
-        assert result == [{'status': 'Failed', 'campaign_id': reference_id, 'cnt': 1}]
+        result = MessageBroadcastProcessor.get_channel_metrics(ChannelTypes.WHATSAPP.value, bot)
+        assert result == [{'status': 'Failed', 'campaign_id': reference_id, 'count': 1}]
 
     @responses.activate
     @mongomock.patch(servers=(('localhost', 27017),))


### PR DESCRIPTION
1. Added rest api to fetch the count of each status in ChannelLogs for Campaign Analytics.
2. Added unit and integration test cases.