### PR TITLE
added x-telemetry-uid and x-session-id header in client chat api

### DIFF
--- a/kairon/chat/routers/web_client.py
+++ b/kairon/chat/routers/web_client.py
@@ -21,13 +21,13 @@ router = APIRouter()
 @router.post("/chat", response_model=Response)
 async def get_agent_response_for_web_client(request: ChatRequest,
                                             x_telemetry_uid: Text = Header(None),
-                                            x_session_id: Text = Header(None),
+                                            x_telemetry_sid: Text = Header(None),
                                             current_user: User = Security(Authentication.get_current_user_and_bot,
                                                                           scopes=CHAT_ACCESS)):
     """
     Retrieves agent response for user message.
     """
-    request.metadata = ChatUtils.add_telemetry_metadata(x_telemetry_uid, x_session_id, request.metadata)
+    request.metadata = ChatUtils.add_telemetry_metadata(x_telemetry_uid, x_telemetry_sid, request.metadata)
     response = await ChatUtils.chat(request.data, current_user.bot_account, current_user.get_bot(),
                                     current_user.get_user(),
                                     current_user.is_integration_user, request.metadata)

--- a/kairon/chat/routers/web_client.py
+++ b/kairon/chat/routers/web_client.py
@@ -1,6 +1,6 @@
 from typing import Text, Dict
 
-from fastapi import APIRouter, Path, Security
+from fastapi import APIRouter, Path, Security, Header
 from starlette.background import BackgroundTasks
 from starlette.requests import Request
 
@@ -20,11 +20,14 @@ router = APIRouter()
 
 @router.post("/chat", response_model=Response)
 async def get_agent_response_for_web_client(request: ChatRequest,
+                                            x_telemetry_uid: Text = Header(None),
+                                            x_session_id: Text = Header(None),
                                             current_user: User = Security(Authentication.get_current_user_and_bot,
                                                                           scopes=CHAT_ACCESS)):
     """
     Retrieves agent response for user message.
     """
+    request.metadata = ChatUtils.add_telemetry_metadata(x_telemetry_uid, x_session_id, request.metadata)
     response = await ChatUtils.chat(request.data, current_user.bot_account, current_user.get_bot(),
                                     current_user.get_user(),
                                     current_user.is_integration_user, request.metadata)

--- a/kairon/chat/utils.py
+++ b/kairon/chat/utils.py
@@ -165,3 +165,11 @@ class ChatUtils:
             metadata["tabname"] = "default"
         metadata.update(default_metadata)
         return metadata
+
+    @staticmethod
+    def add_telemetry_metadata(x_telemetry_uid: Text, x_session_id: Text, metadata: Dict):
+        if x_telemetry_uid and x_session_id:
+            #TODO: validate x_telemetry_uid and x_session_id for the botid
+            metadata["telemetry-uid"] = x_telemetry_uid
+            metadata["session-id"] = x_session_id
+        return metadata

--- a/kairon/chat/utils.py
+++ b/kairon/chat/utils.py
@@ -167,11 +167,11 @@ class ChatUtils:
         return metadata
 
     @staticmethod
-    def add_telemetry_metadata(x_telemetry_uid: Text, x_session_id: Text, metadata: Dict = None):
+    def add_telemetry_metadata(x_telemetry_uid: Text, x_telemetry_sid: Text, metadata: Dict = None):
         if not metadata:
             metadata = {}
-        if x_telemetry_uid and x_session_id:
+        if x_telemetry_uid and x_telemetry_sid:
             #TODO: validate x_telemetry_uid and x_session_id for the botid
             metadata["telemetry-uid"] = x_telemetry_uid
-            metadata["session-id"] = x_session_id
+            metadata["telemetry-sid"] = x_telemetry_sid
         return metadata

--- a/kairon/chat/utils.py
+++ b/kairon/chat/utils.py
@@ -167,7 +167,9 @@ class ChatUtils:
         return metadata
 
     @staticmethod
-    def add_telemetry_metadata(x_telemetry_uid: Text, x_session_id: Text, metadata: Dict):
+    def add_telemetry_metadata(x_telemetry_uid: Text, x_session_id: Text, metadata: Dict = None):
+        if not metadata:
+            metadata = {}
         if x_telemetry_uid and x_session_id:
             #TODO: validate x_telemetry_uid and x_session_id for the botid
             metadata["telemetry-uid"] = x_telemetry_uid

