### PR TITLE
GBM Private key fix

### DIFF
--- a/kairon/shared/chat/processor.py
+++ b/kairon/shared/chat/processor.py
@@ -23,6 +23,9 @@ class ChatDataProcessor:
         :return: None
         """
         primary_slack_config_changed = False
+        private_key = configuration['config'].get('private_key', None)
+        if configuration['connector_type'] == ChannelTypes.BUSINESS_MESSAGES.value and private_key:
+            configuration['config']['private_key'] = private_key.replace("\\n", "\n")
         try:
             filter_args = ChatDataProcessor.__attach_metadata_and_get_filter(configuration, bot)
             channel = Channels.objects(**filter_args).get()

--- a/tests/unit_test/chat/chat_test.py
+++ b/tests/unit_test/chat/chat_test.py
@@ -468,6 +468,34 @@ class TestChat:
         assert message is None
 
     @responses.activate
+    def test_save_channel_config_business_messages_with_invalid_private_key(self):
+        def __mock_endpoint(*args):
+            return f"https://test@test.com/api/bot/business_messages/tests/test"
+
+        with patch('kairon.shared.data.utils.DataUtility.get_channel_endpoint', __mock_endpoint):
+            channel_endpoint = ChatDataProcessor.save_channel_config(
+                {
+                    "connector_type": "business_messages",
+                    "config": {
+                        "type": "service_account",
+                        "private_key_id": "fa006e13b1e17eddf3990eede45ca6111eb74945",
+                        "private_key": "test_private_key\\n399045ca\\n6111eb74945",
+                        "client_email": "provider@gbc-mahesh.iam.testaccount.com",
+                        "client_id": "102056160806575769486"
+                    }
+                },
+                "test",
+                "test")
+            assert channel_endpoint == "https://test@test.com/api/bot/business_messages/tests/test"
+            business_messages_config = ChatDataProcessor.get_channel_config("business_messages",
+                                                                            "test")
+            assert business_messages_config['config'] == {'type': 'service_account',
+                                                          'private_key_id': 'fa006e13b1e17eddf3990eede45ca6111eb*****',
+                                                          'private_key': 'test_private_key\n399045ca\n6111eb*****',
+                                                          'client_email': 'provider@gbc-mahesh.iam.testaccoun*****',
+                                                          'client_id': '1020561608065757*****'}
+
+    @responses.activate
     def test_save_channel_config_business_messages(self):
         def __mock_endpoint(*args):
             return f"https://test@test.com/api/bot/business_messages/tests/test"


### PR DESCRIPTION
GBM private_key issue fixed and added test case related to that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the channel configuration process to handle specific conditions for the `private_key` more effectively.

- **Tests**
	- Updated unit tests for channel configuration to cover scenarios with invalid `private_key`.
	- Improved session history test assertions for better validation of chat sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->