### PR TITLE
Manage Flows

### DIFF
--- a/kairon/api/app/routers/bot/channels.py
+++ b/kairon/api/app/routers/bot/channels.py
@@ -155,6 +155,36 @@ async def preview_whatsapp_flow(
     return Response(data=response)
 
 
+@router.get("/whatsapp/flows/{bsp_type}/{flow_id}/assets", response_model=Response)
+async def get_whatsapp_flow_assets(
+        flow_id: str = Path(default=None, description="flow id", example="594425479261596"),
+        bsp_type: str = Path(default=None, description="Business service provider type",
+                             example=WhatsappBSPTypes.bsp_360dialog.value),
+        current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS)
+):
+    """
+    Returns all assets attached to a specified flow with this endpoint.
+    """
+    provider = BusinessServiceProviderFactory.get_instance(bsp_type)(current_user.get_bot(), current_user.get_user())
+    response = provider.get_whatsapp_flow_assets(flow_id)
+    return Response(data=response)
+
+
+@router.post("/whatsapp/flows/{bsp_type}/{flow_id}/deprecate", response_model=Response)
+async def deprecate_whatsapp_flow(
+        flow_id: str = Path(default=None, description="flow id", example="594425479261596"),
+        bsp_type: str = Path(default=None, description="Business service provider type",
+                             example=WhatsappBSPTypes.bsp_360dialog.value),
+        current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS)
+):
+    """
+    Flow can be deprecated with this endpoint.
+    """
+    provider = BusinessServiceProviderFactory.get_instance(bsp_type)(current_user.get_bot(), current_user.get_user())
+    response = provider.deprecate_whatsapp_flow(flow_id)
+    return Response(data=response)
+
+
 @router.get("/whatsapp/flows/{bsp_type}", response_model=Response)
 async def retrieve_whatsapp_flows(
         request: Request,

--- a/kairon/shared/channels/whatsapp/bsp/dialog360.py
+++ b/kairon/shared/channels/whatsapp/bsp/dialog360.py
@@ -140,6 +140,30 @@ class BSP360Dialog(WhatsappBusinessServiceProviderBase):
             logger.exception(e)
             raise AppException("Channel not found!")
 
+    def get_whatsapp_flow_assets(self, flow_id: str):
+        try:
+            base_url, flow_endpoint = self.get_flow_endpoint_url()
+            headers = {"Authorization": BSP360Dialog.get_partner_auth_token()}
+            url = f"{base_url}{flow_endpoint}/{flow_id}/assets"
+            resp = Utility.execute_http_request(request_method="GET", http_url=url, headers=headers,
+                                                validate_status=True, err_msg="Failed to get flow assets: ")
+            return resp
+        except DoesNotExist as e:
+            logger.exception(e)
+            raise AppException("Channel not found!")
+
+    def deprecate_whatsapp_flow(self, flow_id: str):
+        try:
+            base_url, flow_endpoint = self.get_flow_endpoint_url()
+            headers = {"Authorization": BSP360Dialog.get_partner_auth_token()}
+            url = f"{base_url}{flow_endpoint}/{flow_id}/deprecate"
+            resp = Utility.execute_http_request(request_method="POST", http_url=url, headers=headers,
+                                                validate_status=True, err_msg="Failed to deprecate flow: ")
+            return resp
+        except DoesNotExist as e:
+            logger.exception(e)
+            raise AppException("Channel not found!")
+
     def list_whatsapp_flows(self, **kwargs):
         fields = kwargs.get("fields")
 

--- a/kairon/shared/constants.py
+++ b/kairon/shared/constants.py
@@ -59,6 +59,7 @@ class UserActivityType(str, Enum):
     invalid_login = 'invalid_login'
     download = "download"
     template_creation = 'template_creation'
+    flow_creation = "flow_creation"
     model_reload = "model_reload"
 
 
@@ -124,6 +125,17 @@ class ElementTypes(str, Enum):
 
 class WhatsappBSPTypes(str, Enum):
     bsp_360dialog = "360dialog"
+
+
+class FlowCategories(str, Enum):
+    SIGN_UP = "SIGN_UP"
+    SIGN_IN = "SIGN_IN"
+    APPOINTMENT_BOOKING = "APPOINTMENT_BOOKING"
+    LEAD_GENERATION = "LEAD_GENERATION"
+    CONTACT_US = "CONTACT_US"
+    CUSTOMER_SUPPORT = "CUSTOMER_SUPPORT"
+    SURVEY = "SURVEY"
+    OTHER = "OTHER"
 
 
 class GPT3ResourceTypes(str, Enum):

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -14252,6 +14252,34 @@ def test_publish_whatsapp_flow_error(mock_get_partner_auth_token):
     assert actual["data"] is None
 
 
+@patch("kairon.shared.channels.whatsapp.bsp.dialog360.BSP360Dialog.get_partner_auth_token", autospec=True)
+def test_get_whatsapp_flow_assets_error(mock_get_partner_auth_token):
+    mock_get_partner_auth_token.return_value = "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+    response = client.get(
+        f"/api/bot/{pytest.bot}/channels/whatsapp/flows/360dialog/test_flow_id/assets",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+    assert actual["message"] == "Channel not found!"
+    assert actual["data"] is None
+
+
+@patch("kairon.shared.channels.whatsapp.bsp.dialog360.BSP360Dialog.get_partner_auth_token", autospec=True)
+def test_deprecate_whatsapp_flow_error(mock_get_partner_auth_token):
+    mock_get_partner_auth_token.return_value = "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+    response = client.post(
+        f"/api/bot/{pytest.bot}/channels/whatsapp/flows/360dialog/test_flow_id/deprecate",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+    assert actual["message"] == "Channel not found!"
+    assert actual["data"] is None
+
+
 def test_get_channel_logs():
     from kairon.shared.chat.data_objects import ChannelLogs
     ChannelLogs(
@@ -14695,6 +14723,54 @@ def test_publish_whatsapp_flow(mock_publish_flow):
 
     response = client.post(
         f"/api/bot/{pytest.bot}/channels/whatsapp/flows/360dialog/test_flow_id/publish",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["data"] == api_response
+
+
+@patch("kairon.shared.channels.whatsapp.bsp.dialog360.BSP360Dialog.get_whatsapp_flow_assets", autospec=True)
+def test_get_whatsapp_flow_assets(mock_get_whatsapp_flow_assets):
+    data = {
+        "name": "flow with multiple categories",
+        "categories": ["APPOINTMENT_BOOKING", "OTHER", "SURVEY"]
+    }
+    api_response = {
+        "assets": [
+            {
+                "asset_type": "FLOW_JSON",
+                "download_url": "https://mmg.whatsapp.net/m1/v/t24/An8n-Ot0L5sxj8lupzxfUTfHYhsdsdsdsRyqAZRySBcATvtUGgPjP76UJKS0wMopyj6SNTmNmf_F1pLAt04wbP3B9kFCIpvy7oOG6CM3HK4wFY61Z7TiLDxjGvzEgXjdog6A?ccb=10-5&oh=01_AdTq_Njj-foFgD0-KlMXq4AbdhrqLoNm6_CtlsxZxC03rA&oe=65F414CD&_nc_sid=471a72",
+                "name": "flow.json"
+            }
+        ],
+        "count": 1,
+        "total": 1
+    }
+    mock_get_whatsapp_flow_assets.return_value = api_response
+
+    response = client.get(
+        f"/api/bot/{pytest.bot}/channels/whatsapp/flows/360dialog/test_flow_id/assets",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["data"] == api_response
+
+
+@patch("kairon.shared.channels.whatsapp.bsp.dialog360.BSP360Dialog.deprecate_whatsapp_flow", autospec=True)
+def test_deprecate_whatsapp_flow(mock_deprecate_whatsapp_flow):
+    data = {
+        "name": "flow with multiple categories",
+        "categories": ["APPOINTMENT_BOOKING", "OTHER", "SURVEY"]
+    }
+    api_response = {"success": True}
+    mock_deprecate_whatsapp_flow.return_value = api_response
+
+    response = client.post(
+        f"/api/bot/{pytest.bot}/channels/whatsapp/flows/360dialog/test_flow_id/deprecate",
         headers={"Authorization": pytest.token_type + " " + pytest.access_token},
     )
     actual = response.json()

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -14155,6 +14155,103 @@ def test_list_whatsapp_templates_error():
     assert actual["message"] == "Channel not found!"
 
 
+@patch("kairon.shared.channels.whatsapp.bsp.dialog360.BSP360Dialog.get_partner_auth_token", autospec=True)
+def test_add_whatsapp_flow_error(mock_get_partner_auth_token):
+    mock_get_partner_auth_token.return_value = "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+    data = {
+        "name": "flow with multiple categories",
+        "categories": ["APPOINTMENT_BOOKING", "OTHER", "SURVEY"]
+    }
+    response = client.post(
+        f"/api/bot/{pytest.bot}/channels/whatsapp/flows/360dialog",
+        json={'data': data},
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+    assert actual["message"] == "Channel not found!"
+    assert actual["data"] is None
+
+
+@patch("kairon.shared.channels.whatsapp.bsp.dialog360.BSP360Dialog.get_partner_auth_token", autospec=True)
+def test_edit_whatsapp_flow_error(mock_get_partner_auth_token):
+    mock_get_partner_auth_token.return_value = "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+    data = {
+        "name": "flow.json",
+        "asset_type": "FLOW_JSON",
+    }
+    response = client.post(
+        f"/api/bot/{pytest.bot}/channels/whatsapp/flows/360dialog/test_flow_id",
+        json=data,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+        files={"file": (
+            "tests/testing_data/flow/sample_flow.json",
+            open("tests/testing_data/flow/sample_flow.json", "rb"))}
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+    assert actual["message"] == "Channel not found!"
+    assert actual["data"] is None
+
+
+@patch("kairon.shared.channels.whatsapp.bsp.dialog360.BSP360Dialog.get_partner_auth_token", autospec=True)
+def test_preview_whatsapp_flow_error(mock_get_partner_auth_token):
+    mock_get_partner_auth_token.return_value = "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+    response = client.get(
+        f"/api/bot/{pytest.bot}/channels/whatsapp/flows/360dialog/test_flow_id",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+    assert actual["message"] == "Channel not found!"
+    assert actual["data"] is None
+
+
+@patch("kairon.shared.channels.whatsapp.bsp.dialog360.BSP360Dialog.get_partner_auth_token", autospec=True)
+def test_retrieve_whatsapp_flows_error(mock_get_partner_auth_token):
+    mock_get_partner_auth_token.return_value = "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+    response = client.get(
+        f"/api/bot/{pytest.bot}/channels/whatsapp/flows/360dialog",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+    assert actual["message"] == "Channel not found!"
+    assert actual["data"] is None
+
+
+@patch("kairon.shared.channels.whatsapp.bsp.dialog360.BSP360Dialog.get_partner_auth_token", autospec=True)
+def test_delete_whatsapp_flow_error(mock_get_partner_auth_token):
+    mock_get_partner_auth_token.return_value = "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+    response = client.delete(
+        f"/api/bot/{pytest.bot}/channels/whatsapp/flows/360dialog/test_flow_id",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+    assert actual["message"] == "Channel not found!"
+    assert actual["data"] is None
+
+
+@patch("kairon.shared.channels.whatsapp.bsp.dialog360.BSP360Dialog.get_partner_auth_token", autospec=True)
+def test_publish_whatsapp_flow_error(mock_get_partner_auth_token):
+    mock_get_partner_auth_token.return_value = "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+    response = client.post(
+        f"/api/bot/{pytest.bot}/channels/whatsapp/flows/360dialog/test_flow_id/publish",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+    assert actual["message"] == "Channel not found!"
+    assert actual["data"] is None
+
+
 def test_get_channel_logs():
     from kairon.shared.chat.data_objects import ChannelLogs
     ChannelLogs(
@@ -14465,6 +14562,145 @@ def test_list_templates(mock_list_templates):
     assert actual["success"]
     assert actual["error_code"] == 0
     assert actual["data"]["templates"] == api_resp["waba_templates"]
+
+
+@patch("kairon.shared.channels.whatsapp.bsp.dialog360.BSP360Dialog.add_whatsapp_flow", autospec=True)
+def test_add_whatsapp_flow(mock_add_whatsapp_flow):
+    data = {
+        "name": "flow with multiple categories",
+        "categories": ["APPOINTMENT_BOOKING", "OTHER", "SURVEY"]
+    }
+    api_resp = {
+        "id": "594425479261596",
+    }
+    mock_add_whatsapp_flow.return_value = api_resp
+
+    response = client.post(
+        f"/api/bot/{pytest.bot}/channels/whatsapp/flows/360dialog",
+        json={'data': data},
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["data"] == {'id': '594425479261596'}
+
+
+@patch("kairon.shared.channels.whatsapp.bsp.dialog360.BSP360Dialog.edit_whatsapp_flow", autospec=True)
+def test_edit_whatsapp_flow(mock_edit_whatsapp_flow):
+    data = {
+        "name": "flow with multiple categories",
+        "categories": ["APPOINTMENT_BOOKING", "OTHER", "SURVEY"]
+    }
+    api_resp = {
+        "success": True,
+        "validation_errors": []
+    }
+    mock_edit_whatsapp_flow.return_value = api_resp
+
+    response = client.post(
+        f"/api/bot/{pytest.bot}/channels/whatsapp/flows/360dialog/test_flow_id",
+        json=data,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+        files={"file": (
+            "tests/testing_data/flow/sample_flow.json",
+            open("tests/testing_data/flow/sample_flow.json", "rb"))}
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["data"] == api_resp
+
+
+@patch("kairon.shared.channels.whatsapp.bsp.dialog360.BSP360Dialog.preview_whatsapp_flow", autospec=True)
+def test_preview_whatsapp_flow(mock_preview_whatsapp_flow):
+    data = {
+        "name": "flow with multiple categories",
+        "categories": ["APPOINTMENT_BOOKING", "OTHER", "SURVEY"]
+    }
+    api_response = {
+        "id": "9070429474112345",
+        "preview": {
+            "expires_at": "2024-02-29T06:35:40+0000",
+            "preview_url": "https://business.facebook.com/wa/manage/flows/9070429474112345/preview/?token=ec58dcaa-dd30-4fee-a8a7-3d7e297ac3c9"
+        }
+    }
+    mock_preview_whatsapp_flow.return_value = api_response
+
+    response = client.get(
+        f"/api/bot/{pytest.bot}/channels/whatsapp/flows/360dialog/test_flow_id",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["data"] == api_response
+
+
+@patch("kairon.shared.channels.whatsapp.bsp.dialog360.BSP360Dialog.list_whatsapp_flows", autospec=True)
+def test_retrieve_whatsapp_flows(mock_list_whatsapp_flows):
+    data = {
+        "name": "flow with multiple categories",
+        "categories": ["APPOINTMENT_BOOKING", "OTHER", "SURVEY"]
+    }
+    api_response = [
+        {
+            "id": "9070429474112345",
+            "name": "flow with multiple categories"
+        },
+        {
+            "id": "5432129474112345",
+            "name": "my first flow"
+        }
+    ]
+    mock_list_whatsapp_flows.return_value = api_response
+
+    response = client.get(
+        f"/api/bot/{pytest.bot}/channels/whatsapp/flows/360dialog",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["data"]['flows'] == api_response
+
+
+@patch("kairon.shared.channels.whatsapp.bsp.dialog360.BSP360Dialog.delete_flow", autospec=True)
+def test_delete_whatsapp_flow(mock_delete_flow):
+    data = {
+        "name": "flow with multiple categories",
+        "categories": ["APPOINTMENT_BOOKING", "OTHER", "SURVEY"]
+    }
+    api_response = {"success": True}
+    mock_delete_flow.return_value = api_response
+
+    response = client.delete(
+        f"/api/bot/{pytest.bot}/channels/whatsapp/flows/360dialog/test_flow_id",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["data"] == api_response
+
+
+@patch("kairon.shared.channels.whatsapp.bsp.dialog360.BSP360Dialog.publish_flow", autospec=True)
+def test_publish_whatsapp_flow(mock_publish_flow):
+    data = {
+        "name": "flow with multiple categories",
+        "categories": ["APPOINTMENT_BOOKING", "OTHER", "SURVEY"]
+    }
+    api_response = {"success": True}
+    mock_publish_flow.return_value = api_response
+
+    response = client.post(
+        f"/api/bot/{pytest.bot}/channels/whatsapp/flows/360dialog/test_flow_id/publish",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["data"] == api_response
 
 
 def test_get_channel_endpoint(monkeypatch):

--- a/tests/testing_data/flow/sample_flow.json
+++ b/tests/testing_data/flow/sample_flow.json
@@ -1,0 +1,205 @@
+{
+    "version": "3.0",
+    "screens": [
+        {
+            "id": "ADDRESS",
+            "title": "Address",
+            "data": {},
+            "layout": {
+                "type": "SingleColumnLayout",
+                "children": [
+                    {
+                        "type": "Form",
+                        "name": "form",
+                        "children": [
+                            {
+                                "type": "TextHeading",
+                                "text": "Please Enter Your Details!"
+                            },
+                            {
+                                "type": "TextBody",
+                                "text": "First, we'll need a few details from you."
+                            },
+                            {
+                                "type": "TextInput",
+                                "name": "firstName",
+                                "label": "First Name",
+                                "input-type": "text",
+                                "required": true
+                            },
+                            {
+                                "type": "TextInput",
+                                "label": "Last Name",
+                                "name": "lastName",
+                                "input-type": "text",
+                                "required": true
+                            },
+                            {
+                                "type": "TextInput",
+                                "label": "Email Address",
+                                "name": "email",
+                                "input-type": "email",
+                                "required": true
+                            },
+                            {
+                                "type": "DatePicker",
+                                "label": "Date of Birth",
+                                "name": "dateOfBirth",
+                                "required": true
+                            },
+                            {
+                                "type": "TextInput",
+                                "label": "House Number",
+                                "name": "houseNumber",
+                                "input-type": "text",
+                                "required": true
+                            },
+                            {
+                                "type": "TextInput",
+                                "label": "Landmark",
+                                "name": "landmark",
+                                "input-type": "text",
+                                "required": true
+                            },
+                            {
+                                "type": "TextInput",
+                                "label": "District",
+                                "name": "district",
+                                "input-type": "text",
+                                "required": true
+                            },
+                            {
+                                "type": "TextInput",
+                                "label": "Pincode",
+                                "name": "pincode",
+                                "input-type": "text",
+                                "required": true
+                            },
+                            {
+                                "type": "Footer",
+                                "label": "Continue to survey",
+                                "on-click-action": {
+                                    "name": "navigate",
+                                    "next": {
+                                        "type": "screen",
+                                        "name": "SURVEY"
+                                    },
+                                    "payload": {
+                                        "firstName": "${form.firstName}",
+                                        "lastName": "${form.lastName}",
+                                        "email": "${form.email}",
+                                        "dateOfBirth": "${form.dateOfBirth}",
+                                        "houseNumber": "${form.houseNumber}",
+                                        "landmark": "${form.landmark}",
+                                        "district": "${form.district}",
+                                        "pincode": "${form.pincode}"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "id": "SURVEY",
+            "title": "Thank you",
+            "data": {
+                "firstName": {
+                    "type": "string",
+                    "__example__": "Example"
+                },
+                "lastName": {
+                    "type": "string",
+                    "__example__": "Example"
+                },
+                "email": {
+                    "type": "string",
+                    "__example__": "Example"
+                },
+                "dateOfBirth": {
+                    "type": "string",
+                    "__example__": "Example"
+                },
+                "houseNumber": {
+                    "type": "string",
+                    "__example__": "Example"
+                },
+                "landmark": {
+                    "type": "string",
+                    "__example__": "Example"
+                },
+                "district": {
+                    "type": "string",
+                    "__example__": "Example"
+                },
+                "pincode": {
+                    "type": "string",
+                    "__example__": "Example"
+                }
+            },
+            "terminal": true,
+            "layout": {
+                "type": "SingleColumnLayout",
+                "children": [
+                    {
+                        "type": "Form",
+                        "name": "form",
+                        "children": [
+                            {
+                                "type": "TextHeading",
+                                "text": "Before you go"
+                            },
+                            {
+                                "type": "TextBody",
+                                "text": "How did you hear about us?"
+                            },
+                            {
+                                "type": "RadioButtonsGroup",
+                                "label": "Choose one",
+                                "required": false,
+                                "name": "source",
+                                "data-source": [
+                                    {
+                                        "id": "FRIEND_RECOMMENDATION",
+                                        "title": "Friend's recommendation"
+                                    },
+                                    {
+                                        "id": "TV_ADVERTISEMENT",
+                                        "title": "TV advertisement"
+                                    },
+                                    {
+                                        "id": "SEARCH_ENGINE",
+                                        "title": "Search engine"
+                                    },
+                                    {
+                                        "id": "SOCIAL_MEDIA",
+                                        "title": "Social media"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "Footer",
+                                "label": "Next",
+                                "on-click-action": {
+                                    "name": "complete",
+                                    "payload": {
+                                        "source": "${form.source}",
+                                        "firstName": "${data.firstName}",
+                                        "lastName": "${data.lastName}",
+                                        "email": "${data.email}",
+                                        "dateOfBirth": "${data.dateOfBirth}",
+                                        "houseNumber": "${data.houseNumber}",
+                                        "landmark": "${data.landmark}",
+                                        "district": "${data.district}",
+                                        "pincode": "${data.pincode}"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tests/unit_test/channels/bsp_test.py
+++ b/tests/unit_test/channels/bsp_test.py
@@ -292,6 +292,398 @@ class TestBusinessServiceProvider:
                                     'api_key': 'kHCwksdsdsMVYVx0doabaDyRLUQJUAK', 'waba_account_id': 'Cyih7GWA'}
 
     @responses.activate
+    def test_add_whatsapp_flow_with_missing_keys(self):
+        bot = "62bc24b493a0d6b7a46328ff"
+        data = {
+            "name": "flow with multiple categories",
+            "clone_flow_id": "9070429474112345"
+        }
+        with pytest.raises(AppException, match="Missing categories in request body!"):
+            BSP360Dialog(bot, "test").add_whatsapp_flow(data, bot, "test")
+
+    @responses.activate
+    def test_add_whatsapp_flow_with_invalid_category(self):
+        bot = "62bc24b493a0d6b7a46328ff"
+        data = {
+            "name": "flow with multiple categories",
+            "categories": ["APPOINTMENT_BOOKING", "OTHER", "SURVEY", "FLOW"]
+        }
+        with pytest.raises(AppException, match="Invalid categories FLOW in request body!"):
+            BSP360Dialog(bot, "test").add_whatsapp_flow(data, bot, "test")
+
+    def test_add_whatsapp_flow_error(self):
+        bot = "62bc24b493a0d6b7a46328fg"
+        data = {
+            "name": "flow with multiple categories",
+            "categories": ["APPOINTMENT_BOOKING", "OTHER", "SURVEY"]
+        }
+
+        with pytest.raises(AppException, match="Channel not found!"):
+            BSP360Dialog(bot, "user").add_whatsapp_flow(data, bot, "user")
+
+    @responses.activate
+    def test_add_whatsapp_flow_failure(self, monkeypatch):
+        with mock.patch.dict(Utility.environment, {'channels': {"360dialog": {"partner_id": "new_partner_id"}}}):
+            bot = "62bc24b493a0d6b7a46328ff"
+            partner_id = "new_partner_id"
+            waba_account_id = "Cyih7GWA"
+            data = {
+                "name": "flow with multiple categories",
+                "categories": ["APPOINTMENT_BOOKING", "OTHER", "SURVEY"]
+            }
+            def _get_partners_auth_token(*args, **kwargs):
+                return "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+
+            monkeypatch.setattr(BSP360Dialog, 'get_partner_auth_token', _get_partners_auth_token)
+            base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"]["hub_base_url"]
+            url = f"{base_url}/api/v2/partners/{partner_id}/waba_accounts/{waba_account_id}/flows"
+            responses.add("POST", json={}, url=url, status=500)
+
+            with pytest.raises(AppException, match=r"Failed to add flow: *"):
+                BSP360Dialog(bot, "user").add_whatsapp_flow(data, bot, "user")
+
+    @responses.activate
+    def test_add_whatsapp_flow(self, monkeypatch):
+        with mock.patch.dict(Utility.environment, {'channels': {"360dialog": {"partner_id": "new_partner_id"}}}):
+            responses.reset()
+            bot = "62bc24b493a0d6b7a46328ff"
+            partner_id = "new_partner_id"
+            waba_account_id = "Cyih7GWA"
+            data = {
+                "name": "flow with multiple categories",
+                "categories": ["APPOINTMENT_BOOKING", "OTHER", "SURVEY"]
+            }
+            api_resp = {
+                "id": "9070429474112345"
+            }
+
+            def _get_partners_auth_token(*args, **kwargs):
+                return "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+
+            monkeypatch.setattr(BSP360Dialog, 'get_partner_auth_token', _get_partners_auth_token)
+
+            base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"]["hub_base_url"]
+            url = f"{base_url}/api/v2/partners/{partner_id}/waba_accounts/{waba_account_id}/flows"
+            responses.add("POST", json=api_resp, url=url, status=201)
+            flow_id = BSP360Dialog(bot, "test").add_whatsapp_flow(data, bot, "test")
+            assert flow_id == {'id': '9070429474112345'}
+            count = AuditLogData.objects(attributes=[{"key": "bot", "value": bot}], user="test", action="activity",
+                                         entity="flow_creation").count()
+            assert count == 1
+
+    @responses.activate
+    def test_edit_whatsapp_flow_channel_not_found(self):
+        from fastapi import UploadFile
+
+        bot = "62bc24b493a0d6b7a46328fg"
+        flow_id = "test_id"
+        file = UploadFile(filename="flow.json", file=(open("tests/testing_data/flow/sample_flow.json", "rb")))
+
+        with pytest.raises(AppException, match="Channel not found!"):
+            BSP360Dialog(bot, "user").edit_whatsapp_flow(flow_id=flow_id, file=file,
+                                                         asset_type="FLOW_JSON", name="flow.json")
+
+    @responses.activate
+    def test_edit_whatsapp_flow_failure(self, monkeypatch):
+        from fastapi import UploadFile
+
+        with mock.patch.dict(Utility.environment, {'channels': {"360dialog": {"partner_id": "new_partner_id"}}}):
+            bot = "62bc24b493a0d6b7a46328ff"
+            flow_id = "test_id"
+            partner_id = "new_partner_id"
+            waba_account_id = "Cyih7GWA"
+            file = UploadFile(filename="flow.json", file=(open("tests/testing_data/flow/sample_flow.json", "rb")))
+
+            def _get_partners_auth_token(*args, **kwargs):
+                return "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+
+            monkeypatch.setattr(BSP360Dialog, 'get_partner_auth_token', _get_partners_auth_token)
+            base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"][
+                "hub_base_url"]
+            url = f"{base_url}/api/v2/partners/{partner_id}/waba_accounts/{waba_account_id}/flows/{flow_id}/assets"
+            responses.add("POST", json={}, url=url, status=500)
+
+            with pytest.raises(AppException, match=r"Failed to edit flow: *"):
+                BSP360Dialog(bot, "user").edit_whatsapp_flow(flow_id=flow_id, file=file,
+                                                             asset_type="FLOW_JSON", name="flow.json")
+
+    @responses.activate
+    def test_edit_whatsapp_flow(self, monkeypatch):
+        from fastapi import UploadFile
+
+        with mock.patch.dict(Utility.environment, {'channels': {"360dialog": {"partner_id": "new_partner_id"}}}):
+            bot = "62bc24b493a0d6b7a46328ff"
+            flow_id = "test_id"
+            partner_id = "new_partner_id"
+            waba_account_id = "Cyih7GWA"
+            file = UploadFile(filename="flow.json", file=(open("tests/testing_data/flow/sample_flow.json", "rb")))
+            api_response = {
+                "success": True,
+                "validation_errors": []
+            }
+
+            def _get_partners_auth_token(*args, **kwargs):
+                return "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+
+            monkeypatch.setattr(BSP360Dialog, 'get_partner_auth_token', _get_partners_auth_token)
+            base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"][
+                "hub_base_url"]
+            url = f"{base_url}/api/v2/partners/{partner_id}/waba_accounts/{waba_account_id}/flows/{flow_id}/assets"
+            responses.add("POST", json=api_response, url=url)
+
+            response = BSP360Dialog(bot, "user").edit_whatsapp_flow(flow_id=flow_id, file=file,
+                                                         asset_type="FLOW_JSON", name="flow.json")
+            assert response == api_response
+
+    @responses.activate
+    def test_preview_whatsapp_flow_channel_not_found(self):
+        bot = "62bc24b493a0d6b7a46328fg"
+        flow_id = "test_id"
+
+        with pytest.raises(AppException, match="Channel not found!"):
+            BSP360Dialog(bot, "user").preview_whatsapp_flow(flow_id)
+
+    @responses.activate
+    def test_preview_whatsapp_flow_failure(self, monkeypatch):
+        with mock.patch.dict(Utility.environment, {'channels': {"360dialog": {"partner_id": "new_partner_id"}}}):
+            bot = "62bc24b493a0d6b7a46328ff"
+            flow_id = "test_id"
+            partner_id = "new_partner_id"
+            waba_account_id = "Cyih7GWA"
+
+            def _get_partners_auth_token(*args, **kwargs):
+                return "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+
+            monkeypatch.setattr(BSP360Dialog, 'get_partner_auth_token', _get_partners_auth_token)
+            base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"][
+                "hub_base_url"]
+            url = f"{base_url}/api/v2/partners/{partner_id}/waba_accounts/{waba_account_id}/flows/{flow_id}/preview"
+            responses.add("GET", json={}, url=url, status=500)
+
+            with pytest.raises(AppException, match=r"Failed to get flow: *"):
+                BSP360Dialog(bot, "user").preview_whatsapp_flow(flow_id)
+
+    @responses.activate
+    def test_preview_whatsapp_flow(self, monkeypatch):
+        with mock.patch.dict(Utility.environment, {'channels': {"360dialog": {"partner_id": "new_partner_id"}}}):
+            bot = "62bc24b493a0d6b7a46328ff"
+            flow_id = "test_id"
+            partner_id = "new_partner_id"
+            waba_account_id = "Cyih7GWA"
+            api_response = {
+                "id": "9070429474112345",
+                "preview": {
+                    "expires_at": "2024-02-29T06:35:40+0000",
+                    "preview_url": "https://business.facebook.com/wa/manage/flows/9070429474112345/preview/?token=ec58dcaa-dd30-4fee-a8a7-3d7e297ac3c9"
+                }
+            }
+
+            def _get_partners_auth_token(*args, **kwargs):
+                return "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+
+            monkeypatch.setattr(BSP360Dialog, 'get_partner_auth_token', _get_partners_auth_token)
+            base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"][
+                "hub_base_url"]
+            url = f"{base_url}/api/v2/partners/{partner_id}/waba_accounts/{waba_account_id}/flows/{flow_id}/preview"
+            responses.add("GET", json=api_response, url=url)
+            response = BSP360Dialog(bot, "user").preview_whatsapp_flow(flow_id)
+            assert response == api_response
+
+    @responses.activate
+    def test_list_whatsapp_flows_channel_not_found(self):
+        bot = "62bc24b493a0d6b7a46328fg"
+        flow_id = "test_id"
+
+        with pytest.raises(AppException, match="Channel not found!"):
+            BSP360Dialog(bot, "user").list_whatsapp_flows()
+
+    @responses.activate
+    def test_list_whatsapp_flows_failure(self, monkeypatch):
+        with mock.patch.dict(Utility.environment, {'channels': {"360dialog": {"partner_id": "new_partner_id"}}}):
+            bot = "62bc24b493a0d6b7a46328ff"
+            flow_id = "test_id"
+            partner_id = "new_partner_id"
+            waba_account_id = "Cyih7GWA"
+
+            def _get_partners_auth_token(*args, **kwargs):
+                return "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+
+            monkeypatch.setattr(BSP360Dialog, 'get_partner_auth_token', _get_partners_auth_token)
+            base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"][
+                "hub_base_url"]
+            url = f"{base_url}/api/v2/partners/{partner_id}/waba_accounts/{waba_account_id}/flows"
+            responses.add("GET", json={}, url=url, status=500)
+
+            with pytest.raises(AppException, match=r"Failed to get flows: *"):
+                BSP360Dialog(bot, "user").list_whatsapp_flows()
+
+    @responses.activate
+    def test_list_whatsapp_flows_with_query_params(self, monkeypatch):
+        with mock.patch.dict(Utility.environment, {'channels': {"360dialog": {"partner_id": "new_partner_id"}}}):
+            bot = "62bc24b493a0d6b7a46328ff"
+            flow_id = "test_id"
+            partner_id = "new_partner_id"
+            waba_account_id = "Cyih7GWA"
+            api_response = [
+                {
+                    "id": "9070429474112345",
+                    "name": "flow with multiple categories"
+                },
+                {
+                    "id": "5432129474112345",
+                    "name": "my first flow"
+                }
+            ]
+
+            def _get_partners_auth_token(*args, **kwargs):
+                return "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+
+            monkeypatch.setattr(BSP360Dialog, 'get_partner_auth_token', _get_partners_auth_token)
+            base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"][
+                "hub_base_url"]
+            url = f"{base_url}/api/v2/partners/{partner_id}/waba_accounts/{waba_account_id}/flows?fields=id,name"
+            responses.add("GET", json=api_response, url=url)
+            response = BSP360Dialog(bot, "user").list_whatsapp_flows(fields='id,name')
+            assert response == api_response
+
+    @responses.activate
+    def test_list_whatsapp_flows(self, monkeypatch):
+        with mock.patch.dict(Utility.environment, {'channels': {"360dialog": {"partner_id": "new_partner_id"}}}):
+            bot = "62bc24b493a0d6b7a46328ff"
+            flow_id = "test_id"
+            partner_id = "new_partner_id"
+            waba_account_id = "Cyih7GWA"
+            api_response = [
+                {
+                    "categories": [
+                        "APPOINTMENT_BOOKING",
+                        "OTHER",
+                        "SURVEY"
+                    ],
+                    "id": "9070429474112345",
+                    "name": "flow with multiple categories",
+                    "status": "DRAF",
+                    "validation_errors": []
+                },
+                {
+                    "categories": [
+                        "SIGN_UP"
+                    ],
+                    "id": "5432129474112345",
+                    "name": "my first flow",
+                    "status": "PUBLISHED",
+                    "validation_errors": []
+                }
+            ]
+
+            def _get_partners_auth_token(*args, **kwargs):
+                return "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+
+            monkeypatch.setattr(BSP360Dialog, 'get_partner_auth_token', _get_partners_auth_token)
+            base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"][
+                "hub_base_url"]
+            url = f"{base_url}/api/v2/partners/{partner_id}/waba_accounts/{waba_account_id}/flows"
+            responses.add("GET", json=api_response, url=url)
+            response = BSP360Dialog(bot, "user").list_whatsapp_flows()
+            assert response == api_response
+
+    @responses.activate
+    def test_delete_flow_channel_not_found(self):
+        bot = "62bc24b493a0d6b7a46328fg"
+        flow_id = "test_id"
+
+        with pytest.raises(AppException, match="Channel not found!"):
+            BSP360Dialog(bot, "user").delete_flow(flow_id)
+
+    @responses.activate
+    def test_delete_flow_failure(self, monkeypatch):
+        with mock.patch.dict(Utility.environment, {'channels': {"360dialog": {"partner_id": "new_partner_id"}}}):
+            bot = "62bc24b493a0d6b7a46328ff"
+            flow_id = "test_id"
+            partner_id = "new_partner_id"
+            waba_account_id = "Cyih7GWA"
+
+            def _get_partners_auth_token(*args, **kwargs):
+                return "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+
+            monkeypatch.setattr(BSP360Dialog, 'get_partner_auth_token', _get_partners_auth_token)
+            base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"][
+                "hub_base_url"]
+            url = f"{base_url}/api/v2/partners/{partner_id}/waba_accounts/{waba_account_id}/flows/{flow_id}"
+            responses.add("DELETE", json={}, url=url, status=500)
+
+            with pytest.raises(AppException, match=r"Failed to delete flow: *"):
+                BSP360Dialog(bot, "user").delete_flow(flow_id)
+
+    @responses.activate
+    def test_delete_flow(self, monkeypatch):
+        with mock.patch.dict(Utility.environment, {'channels': {"360dialog": {"partner_id": "new_partner_id"}}}):
+            bot = "62bc24b493a0d6b7a46328ff"
+            flow_id = "test_id"
+            partner_id = "new_partner_id"
+            waba_account_id = "Cyih7GWA"
+
+            def _get_partners_auth_token(*args, **kwargs):
+                return "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+
+            monkeypatch.setattr(BSP360Dialog, 'get_partner_auth_token', _get_partners_auth_token)
+            base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"][
+                "hub_base_url"]
+            url = f"{base_url}/api/v2/partners/{partner_id}/waba_accounts/{waba_account_id}/flows/{flow_id}"
+            responses.add("DELETE", json={"success": True}, url=url)
+
+            response = BSP360Dialog(bot, "user").delete_flow(flow_id)
+            assert response == {"success": True}
+
+    @responses.activate
+    def test_publish_flow_channel_not_found(self):
+        bot = "62bc24b493a0d6b7a46328fg"
+        flow_id = "test_id"
+
+        with pytest.raises(AppException, match="Channel not found!"):
+            BSP360Dialog(bot, "user").publish_flow(flow_id)
+
+    @responses.activate
+    def test_publish_flow_failure(self, monkeypatch):
+        with mock.patch.dict(Utility.environment, {'channels': {"360dialog": {"partner_id": "new_partner_id"}}}):
+            bot = "62bc24b493a0d6b7a46328ff"
+            flow_id = "test_id"
+            partner_id = "new_partner_id"
+            waba_account_id = "Cyih7GWA"
+
+            def _get_partners_auth_token(*args, **kwargs):
+                return "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+
+            monkeypatch.setattr(BSP360Dialog, 'get_partner_auth_token', _get_partners_auth_token)
+            base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"][
+                "hub_base_url"]
+            url = f"{base_url}/api/v2/partners/{partner_id}/waba_accounts/{waba_account_id}/flows/{flow_id}/publish"
+            responses.add("POST", json={}, url=url, status=500)
+
+            with pytest.raises(AppException, match=r"Failed to publish flow: *"):
+                BSP360Dialog(bot, "user").publish_flow(flow_id)
+
+    @responses.activate
+    def test_publish_flow(self, monkeypatch):
+        with mock.patch.dict(Utility.environment, {'channels': {"360dialog": {"partner_id": "new_partner_id"}}}):
+            bot = "62bc24b493a0d6b7a46328ff"
+            flow_id = "test_id"
+            partner_id = "new_partner_id"
+            waba_account_id = "Cyih7GWA"
+
+            def _get_partners_auth_token(*args, **kwargs):
+                return "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+
+            monkeypatch.setattr(BSP360Dialog, 'get_partner_auth_token', _get_partners_auth_token)
+            base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"][
+                "hub_base_url"]
+            url = f"{base_url}/api/v2/partners/{partner_id}/waba_accounts/{waba_account_id}/flows/{flow_id}/publish"
+            responses.add("POST", json={"success": True}, url=url)
+
+            response = BSP360Dialog(bot, "user").publish_flow(flow_id)
+            assert response == {"success": True}
+
+    @responses.activate
     def test_add_template(self, monkeypatch):
         with mock.patch.dict(Utility.environment, {'channels': {"360dialog": {"partner_id": "new_partner_id"}}}):
             responses.reset()
@@ -343,7 +735,8 @@ class TestBusinessServiceProvider:
             responses.add("POST", json=api_resp, url=url, status=201)
             template = BSP360Dialog(bot, "test").add_template(data, bot, "test")
             assert template == {'category': 'MARKETING', 'id': '594425479261596', 'status': 'PENDING'}
-            count = AuditLogData.objects(attributes=[{"key": "bot", "value": bot}], user="test", action="activity").count()
+            count = AuditLogData.objects(attributes=[{"key": "bot", "value": bot}], user="test", action="activity",
+                                         entity="template_creation").count()
             assert count == 1
 
     @responses.activate

--- a/tests/unit_test/channels/bsp_test.py
+++ b/tests/unit_test/channels/bsp_test.py
@@ -436,6 +436,112 @@ class TestBusinessServiceProvider:
             assert response == api_response
 
     @responses.activate
+    def test_get_whatsapp_flow_assets_channel_not_found(self):
+        bot = "62bc24b493a0d6b7a46328fg"
+        flow_id = "test_id"
+
+        with pytest.raises(AppException, match="Channel not found!"):
+            BSP360Dialog(bot, "user").get_whatsapp_flow_assets(flow_id)
+
+    @responses.activate
+    def test_get_whatsapp_flow_assets_failure(self, monkeypatch):
+        with mock.patch.dict(Utility.environment, {'channels': {"360dialog": {"partner_id": "new_partner_id"}}}):
+            bot = "62bc24b493a0d6b7a46328ff"
+            flow_id = "test_id"
+            partner_id = "new_partner_id"
+            waba_account_id = "Cyih7GWA"
+
+            def _get_partners_auth_token(*args, **kwargs):
+                return "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+
+            monkeypatch.setattr(BSP360Dialog, 'get_partner_auth_token', _get_partners_auth_token)
+            base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"][
+                "hub_base_url"]
+            url = f"{base_url}/api/v2/partners/{partner_id}/waba_accounts/{waba_account_id}/flows/{flow_id}/assets"
+            responses.add("GET", json={}, url=url, status=500)
+
+            with pytest.raises(AppException, match=r"Failed to get flow assets: *"):
+                BSP360Dialog(bot, "user").get_whatsapp_flow_assets(flow_id)
+
+    @responses.activate
+    def test_get_whatsapp_flow_assets(self, monkeypatch):
+        with mock.patch.dict(Utility.environment, {'channels': {"360dialog": {"partner_id": "new_partner_id"}}}):
+            bot = "62bc24b493a0d6b7a46328ff"
+            flow_id = "test_id"
+            partner_id = "new_partner_id"
+            waba_account_id = "Cyih7GWA"
+            api_response = {
+                "assets": [
+                    {
+                        "asset_type": "FLOW_JSON",
+                        "download_url": "https://mmg.whatsapp.net/m1/v/t24/An8n-Ot0L5sxj8lupzxfUTfHYhsdsdsdsRyqAZRySBcATvtUGgPjP76UJKS0wMopyj6SNTmNmf_F1pLAt04wbP3B9kFCIpvy7oOG6CM3HK4wFY61Z7TiLDxjGvzEgXjdog6A?ccb=10-5&oh=01_AdTq_Njj-foFgD0-KlMXq4AbdhrqLoNm6_CtlsxZxC03rA&oe=65F414CD&_nc_sid=471a72",
+                        "name": "flow.json"
+                    }
+                ],
+                "count": 1,
+                "total": 1
+            }
+
+            def _get_partners_auth_token(*args, **kwargs):
+                return "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+
+            monkeypatch.setattr(BSP360Dialog, 'get_partner_auth_token', _get_partners_auth_token)
+            base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"][
+                "hub_base_url"]
+            url = f"{base_url}/api/v2/partners/{partner_id}/waba_accounts/{waba_account_id}/flows/{flow_id}/assets"
+            responses.add("GET", json=api_response, url=url)
+            response = BSP360Dialog(bot, "user").get_whatsapp_flow_assets(flow_id)
+            assert response == api_response
+
+    @responses.activate
+    def test_deprecate_whatsapp_flow_channel_not_found(self):
+        bot = "62bc24b493a0d6b7a46328fg"
+        flow_id = "test_id"
+
+        with pytest.raises(AppException, match="Channel not found!"):
+            BSP360Dialog(bot, "user").deprecate_whatsapp_flow(flow_id)
+
+    @responses.activate
+    def test_deprecate_whatsapp_flow_failure(self, monkeypatch):
+        with mock.patch.dict(Utility.environment, {'channels': {"360dialog": {"partner_id": "new_partner_id"}}}):
+            bot = "62bc24b493a0d6b7a46328ff"
+            flow_id = "test_id"
+            partner_id = "new_partner_id"
+            waba_account_id = "Cyih7GWA"
+
+            def _get_partners_auth_token(*args, **kwargs):
+                return "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+
+            monkeypatch.setattr(BSP360Dialog, 'get_partner_auth_token', _get_partners_auth_token)
+            base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"][
+                "hub_base_url"]
+            url = f"{base_url}/api/v2/partners/{partner_id}/waba_accounts/{waba_account_id}/flows/{flow_id}/deprecate"
+            responses.add("POST", json={}, url=url, status=500)
+
+            with pytest.raises(AppException, match=r"Failed to deprecate flow: *"):
+                BSP360Dialog(bot, "user").deprecate_whatsapp_flow(flow_id)
+
+    @responses.activate
+    def test_deprecate_whatsapp_flow(self, monkeypatch):
+        with mock.patch.dict(Utility.environment, {'channels': {"360dialog": {"partner_id": "new_partner_id"}}}):
+            bot = "62bc24b493a0d6b7a46328ff"
+            flow_id = "test_id"
+            partner_id = "new_partner_id"
+            waba_account_id = "Cyih7GWA"
+            api_response = {"success": True}
+
+            def _get_partners_auth_token(*args, **kwargs):
+                return "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIs.ImtpZCI6Ik1EZEZOVFk1UVVVMU9FSXhPRGN3UVVZME9EUTFRVFJDT1.RSRU9VUTVNVGhDTURWRk9UUTNPQSJ9"
+
+            monkeypatch.setattr(BSP360Dialog, 'get_partner_auth_token', _get_partners_auth_token)
+            base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"][
+                "hub_base_url"]
+            url = f"{base_url}/api/v2/partners/{partner_id}/waba_accounts/{waba_account_id}/flows/{flow_id}/deprecate"
+            responses.add("POST", json=api_response, url=url)
+            response = BSP360Dialog(bot, "user").deprecate_whatsapp_flow(flow_id)
+            assert response == api_response
+
+    @responses.activate
     def test_preview_whatsapp_flow_channel_not_found(self):
         bot = "62bc24b493a0d6b7a46328fg"
         flow_id = "test_id"


### PR DESCRIPTION
Added APIs to create, update, retrieve and delete and publish, deprecate and get assets of the flows. Added unit and integration tests for the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced comprehensive API endpoints for managing WhatsApp flows, including functionalities for adding, editing, previewing, managing assets, deprecating, retrieving, deleting, and publishing flows.
	- Added a new `FlowCategories` enum to classify WhatsApp flows into categories such as SIGN_UP, SIGN_IN, APPOINTMENT_BOOKING, LEAD_GENERATION, CONTACT_US, CUSTOMER_SUPPORT, SURVEY, and OTHER.
- **Refactor**
	- Enhanced methods related to WhatsApp flows in `dialog360.py` for better interaction with external services.
- **Tests**
	- Implemented a broad range of integration and unit tests to ensure robust handling of WhatsApp flows, covering scenarios like adding, editing, previewing, retrieving, deleting, publishing, getting assets, and deprecating flows with error management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->