--- a/tests/integration_test/chat_service_test.py
+++ b/tests/integration_test/chat_service_test.py
@@ -610,6 +610,46 @@ def test_chat_with_user_with_metadata():
             assert metadata.args[0].metadata['tabname'] == 'coaching'
 
 
+def test_chat_with_telemetry_headers():
+    with patch.object(Utility, "get_local_mongo_store") as mocked:
+        mocked.side_effect = empty_store
+        patch.dict(Utility.environment['action'], {"url": None})
+
+        with patch.object(KaironMessageProcessor, "handle_message") as mocked_handle_message:
+            mocked_handle_message.return_value = {
+                "nlu": "intent_prediction",
+                "action": "action_prediction",
+                "response": "response_data",
+                "slots": "slot_data",
+                "events": "event_data",
+            }
+
+            request_body = {
+                "data": "Hi",
+                "metadata": {
+                    "name": "test_chat",
+                        "tabname": "coaching"
+                    }
+                }
+
+            response = client.post(
+                f"/api/bot/{bot}/chat",
+                json=request_body,
+                headers={"Authorization": token_type + " " + token,
+                         "X-TELEMETRY-UID": "test_telemetry",
+                         "X-TELEMETRY-SID": "test_session"},
+            )
+            actual = response.json()
+            assert actual['success']
+            assert actual['error_code'] == 0
+            metadata = mocked_handle_message.call_args
+            assert metadata.args[0].metadata['name'] == 'test_chat'
+            assert metadata.args[0].metadata['telemetry-uid'] == 'test_telemetry'
+            assert metadata.args[0].metadata['telemetry-sid'] == 'test_session'
+
+
+
+
 def test_chat_with_user_with_invalid_metadata():
     request_body = {
         "data": "Hi",

--- a/tests/integration_test/chat_service_test.py
+++ b/tests/integration_test/chat_service_test.py
@@ -5,6 +5,11 @@ import time
 from datetime import datetime, timedelta
 from unittest import mock
 from urllib.parse import urlencode, quote_plus
+from kairon.shared.utils import Utility
+
+os.environ["system_file"] = "./tests/testing_data/system.yaml"
+os.environ['ASYNC_TEST_TIMEOUT'] = "3600"
+Utility.load_environment()
 
 import pytest
 import responses
@@ -35,12 +40,9 @@ from kairon.shared.data.processor import MongoProcessor
 from kairon.shared.live_agent.processor import LiveAgentsProcessor
 from kairon.shared.metering.constants import MetricType
 from kairon.shared.metering.metering_processor import MeteringProcessor
-from kairon.shared.utils import Utility
 from kairon.train import start_training
 
-os.environ["system_file"] = "./tests/testing_data/system.yaml"
-os.environ['ASYNC_TEST_TIMEOUT'] = "3600"
-Utility.load_environment()
+
 connect(**Utility.mongoengine_connection())
 
 loop = asyncio.new_event_loop()
@@ -1456,7 +1458,6 @@ def test_whatsapp_exception_when_try_to_handle_webhook_for_whatsapp_message(mock
 def test_whatsapp_valid_button_message_request():
     def _mock_validate_hub_signature(*args, **kwargs):
         return True
-    responses.reset()
     responses.add(
         "POST", "https://graph.facebook.com/v13.0/12345678/messages", json={}
     )
@@ -1519,7 +1520,6 @@ def test_whatsapp_valid_button_message_request():
 def test_whatsapp_valid_attachment_message_request():
     def _mock_validate_hub_signature(*args, **kwargs):
         return True
-    responses.reset()
     responses.add(
         "POST", "https://graph.facebook.com/v13.0/12345678/messages", json={}
     )
@@ -1585,7 +1585,6 @@ def test_whatsapp_valid_attachment_message_request():
 
 @responses.activate
 def test_whatsapp_valid_order_message_request():
-    responses.reset()
     def _mock_validate_hub_signature(*args, **kwargs):
         return True
 
@@ -1661,7 +1660,6 @@ def test_whatsapp_valid_order_message_request():
 
 @responses.activate
 def test_whatsapp_valid_flows_message_request():
-    responses.reset()
 
     def _mock_validate_hub_signature(*args, **kwargs):
         return True
@@ -2078,7 +2076,6 @@ def test_whatsapp_bsp_valid_text_message_request():
         })
     actual = response.json()
     assert actual == 'success'
