### PR TITLE
Add Member Email Template first name change 

### DIFF
--- a/template/emails/memberAddAccept.html
+++ b/template/emails/memberAddAccept.html
@@ -147,7 +147,7 @@
                         font-size: 15px;
                         padding: 16px 0;
                       ">
-                                        <p>Hi buddy,</p>
+                                        <p>Hi FIRST_NAME,</p>
                                         <p>
                                             You have been invited to collaborate on BOT_NAME bot by BOT_OWNER_NAME. Please click the link below to accept the invitation and sign in using USER_EMAIL to access
                                             newly


### PR DESCRIPTION
1. Made changes in the email template for add member invitation by changing it to first name.

2. Added and fixed test cases regarding the same.