### PR TITLE
Metadata in chat history wc fix

### DIFF
--- a/kairon/actions/definitions/live_agent.py
+++ b/kairon/actions/definitions/live_agent.py
@@ -94,7 +94,8 @@ class ActionLiveAgent(ActionsBase):
                         'action': 'live_agent',
                         'response': bot_response
                     }
-                bot_response, message = ActionUtility.handle_utter_bot_response(dispatcher, DispatchType.text.value, bot_response)
+                dispatch_type = DispatchType.json.value if is_web else DispatchType.text.value
+                bot_response, message = ActionUtility.handle_utter_bot_response(dispatcher, dispatch_type, bot_response)
                 if message:
                     msg_logger.append(message)
             ActionServerLogs(

--- a/kairon/shared/trackers.py
+++ b/kairon/shared/trackers.py
@@ -131,6 +131,7 @@ class KMongoTrackerStore(TrackerStore, SerializedTrackerAsText):
                     )
             flattened_conversation["data"]["action"] = actions_predicted
             flattened_conversation["data"]["bot_response"] = bot_responses
+            flattened_conversation["metadata"] = metadata
             data.append(flattened_conversation)
             if data:
                 self.conversations.insert_many(data)


### PR DESCRIPTION
Metadata in chat history
webclient response type fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved bot response handling by conditionally setting dispatch type based on web or text dispatch.
  - Added metadata inclusion in conversation data for better tracking and analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->