-    responses.reset()
 
 
 @responses.activate
@@ -2125,7 +2122,6 @@ def test_whatsapp_bsp_valid_button_message_request():
         })
     actual = response.json()
     assert actual == 'success'
-    responses.reset()
 
 
 @responses.activate
@@ -2171,7 +2167,6 @@ def test_whatsapp_bsp_valid_attachment_message_request():
         })
     actual = response.json()
     assert actual == 'success'
-    responses.reset()
 
 
 @responses.activate
@@ -2227,8 +2222,6 @@ def test_whatsapp_bsp_valid_order_message_request():
         })
     actual = response.json()
     assert actual == 'success'
-    responses.reset()
-
 
 def add_live_agent_config(bot_id, email):
     config = {
@@ -2236,8 +2229,7 @@ def add_live_agent_config(bot_id, email):
         "override_bot": False, "trigger_on_intents": ["nlu_fallback"],
         "trigger_on_actions": ["action_default_fallback"]
     }
-    responses.reset()
-    responses.start()
+
     responses.add(
         "GET",
         f"https://app.chatwoot.com/api/v1/accounts/{config['config']['account_id']}/inboxes",
@@ -2249,16 +2241,13 @@ def add_live_agent_config(bot_id, email):
         json={"inbox_identifier": "tSaxZWrxyFowmFHzWwhMwi5y"}
     )
     LiveAgentsProcessor.save_config(config, bot_id, email)
-    responses.stop()
 
-
+@responses.activate
 @patch("rasa.core.tracker_store.TrackerStore.serialise_tracker")
 @patch("kairon.live_agent.chatwoot.ChatwootLiveAgent.getBusinesshours")
 @patch("kairon.live_agent.chatwoot.ChatwootLiveAgent.validate_businessworkinghours")
 def test_chat_with_chatwoot_agent_fallback(mock_validatebusinesshours, mock_getbusinesshrs, mock_tracker):
     add_live_agent_config(bot, user["email"])
