### PR TITLE
live agent url in chat client config

### DIFF
--- a/kairon/actions/definitions/live_agent.py
+++ b/kairon/actions/definitions/live_agent.py
@@ -45,7 +45,6 @@ class ActionLiveAgent(ActionsBase):
         try:
             live_agent_config_dict = LiveAgentActionConfig.objects().get(bot=self.bot,
                                                               name=self.name, status=True).to_mongo().to_dict()
-            logger.debug("live_agent_action_config: " + str(live_agent_config_dict))
             return live_agent_config_dict
         except DoesNotExist as e:
             logger.exception(e)

--- a/kairon/actions/definitions/live_agent.py
+++ b/kairon/actions/definitions/live_agent.py
@@ -78,6 +78,7 @@ class ActionLiveAgent(ActionsBase):
             resp_data = await LiveAgentHandler.request_live_agent(self.bot, tracker.sender_id, channel)
             if resp_data and resp_data.get('msg'):
                 bot_response = resp_data.get('msg')
+                dispatch_bot_response = True
             self.__is_success = True
             self.__response = bot_response
         except Exception as e:
@@ -97,6 +98,15 @@ class ActionLiveAgent(ActionsBase):
                 bot_response, message = ActionUtility.handle_utter_bot_response(dispatcher, dispatch_type, bot_response)
                 if message:
                     msg_logger.append(message)