-    responses.reset()
-    responses.start()
     responses.add(
         "POST", 'https://app.chatwoot.com/public/api/v1/inboxes/tSaxZWrxyFowmFHzWwhMwi5y/contacts',
         json={
@@ -2339,7 +2328,6 @@ def test_chat_with_chatwoot_agent_fallback(mock_validatebusinesshours, mock_getb
                 headers={"Authorization": token_type + " " + token},
                 timeout=0,
             )
-            responses.stop()
             actual = response.json()
             assert actual["success"]
             assert actual["error_code"] == 0
@@ -2367,6 +2355,7 @@ def test_chat_with_chatwoot_agent_fallback(mock_validatebusinesshours, mock_getb
             assert MeteringProcessor.get_metric_count(user['account'], metric_type=MetricType.agent_handoff) > 0
 
 
+@responses.activate
 @patch("rasa.core.tracker_store.TrackerStore.serialise_tracker")
 @patch("kairon.live_agent.chatwoot.ChatwootLiveAgent.getBusinesshours")
 def test_chat_with_chatwoot_agent_fallback_existing_contact(mock_businesshours, mock_tracker):
@@ -2376,8 +2365,6 @@ def test_chat_with_chatwoot_agent_fallback_existing_contact(mock_businesshours, 
         with patch.object(KaironAgent, "handle_message") as mock_agent:
             mock_agent.side_effect = mock_agent_response
             mock_businesshours.side_effect = __mock_getbusinessdata_workingdisabled
-            responses.reset()
-            responses.start()
             responses.add(
                 "POST", 'https://app.chatwoot.com/public/api/v1/inboxes/tSaxZWrxyFowmFHzWwhMwi5y/contacts',
                 json={
@@ -2451,7 +2438,6 @@ def test_chat_with_chatwoot_agent_fallback_existing_contact(mock_businesshours, 
                 headers={"Authorization": token_type + " " + token},
                 timeout=0,
             )
-            responses.stop()
             actual = response.json()
             assert actual["success"]
             assert actual["error_code"] == 0
@@ -2477,10 +2463,8 @@ def test_chat_with_chatwoot_agent_fallback_existing_contact(mock_businesshours, 
             assert len(data["logs"]) == data["total"]
             assert MeteringProcessor.get_metric_count(user['account'], metric_type=MetricType.agent_handoff) == 2
 
-
+@responses.activate
 def test_chat_with_live_agent():
-    responses.reset()
-    responses.start()
     responses.add(
         "POST",
         'https://app.chatwoot.com/api/v1/accounts/12/conversations/2/messages',
@@ -2519,12 +2503,9 @@ def test_chat_with_live_agent():
     assert actual["error_code"] == 0
     assert actual["data"]
     assert Utility.check_empty_string(actual["message"])
-    responses.stop()
 
-
+@responses.activate
 def test_chat_with_live_agent_failed_to_send_message():
-    responses.reset()
-    responses.start()
     responses.add(
         "POST",
         'https://app.chatwoot.com/api/v1/accounts/12/conversations/2/messages',
@@ -2542,14 +2523,12 @@ def test_chat_with_live_agent_failed_to_send_message():
     assert actual["error_code"] == 422
     assert actual["data"] is None
     assert actual["message"] == "Failed to send message: Service Unavailable"
-    responses.stop()
 
 
+@responses.activate
 def test_chat_with_live_agent_with_integration_token():
     access_token = chat_client_config['config']['headers']['authorization']['access_token']
     token_type = chat_client_config['config']['headers']['authorization']['token_type']
-    responses.reset()
-    responses.start()
     responses.add(
         "POST",
         'https://app.chatwoot.com/api/v1/accounts/12/conversations/2/messages',
@@ -2588,17 +2567,14 @@ def test_chat_with_live_agent_with_integration_token():
     assert actual["error_code"] == 0
     assert actual["data"]["response"]
     assert Utility.check_empty_string(actual["message"])
-    responses.stop()
 
-
+@responses.activate
 def test_chat_with_chatwoot_agent_fallback_failed_to_initiate():
     with patch.object(Utility, "get_local_mongo_store") as mocked:
         mocked.side_effect = empty_store
         patch.dict(Utility.environment['action'], {"url": None})
         with patch.object(KaironAgent, "handle_message") as mock_agent:
             mock_agent.side_effect = mock_agent_response
-            responses.reset()
-            responses.start()
             responses.add(
                 "POST", 'https://app.chatwoot.com/public/api/v1/inboxes/tSaxZWrxyFowmFHzWwhMwi5y/contacts',
                 json={
@@ -2637,8 +2613,6 @@ def test_chat_with_chatwoot_agent_fallback_failed_to_initiate():
             assert actual["data"]["response"]
             assert actual["data"]["agent_handoff"] == {'initiate': False, 'type': 'chatwoot',
                                                        'additional_properties': None}
-            responses.reset()
-            responses.stop()
             data = MeteringProcessor.get_logs(user["account"], bot=bot, metric_type="agent_handoff")
             assert len(data["logs"]) == 3
             assert len(data["logs"]) == data["total"]
@@ -2820,13 +2794,11 @@ def test_get_chat_history_http_error(monkeypatch):
     assert error_code == 401
     assert message == "Session expired. Please login again!"
 
-
+@responses.activate
 @patch("kairon.live_agent.chatwoot.ChatwootLiveAgent.getBusinesshours")
 @patch("kairon.live_agent.chatwoot.ChatwootLiveAgent.validate_businessworkinghours")
 def test_chat_with_chatwoot_agent_outof_workinghours(mock_validatebusiness, mock_getbusiness):
     add_live_agent_config(bot, user["email"])
-    responses.reset()
-    responses.start()
     responses.add(
         "POST", 'https://app.chatwoot.com/public/api/v1/inboxes/tSaxZWrxyFowmFHzWwhMwi5y/contacts',
         json={
@@ -2903,7 +2875,6 @@ def test_chat_with_chatwoot_agent_outof_workinghours(mock_validatebusiness, mock
                 headers={"Authorization": token_type + " " + token},
                 timeout=0,
             )
-            responses.stop()
             actual = response.json()
             assert actual["data"]["agent_handoff"][
                        "businessworking"] == "We are unavailable at the moment. In case of any query related to Sales, gifting or enquiry of order, please connect over following whatsapp number +912929393 ."


### PR DESCRIPTION
added x-telemetry-uid and x-session-id header into client chat to be included into metadata for database entry in case these headers are available

-added empty matadata check (accidentally forgot to add  : / )

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Enhanced chat functionality to accept additional telemetry headers for improved session tracking and analytics.
    - Added a static method to include telemetry metadata in the response.
    - Improved error handling and test setups for better integration testing.
    - Refactored test functions for better efficiency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->