+            elif is_web:
+                resp_obj = {
+                    'action': 'live_agent',
+                    'response': None,
+                }
+                bot_response, message = ActionUtility.handle_utter_bot_response(dispatcher,
+                                                                                DispatchType.json.value,
+                                                                                resp_obj)
+
             ActionServerLogs(
                 type=ActionType.live_agent_action.value,
                 intent=tracker.get_intent_of_latest_message(skip_fallback_intent=False),

--- a/kairon/shared/data/processor.py
+++ b/kairon/shared/data/processor.py
@@ -5584,14 +5584,7 @@ class MongoProcessor:
             client_config.config['headers']['X-USER'] = user
         client_config.config['api_server_host_url'] = Utility.environment['app']['server_url']
         client_config.config['nudge_server_url'] = Utility.environment['nudge']['server_url']
-
-        live_agent_url = Utility.environment['live_agent']['url']
-        parsed_url = urlparse(live_agent_url)
-        la_protocol = parsed_url.scheme
-        la_base_url = parsed_url.netloc
-        la_ws_protocol = 'ws' if la_protocol == 'http' else 'wss'
-        la_ws_url = f'{la_ws_protocol}://{la_base_url}/ws/client'
-        client_config.config['live_agent_socket_url'] = la_ws_url
+        client_config.config['live_agent_socket_url'] = Utility.environment['live_agent']['live_agent_socket_url']
 
         token, refresh_token = Authentication.generate_integration_token(
             bot,

--- a/kairon/shared/data/processor.py
+++ b/kairon/shared/data/processor.py
@@ -5584,6 +5584,14 @@ class MongoProcessor:
             client_config.config['headers']['X-USER'] = user
         client_config.config['api_server_host_url'] = Utility.environment['app']['server_url']
         client_config.config['nudge_server_url'] = Utility.environment['nudge']['server_url']
+
+        la_url_parts = Utility.environment['live_agent']['url'].split('://')
+        la_protocol = la_url_parts[0]
+        la_base_url = la_url_parts[1].split('/')[0]
+        la_ws_protocol = 'ws' if la_protocol == 'http' else 'wss'
+        la_ws_url = f'{la_ws_protocol}://{la_base_url}/ws/client'
+        client_config.config['live_agent_socket_url'] = la_ws_url
+
         token, refresh_token = Authentication.generate_integration_token(
             bot,
             user,

--- a/kairon/shared/data/processor.py
+++ b/kairon/shared/data/processor.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Text, Dict, List, Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 from loguru import logger
 
 import networkx as nx
@@ -5585,9 +5585,10 @@ class MongoProcessor:
         client_config.config['api_server_host_url'] = Utility.environment['app']['server_url']
         client_config.config['nudge_server_url'] = Utility.environment['nudge']['server_url']
 
-        la_url_parts = Utility.environment['live_agent']['url'].split('://')
-        la_protocol = la_url_parts[0]
-        la_base_url = la_url_parts[1].split('/')[0]
+        live_agent_url = Utility.environment['live_agent']['url']
+        parsed_url = urlparse(live_agent_url)
+        la_protocol = parsed_url.scheme
+        la_base_url = parsed_url.netloc
         la_ws_protocol = 'ws' if la_protocol == 'http' else 'wss'
         la_ws_url = f'{la_ws_protocol}://{la_base_url}/ws/client'
         client_config.config['live_agent_socket_url'] = la_ws_url

--- a/system.yaml
+++ b/system.yaml
@@ -245,4 +245,5 @@ core:
 live_agent:
   enable: true
   url: ${LIVE_AGENT_SERVER_URL:"http://localhost:8000/api/v1"}
+  live_agent_socket_url: ${LIVE_AGENT_SOCKET_URL:"ws://localhost:8000/ws/client"}
   auth_token: ${LIVE_AGENT_AUTH_TOKEN:"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoia2Fpcm9uIn0.EJXuG2n8dy72h9J-8SoIBToVmnB4gpXDGKg_Smcz-C8"}

--- a/tests/testing_data/all/chat_client_config.yml
+++ b/tests/testing_data/all/chat_client_config.yml
@@ -10,6 +10,7 @@ config:
   headerClassName: ''
   name: kairon_testing
   openButtonClassName: ''
+  live_agent_socket_url: ws://localhost:8000/ws/client,
   styles:
     botStyle:
       backgroundColor: '#e0e0e0'

--- a/tests/testing_data/all/chat_client_config.yml
+++ b/tests/testing_data/all/chat_client_config.yml
@@ -10,7 +10,7 @@ config:
   headerClassName: ''
   name: kairon_testing
   openButtonClassName: ''
-  live_agent_socket_url: ws://localhost:8000/ws/client,
+  live_agent_socket_url: ws://localhost:8000/ws/client
   styles:
     botStyle:
       backgroundColor: '#e0e0e0'

--- a/tests/testing_data/system.yaml
+++ b/tests/testing_data/system.yaml
@@ -239,4 +239,5 @@ core:
 live_agent:
   enable: true
   url: ${LIVE_AGENT_SERVER_URL:"http://localhost:8000/api/v1"}
+  live_agent_socket_url: ${LIVE_AGENT_SOCKET_URL:"ws://localhost:8000/ws/client"}
   auth_token: ${LIVE_AGENT_AUTH_TOKEN:"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoia2Fpcm9uIn0.EJXuG2n8dy72h9J-8SoIBToVmnB4gpXDGKg_Smcz-C8"}

--- a/tests/unit_test/data_processor/data_processor_test.py
+++ b/tests/unit_test/data_processor/data_processor_test.py
@@ -6487,6 +6487,7 @@ class TestMongoProcessor:
         del actual_config.config['nudge_server_url']
         assert 'chat_server_base_url' in actual_config.config
         actual_config.config.pop('chat_server_base_url')
+        actual_config.config.pop('live_agent_socket_url')
         headers = actual_config.config.pop('headers')
         expected_config['multilingual'] = {'enable': False, 'bots': []}
         assert expected_config == actual_config.config


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for `live_agent_socket_url` configuration, enabling WebSocket connectivity for live agents.

- **Tests**
  - Added new test scenarios for `live_agent_socket_url` configuration to ensure reliability and proper handling of failure cases.

- **Chores**
  - Updated configuration files (`chat_client_config.yml`, `system.yaml`) to include `live_agent_socket_url` parameter with default values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->