### PR TITLE
Added endpoints to list all actions and fetch rasa default names

### DIFF
--- a/kairon/actions/definitions/email.py
+++ b/kairon/actions/definitions/email.py
@@ -54,11 +54,11 @@ class ActionEmail(ActionsBase):
         exception = None
         action_config = self.retrieve_config()
         bot_response = action_config.get("response")
-        to_email = action_config['to_email']
         smtp_password = action_config.get('smtp_password')
         smtp_userid = action_config.get('smtp_userid')
         custom_text = action_config.get('custom_text')
         try:
+            from_email, to_email = self.__get_from_email_and_to_email(action_config, tracker)
             tracker_data = ActionUtility.build_context(tracker)
             password = ActionUtility.retrieve_value_for_custom_action_parameter(tracker_data, smtp_password, self.bot)
             userid = ActionUtility.retrieve_value_for_custom_action_parameter(tracker_data, smtp_userid, self.bot)
@@ -74,7 +74,7 @@ class ActionEmail(ActionsBase):
                                                 body=body,
                                                 smtp_url=action_config['smtp_url'],
                                                 smtp_port=action_config['smtp_port'],
-                                                sender_email=action_config['from_email'],
+                                                sender_email=from_email,
                                                 smtp_password=password,
                                                 smtp_userid=userid,
                                                 tls=action_config['tls']
@@ -100,3 +100,21 @@ class ActionEmail(ActionsBase):
             ).save()
         dispatcher.utter_message(bot_response)
         return {KaironSystemSlots.kairon_action_response.value: bot_response}
+
+    @staticmethod
+    def __get_from_email_and_to_email(action_config: EmailActionConfig, tracker: Tracker):
+        from_email_type = action_config['from_email']['parameter_type']
+        to_email_type = action_config['to_email']['parameter_type']
+        from_email = tracker.get_slot(action_config['from_email']['value']) if from_email_type == "slot" \
+            else action_config['from_email']['value']
+        to_email = tracker.get_slot(action_config['to_email']['value']) if to_email_type == "slot" \
+            else action_config['to_email']['value']
+
+        if not isinstance(to_email, (str, list)):
+            raise ValueError("Invalid 'to_email' type. It must be of type str or list.")
+
+        if not isinstance(from_email, str):
+            raise ValueError("Invalid 'from_email' type. It must be of type str.")
+
+        to_email = [to_email] if isinstance(to_email, str) else to_email
+        return from_email, to_email

--- a/kairon/api/app/routers/bot/action.py
+++ b/kairon/api/app/routers/bot/action.py
@@ -604,7 +604,7 @@ async def disable_live_agent(
 
 
 @router.get("/actions", response_model=Response)
-async def list_actions(
+async def list_available_actions(
         current_user: User = Security(Authentication.get_current_user_and_bot, scopes=TESTER_ACCESS)):
     """
     Returns list of all actions for bot.

--- a/kairon/api/app/routers/bot/action.py
+++ b/kairon/api/app/routers/bot/action.py
@@ -602,3 +602,13 @@ async def disable_live_agent(
     mongo_processor.disable_live_agent(current_user.get_bot())
     return Response(message="Live Agent Action disabled!")
 
+
+@router.get("/actions", response_model=Response)
+async def list_actions(
+        current_user: User = Security(Authentication.get_current_user_and_bot, scopes=TESTER_ACCESS)):
+    """
+    Returns list of all actions for bot.
+    """
+    actions = list(mongo_processor.list_all_actions(bot=current_user.get_bot()))
+    return Response(data=actions)
+

--- a/kairon/api/app/routers/system.py
+++ b/kairon/api/app/routers/system.py
@@ -1,4 +1,6 @@
 from fastapi import APIRouter
+from rasa.shared.core.constants import DEFAULT_INTENTS, DEFAULT_ACTION_NAMES, DEFAULT_SLOT_NAMES
+
 from kairon.shared.utils import Utility
 from kairon.api.models import Response
 
@@ -27,3 +29,16 @@ async def get_templates():
     Fetches use-case templates name
     """
     return {"data": {"use-cases": Utility.list_directories("./template/use-cases")}}
+
+
+@router.get("/default/names", response_model=Response)
+async def get_default_names():
+    """
+    Fetches the default intents, action names, and slot names.
+    """
+    data = {
+        "default_intents": DEFAULT_INTENTS,
+        "default_action_names": DEFAULT_ACTION_NAMES,
+        "default_slot_names": list(DEFAULT_SLOT_NAMES),
+    }
+    return Response(data=data)

--- a/kairon/shared/data/constant.py
+++ b/kairon/shared/data/constant.py
@@ -82,6 +82,13 @@ class CUSTOM_ACTIONS(str, Enum):
     HTTP_ACTION_CONFIG = "http_action_config"
 
 
+class DEMO_REQUEST_STATUS(str, Enum):
+    REQUEST_RECEIVED = "request_received"
+    MAIL_SENT = "mail_sent"
+    DEMO_PLANNED = "demo_planned"
+    DEMO_GIVEN = "demo_given"
+
+
 class EVENT_STATUS(str, Enum):
     ENQUEUED = "Enqueued"
     INITIATED = "Initiated"

--- a/kairon/shared/data/processor.py
+++ b/kairon/shared/data/processor.py
@@ -80,7 +80,8 @@ from kairon.shared.actions.data_objects import (
     DbQuery,
     PyscriptActionConfig,
     WebSearchAction,
-    UserQuestion, LiveAgentActionConfig,
+    UserQuestion, CustomActionParameters,
+    LiveAgentActionConfig,
 )
 from kairon.shared.actions.models import (
     ActionType,
@@ -6522,9 +6523,9 @@ class MongoProcessor:
             if action.get("custom_text")
             else None
         )
-        email_action.from_email = action["from_email"]
+        email_action.from_email = CustomActionRequestParameters(**action['from_email']) if action.get('from_email') else None
         email_action.subject = action["subject"]
-        email_action.to_email = action["to_email"]
+        email_action.to_email = CustomActionParameters(**action['to_email']) if action.get('to_email') else None
         email_action.response = action["response"]
         email_action.tls = action["tls"]
         email_action.user = user

--- a/kairon/shared/data/processor.py
+++ b/kairon/shared/data/processor.py
@@ -128,6 +128,7 @@ from .constant import (
     DEFAULT_NLU_FALLBACK_UTTERANCE_NAME,
     ACCESS_ROLES,
     LogType,
+    DEMO_REQUEST_STATUS,
 )
 from .data_objects import (
     Responses,
@@ -152,7 +153,7 @@ from .data_objects import (
     Rules,
     Utterances, BotSettings, ChatClientConfig, SlotMapping, KeyVault, EventConfig, TrainingDataGenerator,
     MultiflowStories, MultiflowStoryEvents, MultiFlowStoryMetadata,
-    Synonyms, Lookup, Analytics, ModelTraining, ConversationsHistoryDeleteLogs
+    Synonyms, Lookup, Analytics, ModelTraining, ConversationsHistoryDeleteLogs, DemoRequestLogs
 )
 from .utils import DataUtility
 from ..chat.broadcast.data_objects import MessageBroadcastLogs
@@ -5469,6 +5470,21 @@ class MongoProcessor:
             logging.info(e)
             settings = BotSettings(bot=bot, user=user).save()
         return settings
+
+    @staticmethod
+    def add_demo_request(**kwargs):
+        try:
+            logs = DemoRequestLogs(
+                first_name=kwargs.get("first_name"),
+                last_name=kwargs.get("last_name"),
+                email=kwargs.get("email"),
+                phone=kwargs.get("phone", None),
+                message=kwargs.get("message", None),
+                status=kwargs.get("status", DEMO_REQUEST_STATUS.REQUEST_RECEIVED.value),
+                recaptcha_response=kwargs.get("recaptcha_response", None),
+            ).save()
+        except Exception as e:
+            logging.error(str(e))
 
     @staticmethod
     def edit_bot_settings(bot_settings: dict, bot: Text, user: Text):

--- a/kairon/shared/data/processor.py
+++ b/kairon/shared/data/processor.py
@@ -4325,6 +4325,25 @@ class MongoProcessor:
             action.pop("status")
             yield action
 
+    def list_all_actions(self, bot: str, with_doc_id: bool = True):
+        """
+        Fetches all actions from the collection
+        :param bot: bot id
+        :param with_doc_id: return document id along with action configuration if True
+        :return: List of actions.
+        """
+        for action in Actions.objects(bot=bot, status=True):
+            action = action.to_mongo().to_dict()
+            if with_doc_id:
+                action["_id"] = str(action["_id"])
+            else:
+                action.pop("_id")
+            action.pop("user")
+            action.pop("bot")
+            action.pop("status")
+            action.pop("timestamp")
+            yield action
+
     def add_slot(self, slot_value: Dict, bot, user, raise_exception_if_exists=True):
         """
         Adds slot if it doesn't exist, updates slot if it exists

--- a/kairon/shared/utils.py
+++ b/kairon/shared/utils.py
@@ -2695,9 +2695,11 @@ class MailUtility:
     @staticmethod
     def __handle_book_a_demo(**kwargs):
         from kairon.shared.plugins.factory import PluginFactory
+        from kairon.shared.data.processor import MongoProcessor
 
         request = kwargs.get("request")
         data = kwargs.get("data")
+        MongoProcessor.add_demo_request(**data)
         ip = Utility.get_client_ip(request)
         geo_location = (
             PluginFactory.get_instance(PluginTypes.ip_info.value).execute(ip=ip) or {}

--- a/tests/integration_test/action_service_test.py
+++ b/tests/integration_test/action_service_test.py
@@ -20,7 +20,8 @@ from kairon.shared.actions.data_objects import HttpActionConfig, SlotSetAction, 
     EmailActionConfig, ActionServerLogs, GoogleSearchAction, JiraAction, ZendeskAction, PipedriveLeadsAction, SetSlots, \
     HubspotFormsAction, HttpActionResponse, HttpActionRequestBody, SetSlotsFromResponse, CustomActionRequestParameters, \
     KaironTwoStageFallbackAction, TwoStageFallbackTextualRecommendations, RazorpayAction, PromptAction, FormSlotSet, \
-    DatabaseAction, DbQuery, PyscriptActionConfig, WebSearchAction, UserQuestion, LiveAgentActionConfig
+    DatabaseAction, DbQuery, PyscriptActionConfig, WebSearchAction, UserQuestion, LiveAgentActionConfig, \
+    CustomActionParameters
 from kairon.shared.actions.exception import ActionFailure
 from kairon.shared.actions.models import ActionType, ActionParameterType, DispatchType, DbActionOperationType, \
     DbQueryValueType
@@ -5312,9 +5313,9 @@ def test_email_action_execution_script_evaluation(mock_smtp, mock_action_config,
         smtp_url="test.localhost",
         smtp_port=293,
         smtp_password=CustomActionRequestParameters(key='smtp_password', value="test"),
-        from_email="test@demo.com",
-        subject="test script",
-        to_email=["test@test.com"],
+        from_email=CustomActionRequestParameters(value="test@demo.com", parameter_type="value"),
+        to_email=CustomActionParameters(value=["test@test.com"], parameter_type="value"),
+        subject="test",
         response="Email Triggered",
         custom_text=CustomActionRequestParameters(key="custom_text", value="custom_mail_text",
                                                   parameter_type=ActionParameterType.slot.value),
@@ -5366,14 +5367,14 @@ def test_email_action_execution_script_evaluation(mock_smtp, mock_action_config,
     assert {} == kwargs
 
     from_email, password = args
-    assert from_email == action_config.from_email
+    assert from_email == action_config.from_email.value
     assert password == action_config.smtp_password.value
 
     name, args, kwargs = mock_smtp.method_calls.pop(0)
     assert name == '().sendmail'
     assert {} == kwargs
 
-    assert args[0] == action_config.from_email
+    assert args[0] == action_config.from_email.value
     assert args[1] == ["test@test.com"]
     assert str(args[2]).__contains__(action_config.subject)
     assert str(args[2]).__contains__("Content-Type: text/html")
@@ -5399,9 +5400,9 @@ def test_email_action_execution(mock_smtp, mock_action_config, mock_action):
         smtp_url="test.localhost",
         smtp_port=293,
         smtp_password=CustomActionRequestParameters(key='smtp_password', value="test"),
-        from_email="test@demo.com",
+        from_email=CustomActionRequestParameters(value="test@demo.com", parameter_type="value"),
+        to_email=CustomActionParameters(value=["test@test.com"], parameter_type="value"),
         subject="test",
-        to_email=["test@test.com"],
         response="Email Triggered",
         bot="bot",
         user="user"
@@ -5517,18 +5518,864 @@ def test_email_action_execution(mock_smtp, mock_action_config, mock_action):
     assert {} == kwargs
 
     from_email, password = args
-    assert from_email == action_config.from_email
+    assert from_email == action_config.from_email.value
     assert password == action_config.smtp_password.value
 
     name, args, kwargs = mock_smtp.method_calls.pop(0)
     assert name == '().sendmail'
     assert {} == kwargs
 
-    assert args[0] == action_config.from_email
+    assert args[0] == action_config.from_email.value
     assert args[1] == ["test@test.com"]
     assert str(args[2]).__contains__(action_config.subject)
     assert str(args[2]).__contains__("Content-Type: text/html")
     assert str(args[2]).__contains__("Subject: default test")
+
+
+@patch("kairon.shared.actions.utils.ActionUtility.get_action")
+@patch("kairon.actions.definitions.email.ActionEmail.retrieve_config")
+@patch("kairon.shared.utils.SMTP", autospec=True)
+def test_email_action_execution_with_sender_email_from_slot(mock_smtp, mock_action_config, mock_action):
+    Utility.email_conf['email']['templates']['conversation'] = open('template/emails/conversation.html',
+                                                                    'rb').read().decode()
+    Utility.email_conf['email']['templates']['bot_msg_conversation'] = open(
+        'template/emails/bot_msg_conversation.html', 'rb').read().decode()
+    Utility.email_conf['email']['templates']['user_msg_conversation'] = open(
+        'template/emails/user_msg_conversation.html', 'rb').read().decode()
+    Utility.email_conf['email']['templates']['button_template'] = open('template/emails/button.html',
+                                                                       'rb').read().decode()
+    action_name = "test_email_action_execution_with_sender_email_from_slot"
+    action = Actions(name=action_name, type=ActionType.email_action.value, bot="bot", user="user")
+    action_config = EmailActionConfig(
+        action_name=action_name,
+        smtp_url="test.localhost",
+        smtp_port=293,
+        smtp_password=CustomActionRequestParameters(key='smtp_password', value="test"),
+        from_email=CustomActionRequestParameters(value="from_email", parameter_type="slot"),
+        to_email=CustomActionParameters(value=["test@test.com"], parameter_type="value"),
+        subject="test",
+        response="Email Triggered",
+        bot="bot",
+        user="user"
+    )
+
+    def _get_action(*arge, **kwargs):
+        return action.to_mongo().to_dict()
+
+    def _get_action_config(*arge, **kwargs):
+        return action_config.to_mongo().to_dict()
+
+    request_object = {
+        "next_action": action_name,
+        "tracker": {
+            "sender_id": "mahesh.sattala",
+            "conversation_id": "default",
+            "slots": {"bot": "5f50fd0a56b698ca10d35d2e", "requested_slot": "from_email",
+                      "from_email": "mahesh@gmail.com"},
+            "latest_message": {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]},
+            "latest_event_time": 1537645578.314389,
+            "followup_action": "action_listen",
+            "paused": False,
+            "events": [
+                {"event": "action", "timestamp": 1594907100.12764, "name": "action_session_start", "policy": None,
+                 "confidence": None}, {"event": "session_started", "timestamp": 1594907100.12765},
+                {"event": "action", "timestamp": 1594907100.12767, "name": "action_listen", "policy": None,
+                 "confidence": None}, {"event": "user", "timestamp": 1594907100.42744, "text": "can't",
+                                       "parse_data": {
+                                           "intent": {"name": "test intent", "confidence": 0.253578245639801},
+                                           "entities": [], "intent_ranking": [
+                                               {"name": "test intent", "confidence": 0.253578245639801},
+                                               {"name": "goodbye", "confidence": 0.1504897326231},
+                                               {"name": "greet", "confidence": 0.138640150427818},
+                                               {"name": "affirm", "confidence": 0.0857767835259438},
+                                               {"name": "smalltalk_human", "confidence": 0.0721133947372437},
+                                               {"name": "deny", "confidence": 0.069614589214325},
+                                               {"name": "bot_challenge", "confidence": 0.0664894133806229},
+                                               {"name": "faq_vaccine", "confidence": 0.062177762389183},
+                                               {"name": "faq_testing", "confidence": 0.0530692934989929},
+                                               {"name": "out_of_scope", "confidence": 0.0480506233870983}],
+                                           "response_selector": {
+                                               "default": {"response": {"name": None, "confidence": 0},
+                                                           "ranking": [], "full_retrieval_intent": None}},
+                                           "text": "can't"}, "input_channel": None,
+                                       "message_id": "bbd413bf5c834bf3b98e0da2373553b2", "metadata": {}},
+                {"event": "action", "timestamp": 1594907100.4308, "name": "utter_test intent",
+                 "policy": "policy_0_MemoizationPolicy", "confidence": 1},
+                {"event": "bot", "timestamp": 1594907100.4308, "text": "will not = won\"t",
+                 "data": {"elements": None, "quick_replies": None, "buttons": None, "attachment": None,
+                          "image": None, "custom": None}, "metadata": {}},
+                {"event": "action", "timestamp": 1594907100.43384, "name": "action_listen",
+                 "policy": "policy_0_MemoizationPolicy", "confidence": 1},
+                {"event": "user", "timestamp": 1594907117.04194, "text": "can\"t",
+                 "parse_data": {"intent": {"name": "test intent", "confidence": 0.253578245639801}, "entities": [],
+                                "intent_ranking": [{"name": "test intent", "confidence": 0.253578245639801},
+                                                   {"name": "goodbye", "confidence": 0.1504897326231},
+                                                   {"name": "greet", "confidence": 0.138640150427818},
+                                                   {"name": "affirm", "confidence": 0.0857767835259438},
+                                                   {"name": "smalltalk_human", "confidence": 0.0721133947372437},
+                                                   {"name": "deny", "confidence": 0.069614589214325},
+                                                   {"name": "bot_challenge", "confidence": 0.0664894133806229},
+                                                   {"name": "faq_vaccine", "confidence": 0.062177762389183},
+                                                   {"name": "faq_testing", "confidence": 0.0530692934989929},
+                                                   {"name": "out_of_scope", "confidence": 0.0480506233870983}],
+                                "response_selector": {
+                                    "default": {"response": {"name": None, "confidence": 0}, "ranking": [],
+                                                "full_retrieval_intent": None}}, "text": "can\"t"},
+                 "input_channel": None, "message_id": "e96e2a85de0748798748385503c65fb3", "metadata": {}},
+                {"event": "action", "timestamp": 1594907117.04547, "name": "utter_test intent",
+                 "policy": "policy_1_TEDPolicy", "confidence": 0.978452920913696},
+                {"event": "bot", "timestamp": 1594907117.04548, "text": "can not = can't",
+                 "data": {"elements": None, "quick_replies": None, "buttons": None, "attachment": None,
+                          "image": None, "custom": None}, "metadata": {}}],
+            "latest_input_channel": "rest",
+            "active_loop": {},
+            "latest_action": {},
+        },
+        "domain": {
+            "config": {},
+            "session_config": {},
+            "intents": [],
+            "entities": [],
+            "slots": {"bot": "5f50fd0a56b698ca10d35d2e"},
+            "responses": {},
+            "actions": [],
+            "forms": {},
+            "e2e_actions": []
+        },
+        "version": "version"
+    }
+    mock_action.side_effect = _get_action
+    mock_action_config.side_effect = _get_action_config
+    response = client.post("/webhook", json=request_object)
+    response_json = response.json()
+    assert response.status_code == 200
+    assert len(response_json['events']) == 1
+    assert len(response_json['responses']) == 1
+    assert response_json['events'] == [
+        {'event': 'slot', 'timestamp': None, 'name': 'kairon_action_response',
+         'value': "Email Triggered"}]
+    assert response_json['responses'][0]['text'] == "Email Triggered"
+    logs = ActionServerLogs.objects(type=ActionType.email_action.value).order_by("-id").first()
+    assert logs.status == "SUCCESS"
+
+    name, args, kwargs = mock_smtp.method_calls.pop(0)
+    assert name == '().connect'
+    assert {} == kwargs
+
+    host, port = args
+    assert host == action_config.smtp_url
+    assert port == action_config.smtp_port
+    name, args, kwargs = mock_smtp.method_calls.pop(0)
+    assert name == '().login'
+    assert {} == kwargs
+
+    from_email, password = args
+    assert from_email == 'mahesh@gmail.com'
+    assert password == action_config.smtp_password.value
+
+    name, args, kwargs = mock_smtp.method_calls.pop(0)
+    assert name == '().sendmail'
+    assert {} == kwargs
+
+    assert args[0] == 'mahesh@gmail.com'
+    assert args[1] == ["test@test.com"]
+    assert str(args[2]).__contains__(action_config.subject)
+    assert str(args[2]).__contains__("Content-Type: text/html")
+    assert str(args[2]).__contains__("Subject: mahesh.sattala test")
+
+
+@patch("kairon.shared.actions.utils.ActionUtility.get_action")
+@patch("kairon.actions.definitions.email.ActionEmail.retrieve_config")
+@patch("kairon.shared.utils.SMTP", autospec=True)
+def test_email_action_execution_with_receiver_email_list_from_slot(mock_smtp, mock_action_config, mock_action):
+    Utility.email_conf['email']['templates']['conversation'] = open('template/emails/conversation.html',
+                                                                    'rb').read().decode()
+    Utility.email_conf['email']['templates']['bot_msg_conversation'] = open(
+        'template/emails/bot_msg_conversation.html', 'rb').read().decode()
+    Utility.email_conf['email']['templates']['user_msg_conversation'] = open(
+        'template/emails/user_msg_conversation.html', 'rb').read().decode()
+    Utility.email_conf['email']['templates']['button_template'] = open('template/emails/button.html',
+                                                                       'rb').read().decode()
+
+    action_name = "test_email_action_execution_with_receiver_email_list_from_slot"
+    action = Actions(name=action_name, type=ActionType.email_action.value, bot="bot", user="user")
+    action_config = EmailActionConfig(
+        action_name=action_name,
+        smtp_url="test.localhost",
+        smtp_port=293,
+        smtp_password=CustomActionRequestParameters(key='smtp_password', value="test"),
+        from_email=CustomActionRequestParameters(value="test@demo.com", parameter_type="value"),
+        to_email=CustomActionParameters(value="to_email", parameter_type="slot"),
+        subject="test",
+        response="Email Triggered",
+        bot="bot",
+        user="user"
+    )
+
+    def _get_action(*arge, **kwargs):
+        return action.to_mongo().to_dict()
+
+    def _get_action_config(*arge, **kwargs):
+        return action_config.to_mongo().to_dict()
+
+    request_object = {
+        "next_action": action_name,
+        "tracker": {
+            "sender_id": "mahesh.sattala",
+            "conversation_id": "default",
+            "slots": {"bot": "5f50fd0a56b698ca10d35d2e", "requested_slot": "to_email",
+                      "to_email": ["test@gmail.com"]},
+            "latest_message": {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]},
+            "latest_event_time": 1537645578.314389,
+            "followup_action": "action_listen",
+            "paused": False,
+            "events": [
+                {"event": "action", "timestamp": 1594907100.12764, "name": "action_session_start", "policy": None,
+                 "confidence": None}, {"event": "session_started", "timestamp": 1594907100.12765},
+                {"event": "action", "timestamp": 1594907100.12767, "name": "action_listen", "policy": None,
+                 "confidence": None}, {"event": "user", "timestamp": 1594907100.42744, "text": "can't",
+                                       "parse_data": {
+                                           "intent": {"name": "test intent", "confidence": 0.253578245639801},
+                                           "entities": [], "intent_ranking": [
+                                               {"name": "test intent", "confidence": 0.253578245639801},
+                                               {"name": "goodbye", "confidence": 0.1504897326231},
+                                               {"name": "greet", "confidence": 0.138640150427818},
+                                               {"name": "affirm", "confidence": 0.0857767835259438},
+                                               {"name": "smalltalk_human", "confidence": 0.0721133947372437},
+                                               {"name": "deny", "confidence": 0.069614589214325},
+                                               {"name": "bot_challenge", "confidence": 0.0664894133806229},
+                                               {"name": "faq_vaccine", "confidence": 0.062177762389183},
+                                               {"name": "faq_testing", "confidence": 0.0530692934989929},
+                                               {"name": "out_of_scope", "confidence": 0.0480506233870983}],
+                                           "response_selector": {
+                                               "default": {"response": {"name": None, "confidence": 0},
+                                                           "ranking": [], "full_retrieval_intent": None}},
+                                           "text": "can't"}, "input_channel": None,
+                                       "message_id": "bbd413bf5c834bf3b98e0da2373553b2", "metadata": {}},
+                {"event": "action", "timestamp": 1594907100.4308, "name": "utter_test intent",
+                 "policy": "policy_0_MemoizationPolicy", "confidence": 1},
+                {"event": "bot", "timestamp": 1594907100.4308, "text": "will not = won\"t",
+                 "data": {"elements": None, "quick_replies": None, "buttons": None, "attachment": None,
+                          "image": None, "custom": None}, "metadata": {}},
+                {"event": "action", "timestamp": 1594907100.43384, "name": "action_listen",
+                 "policy": "policy_0_MemoizationPolicy", "confidence": 1},
+                {"event": "user", "timestamp": 1594907117.04194, "text": "can\"t",
+                 "parse_data": {"intent": {"name": "test intent", "confidence": 0.253578245639801}, "entities": [],
+                                "intent_ranking": [{"name": "test intent", "confidence": 0.253578245639801},
+                                                   {"name": "goodbye", "confidence": 0.1504897326231},
+                                                   {"name": "greet", "confidence": 0.138640150427818},
+                                                   {"name": "affirm", "confidence": 0.0857767835259438},
+                                                   {"name": "smalltalk_human", "confidence": 0.0721133947372437},
+                                                   {"name": "deny", "confidence": 0.069614589214325},
+                                                   {"name": "bot_challenge", "confidence": 0.0664894133806229},
+                                                   {"name": "faq_vaccine", "confidence": 0.062177762389183},
+                                                   {"name": "faq_testing", "confidence": 0.0530692934989929},
+                                                   {"name": "out_of_scope", "confidence": 0.0480506233870983}],
+                                "response_selector": {
+                                    "default": {"response": {"name": None, "confidence": 0}, "ranking": [],
+                                                "full_retrieval_intent": None}}, "text": "can\"t"},
+                 "input_channel": None, "message_id": "e96e2a85de0748798748385503c65fb3", "metadata": {}},
+                {"event": "action", "timestamp": 1594907117.04547, "name": "utter_test intent",
+                 "policy": "policy_1_TEDPolicy", "confidence": 0.978452920913696},
+                {"event": "bot", "timestamp": 1594907117.04548, "text": "can not = can't",
+                 "data": {"elements": None, "quick_replies": None, "buttons": None, "attachment": None,
+                          "image": None, "custom": None}, "metadata": {}}],
+            "latest_input_channel": "rest",
+            "active_loop": {},
+            "latest_action": {},
+        },
+        "domain": {
+            "config": {},
+            "session_config": {},
+            "intents": [],
+            "entities": [],
+            "slots": {"bot": "5f50fd0a56b698ca10d35d2e"},
+            "responses": {},
+            "actions": [],
+            "forms": {},
+            "e2e_actions": []
+        },
+        "version": "version"
+    }
+    mock_action.side_effect = _get_action
+    mock_action_config.side_effect = _get_action_config
+    response = client.post("/webhook", json=request_object)
+    response_json = response.json()
+    assert response.status_code == 200
+    assert len(response_json['events']) == 1
+    assert len(response_json['responses']) == 1
+    assert response_json['events'] == [
+        {'event': 'slot', 'timestamp': None, 'name': 'kairon_action_response',
+         'value': "Email Triggered"}]
+    assert response_json['responses'][0]['text'] == "Email Triggered"
+    logs = ActionServerLogs.objects(type=ActionType.email_action.value).order_by("-id").first()
+    assert logs.status == "SUCCESS"
+
+    name, args, kwargs = mock_smtp.method_calls.pop(0)
+    assert name == '().connect'
+    assert {} == kwargs
+
+    host, port = args
+    assert host == action_config.smtp_url
+    assert port == action_config.smtp_port
+    name, args, kwargs = mock_smtp.method_calls.pop(0)
+    assert name == '().login'
+    assert {} == kwargs
+
+    from_email, password = args
+    assert from_email == action_config.from_email.value
+    assert password == action_config.smtp_password.value
+
+    name, args, kwargs = mock_smtp.method_calls.pop(0)
+    assert name == '().sendmail'
+    assert {} == kwargs
+
+    assert args[0] == action_config.from_email.value
+    assert args[1] == ["test@gmail.com"]
+    assert str(args[2]).__contains__(action_config.subject)
+    assert str(args[2]).__contains__("Content-Type: text/html")
+    assert str(args[2]).__contains__("Subject: mahesh.sattala test")
+
+
+@patch("kairon.shared.actions.utils.ActionUtility.get_action")
+@patch("kairon.actions.definitions.email.ActionEmail.retrieve_config")
+@patch("kairon.shared.utils.SMTP", autospec=True)
+def test_email_action_execution_with_single_receiver_email_from_slot(mock_smtp, mock_action_config, mock_action):
+    Utility.email_conf['email']['templates']['conversation'] = open('template/emails/conversation.html',
+                                                                    'rb').read().decode()
+    Utility.email_conf['email']['templates']['bot_msg_conversation'] = open(
+        'template/emails/bot_msg_conversation.html', 'rb').read().decode()
+    Utility.email_conf['email']['templates']['user_msg_conversation'] = open(
+        'template/emails/user_msg_conversation.html', 'rb').read().decode()
+    Utility.email_conf['email']['templates']['button_template'] = open('template/emails/button.html',
+                                                                       'rb').read().decode()
+
+    action_name = "test_email_action_execution_with_single_receiver_email_from_slot"
+    action = Actions(name=action_name, type=ActionType.email_action.value, bot="bot", user="user")
+    action_config = EmailActionConfig(
+        action_name=action_name,
+        smtp_url="test.localhost",
+        smtp_port=293,
+        smtp_password=CustomActionRequestParameters(key='smtp_password', value="test"),
+        from_email=CustomActionRequestParameters(value="test@demo.com", parameter_type="value"),
+        to_email=CustomActionParameters(value="to_email", parameter_type="slot"),
+        subject="test",
+        response="Email Triggered",
+        bot="bot",
+        user="user"
+    )
+
+    def _get_action(*arge, **kwargs):
+        return action.to_mongo().to_dict()
+
+    def _get_action_config(*arge, **kwargs):
+        return action_config.to_mongo().to_dict()
+
+    request_object = {
+        "next_action": action_name,
+        "tracker": {
+            "sender_id": "mahesh.sattala",
+            "conversation_id": "default",
+            "slots": {"bot": "5f50fd0a56b698ca10d35d2e", "requested_slot": "to_email",
+                      "to_email": "example@gmail.com"},
+            "latest_message": {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]},
+            "latest_event_time": 1537645578.314389,
+            "followup_action": "action_listen",
+            "paused": False,
+            "events": [
+                {"event": "action", "timestamp": 1594907100.12764, "name": "action_session_start", "policy": None,
+                 "confidence": None}, {"event": "session_started", "timestamp": 1594907100.12765},
+                {"event": "action", "timestamp": 1594907100.12767, "name": "action_listen", "policy": None,
+                 "confidence": None}, {"event": "user", "timestamp": 1594907100.42744, "text": "can't",
+                                       "parse_data": {
+                                           "intent": {"name": "test intent", "confidence": 0.253578245639801},
+                                           "entities": [], "intent_ranking": [
+                                               {"name": "test intent", "confidence": 0.253578245639801},
+                                               {"name": "goodbye", "confidence": 0.1504897326231},
+                                               {"name": "greet", "confidence": 0.138640150427818},
+                                               {"name": "affirm", "confidence": 0.0857767835259438},
+                                               {"name": "smalltalk_human", "confidence": 0.0721133947372437},
+                                               {"name": "deny", "confidence": 0.069614589214325},
+                                               {"name": "bot_challenge", "confidence": 0.0664894133806229},
+                                               {"name": "faq_vaccine", "confidence": 0.062177762389183},
+                                               {"name": "faq_testing", "confidence": 0.0530692934989929},
+                                               {"name": "out_of_scope", "confidence": 0.0480506233870983}],
+                                           "response_selector": {
+                                               "default": {"response": {"name": None, "confidence": 0},
+                                                           "ranking": [], "full_retrieval_intent": None}},
+                                           "text": "can't"}, "input_channel": None,
+                                       "message_id": "bbd413bf5c834bf3b98e0da2373553b2", "metadata": {}},
+                {"event": "action", "timestamp": 1594907100.4308, "name": "utter_test intent",
+                 "policy": "policy_0_MemoizationPolicy", "confidence": 1},
+                {"event": "bot", "timestamp": 1594907100.4308, "text": "will not = won\"t",
+                 "data": {"elements": None, "quick_replies": None, "buttons": None, "attachment": None,
+                          "image": None, "custom": None}, "metadata": {}},
+                {"event": "action", "timestamp": 1594907100.43384, "name": "action_listen",
+                 "policy": "policy_0_MemoizationPolicy", "confidence": 1},
+                {"event": "user", "timestamp": 1594907117.04194, "text": "can\"t",
+                 "parse_data": {"intent": {"name": "test intent", "confidence": 0.253578245639801}, "entities": [],
+                                "intent_ranking": [{"name": "test intent", "confidence": 0.253578245639801},
+                                                   {"name": "goodbye", "confidence": 0.1504897326231},
+                                                   {"name": "greet", "confidence": 0.138640150427818},
+                                                   {"name": "affirm", "confidence": 0.0857767835259438},
+                                                   {"name": "smalltalk_human", "confidence": 0.0721133947372437},
+                                                   {"name": "deny", "confidence": 0.069614589214325},
+                                                   {"name": "bot_challenge", "confidence": 0.0664894133806229},
+                                                   {"name": "faq_vaccine", "confidence": 0.062177762389183},
+                                                   {"name": "faq_testing", "confidence": 0.0530692934989929},
+                                                   {"name": "out_of_scope", "confidence": 0.0480506233870983}],
+                                "response_selector": {
+                                    "default": {"response": {"name": None, "confidence": 0}, "ranking": [],
+                                                "full_retrieval_intent": None}}, "text": "can\"t"},
+                 "input_channel": None, "message_id": "e96e2a85de0748798748385503c65fb3", "metadata": {}},
+                {"event": "action", "timestamp": 1594907117.04547, "name": "utter_test intent",
+                 "policy": "policy_1_TEDPolicy", "confidence": 0.978452920913696},
+                {"event": "bot", "timestamp": 1594907117.04548, "text": "can not = can't",
+                 "data": {"elements": None, "quick_replies": None, "buttons": None, "attachment": None,
+                          "image": None, "custom": None}, "metadata": {}}],
+            "latest_input_channel": "rest",
+            "active_loop": {},
+            "latest_action": {},
+        },
+        "domain": {
+            "config": {},
+            "session_config": {},
+            "intents": [],
+            "entities": [],
+            "slots": {"bot": "5f50fd0a56b698ca10d35d2e"},
+            "responses": {},
+            "actions": [],
+            "forms": {},
+            "e2e_actions": []
+        },
+        "version": "version"
+    }
+    mock_action.side_effect = _get_action
+    mock_action_config.side_effect = _get_action_config
+    response = client.post("/webhook", json=request_object)
+    response_json = response.json()
+    assert response.status_code == 200
+    assert len(response_json['events']) == 1
+    assert len(response_json['responses']) == 1
+    assert response_json['events'] == [
+        {'event': 'slot', 'timestamp': None, 'name': 'kairon_action_response',
+         'value': "Email Triggered"}]
+    assert response_json['responses'][0]['text'] == "Email Triggered"
+    logs = ActionServerLogs.objects(type=ActionType.email_action.value).order_by("-id").first()
+    assert logs.status == "SUCCESS"
+
+    name, args, kwargs = mock_smtp.method_calls.pop(0)
+    assert name == '().connect'
+    assert {} == kwargs
+
+    host, port = args
+    assert host == action_config.smtp_url
+    assert port == action_config.smtp_port
+    name, args, kwargs = mock_smtp.method_calls.pop(0)
+    assert name == '().login'
+    assert {} == kwargs
+
+    from_email, password = args
+    assert from_email == action_config.from_email.value
+    assert password == action_config.smtp_password.value
+
+    name, args, kwargs = mock_smtp.method_calls.pop(0)
+    assert name == '().sendmail'
+    assert {} == kwargs
+
+    assert args[0] == action_config.from_email.value
+    assert args[1] == ["example@gmail.com"]
+    assert str(args[2]).__contains__(action_config.subject)
+    assert str(args[2]).__contains__("Content-Type: text/html")
+    assert str(args[2]).__contains__("Subject: mahesh.sattala test")
+
+
+@patch("kairon.shared.actions.utils.ActionUtility.get_action")
+@patch("kairon.actions.definitions.email.ActionEmail.retrieve_config")
+@patch("kairon.shared.utils.SMTP", autospec=True)
+def test_email_action_execution_with_invalid_from_email(mock_smtp, mock_action_config, mock_action):
+    Utility.email_conf['email']['templates']['conversation'] = open('template/emails/conversation.html',
+                                                                    'rb').read().decode()
+    Utility.email_conf['email']['templates']['bot_msg_conversation'] = open(
+        'template/emails/bot_msg_conversation.html', 'rb').read().decode()
+    Utility.email_conf['email']['templates']['user_msg_conversation'] = open(
+        'template/emails/user_msg_conversation.html', 'rb').read().decode()
+    Utility.email_conf['email']['templates']['button_template'] = open('template/emails/button.html',
+                                                                       'rb').read().decode()
+
+    action_name = "test_email_action_execution_with_invalid_from_email"
+    action = Actions(name=action_name, type=ActionType.email_action.value, bot="bot", user="user")
+    action_config = EmailActionConfig(
+        action_name=action_name,
+        smtp_url="test.localhost",
+        smtp_port=293,
+        smtp_password=CustomActionRequestParameters(key='smtp_password', value="test"),
+        from_email=CustomActionRequestParameters(value=["test@demo.com"], parameter_type="value"),
+        to_email=CustomActionParameters(value="to_email", parameter_type="slot"),
+        subject="test",
+        response="Email Triggered",
+        bot="bot",
+        user="user"
+    )
+
+    def _get_action(*arge, **kwargs):
+        return action.to_mongo().to_dict()
+
+    def _get_action_config(*arge, **kwargs):
+        return action_config.to_mongo().to_dict()
+
+    request_object = {
+        "next_action": action_name,
+        "tracker": {
+            "sender_id": "mahesh.sattala",
+            "conversation_id": "default",
+            "slots": {"bot": "5f50fd0a56b698ca10d35d2e", "requested_slot": "to_email",
+                      "to_email": "example@gmail.com"},
+            "latest_message": {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]},
+            "latest_event_time": 1537645578.314389,
+            "followup_action": "action_listen",
+            "paused": False,
+            "events": [
+                {"event": "action", "timestamp": 1594907100.12764, "name": "action_session_start", "policy": None,
+                 "confidence": None}, {"event": "session_started", "timestamp": 1594907100.12765},
+                {"event": "action", "timestamp": 1594907100.12767, "name": "action_listen", "policy": None,
+                 "confidence": None}, {"event": "user", "timestamp": 1594907100.42744, "text": "can't",
+                                       "parse_data": {
+                                           "intent": {"name": "test intent", "confidence": 0.253578245639801},
+                                           "entities": [], "intent_ranking": [
+                                               {"name": "test intent", "confidence": 0.253578245639801},
+                                               {"name": "goodbye", "confidence": 0.1504897326231},
+                                               {"name": "greet", "confidence": 0.138640150427818},
+                                               {"name": "affirm", "confidence": 0.0857767835259438},
+                                               {"name": "smalltalk_human", "confidence": 0.0721133947372437},
+                                               {"name": "deny", "confidence": 0.069614589214325},
+                                               {"name": "bot_challenge", "confidence": 0.0664894133806229},
+                                               {"name": "faq_vaccine", "confidence": 0.062177762389183},
+                                               {"name": "faq_testing", "confidence": 0.0530692934989929},
+                                               {"name": "out_of_scope", "confidence": 0.0480506233870983}],
+                                           "response_selector": {
+                                               "default": {"response": {"name": None, "confidence": 0},
+                                                           "ranking": [], "full_retrieval_intent": None}},
+                                           "text": "can't"}, "input_channel": None,
+                                       "message_id": "bbd413bf5c834bf3b98e0da2373553b2", "metadata": {}},
+                {"event": "action", "timestamp": 1594907100.4308, "name": "utter_test intent",
+                 "policy": "policy_0_MemoizationPolicy", "confidence": 1},
+                {"event": "bot", "timestamp": 1594907100.4308, "text": "will not = won\"t",
+                 "data": {"elements": None, "quick_replies": None, "buttons": None, "attachment": None,
+                          "image": None, "custom": None}, "metadata": {}},
+                {"event": "action", "timestamp": 1594907100.43384, "name": "action_listen",
+                 "policy": "policy_0_MemoizationPolicy", "confidence": 1},
+                {"event": "user", "timestamp": 1594907117.04194, "text": "can\"t",
+                 "parse_data": {"intent": {"name": "test intent", "confidence": 0.253578245639801}, "entities": [],
+                                "intent_ranking": [{"name": "test intent", "confidence": 0.253578245639801},
+                                                   {"name": "goodbye", "confidence": 0.1504897326231},
+                                                   {"name": "greet", "confidence": 0.138640150427818},
+                                                   {"name": "affirm", "confidence": 0.0857767835259438},
+                                                   {"name": "smalltalk_human", "confidence": 0.0721133947372437},
+                                                   {"name": "deny", "confidence": 0.069614589214325},
+                                                   {"name": "bot_challenge", "confidence": 0.0664894133806229},
+                                                   {"name": "faq_vaccine", "confidence": 0.062177762389183},
+                                                   {"name": "faq_testing", "confidence": 0.0530692934989929},
+                                                   {"name": "out_of_scope", "confidence": 0.0480506233870983}],
+                                "response_selector": {
+                                    "default": {"response": {"name": None, "confidence": 0}, "ranking": [],
+                                                "full_retrieval_intent": None}}, "text": "can\"t"},
+                 "input_channel": None, "message_id": "e96e2a85de0748798748385503c65fb3", "metadata": {}},
+                {"event": "action", "timestamp": 1594907117.04547, "name": "utter_test intent",
+                 "policy": "policy_1_TEDPolicy", "confidence": 0.978452920913696},
+                {"event": "bot", "timestamp": 1594907117.04548, "text": "can not = can't",
+                 "data": {"elements": None, "quick_replies": None, "buttons": None, "attachment": None,
+                          "image": None, "custom": None}, "metadata": {}}],
+            "latest_input_channel": "rest",
+            "active_loop": {},
+            "latest_action": {},
+        },
+        "domain": {
+            "config": {},
+            "session_config": {},
+            "intents": [],
+            "entities": [],
+            "slots": {"bot": "5f50fd0a56b698ca10d35d2e"},
+            "responses": {},
+            "actions": [],
+            "forms": {},
+            "e2e_actions": []
+        },
+        "version": "version"
+    }
+    mock_action.side_effect = _get_action
+    mock_action_config.side_effect = _get_action_config
+    response = client.post("/webhook", json=request_object)
+    response_json = response.json()
+    assert response.status_code == 200
+    assert len(response_json['events']) == 1
+    assert len(response_json['responses']) == 1
+    assert response_json['events'] == [
+        {'event': 'slot', 'timestamp': None, 'name': 'kairon_action_response',
+         'value': "I have failed to process your request"}]
+    assert response_json['responses'][0]['text'] == "I have failed to process your request"
+    logs = ActionServerLogs.objects(type=ActionType.email_action.value).order_by("-id").first()
+    assert logs.status == "FAILURE"
+    assert logs.exception == "Invalid 'from_email' type. It must be of type str."
+
+
+@patch("kairon.shared.actions.utils.ActionUtility.get_action")
+@patch("kairon.actions.definitions.email.ActionEmail.retrieve_config")
+@patch("kairon.shared.utils.SMTP", autospec=True)
+def test_email_action_execution_with_invalid_to_email(mock_smtp, mock_action_config, mock_action):
+    Utility.email_conf['email']['templates']['conversation'] = open('template/emails/conversation.html',
+                                                                    'rb').read().decode()
+    Utility.email_conf['email']['templates']['bot_msg_conversation'] = open(
+        'template/emails/bot_msg_conversation.html', 'rb').read().decode()
+    Utility.email_conf['email']['templates']['user_msg_conversation'] = open(
+        'template/emails/user_msg_conversation.html', 'rb').read().decode()
+    Utility.email_conf['email']['templates']['button_template'] = open('template/emails/button.html',
+                                                                       'rb').read().decode()
+
+    action_name = "test_email_action_execution_with_invalid_to_email"
+    action = Actions(name=action_name, type=ActionType.email_action.value, bot="bot", user="user")
+    action_config = EmailActionConfig(
+        action_name=action_name,
+        smtp_url="test.localhost",
+        smtp_port=293,
+        smtp_password=CustomActionRequestParameters(key='smtp_password', value="test"),
+        from_email=CustomActionRequestParameters(value="test@demo.com", parameter_type="value"),
+        to_email=CustomActionParameters(value={"to_email": "test@test.com"}, parameter_type="value"),
+        subject="test",
+        response="Email Triggered",
+        bot="bot",
+        user="user"
+    )
+
+    def _get_action(*arge, **kwargs):
+        return action.to_mongo().to_dict()
+
+    def _get_action_config(*arge, **kwargs):
+        return action_config.to_mongo().to_dict()
+
+    request_object = {
+        "next_action": action_name,
+        "tracker": {
+            "sender_id": "mahesh.sattala",
+            "conversation_id": "default",
+            "slots": {"bot": "5f50fd0a56b698ca10d35d2e", "requested_slot": "to_email",
+                      "to_email": "example@gmail.com"},
+            "latest_message": {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]},
+            "latest_event_time": 1537645578.314389,
+            "followup_action": "action_listen",
+            "paused": False,
+            "events": [
+                {"event": "action", "timestamp": 1594907100.12764, "name": "action_session_start", "policy": None,
+                 "confidence": None}, {"event": "session_started", "timestamp": 1594907100.12765},
+                {"event": "action", "timestamp": 1594907100.12767, "name": "action_listen", "policy": None,
+                 "confidence": None}, {"event": "user", "timestamp": 1594907100.42744, "text": "can't",
+                                       "parse_data": {
+                                           "intent": {"name": "test intent", "confidence": 0.253578245639801},
+                                           "entities": [], "intent_ranking": [
+                                               {"name": "test intent", "confidence": 0.253578245639801},
+                                               {"name": "goodbye", "confidence": 0.1504897326231},
+                                               {"name": "greet", "confidence": 0.138640150427818},
+                                               {"name": "affirm", "confidence": 0.0857767835259438},
+                                               {"name": "smalltalk_human", "confidence": 0.0721133947372437},
+                                               {"name": "deny", "confidence": 0.069614589214325},
+                                               {"name": "bot_challenge", "confidence": 0.0664894133806229},
+                                               {"name": "faq_vaccine", "confidence": 0.062177762389183},
+                                               {"name": "faq_testing", "confidence": 0.0530692934989929},
+                                               {"name": "out_of_scope", "confidence": 0.0480506233870983}],
+                                           "response_selector": {
+                                               "default": {"response": {"name": None, "confidence": 0},
+                                                           "ranking": [], "full_retrieval_intent": None}},
+                                           "text": "can't"}, "input_channel": None,
+                                       "message_id": "bbd413bf5c834bf3b98e0da2373553b2", "metadata": {}},
+                {"event": "action", "timestamp": 1594907100.4308, "name": "utter_test intent",
+                 "policy": "policy_0_MemoizationPolicy", "confidence": 1},
+                {"event": "bot", "timestamp": 1594907100.4308, "text": "will not = won\"t",
+                 "data": {"elements": None, "quick_replies": None, "buttons": None, "attachment": None,
+                          "image": None, "custom": None}, "metadata": {}},
+                {"event": "action", "timestamp": 1594907100.43384, "name": "action_listen",
+                 "policy": "policy_0_MemoizationPolicy", "confidence": 1},
+                {"event": "user", "timestamp": 1594907117.04194, "text": "can\"t",
+                 "parse_data": {"intent": {"name": "test intent", "confidence": 0.253578245639801}, "entities": [],
+                                "intent_ranking": [{"name": "test intent", "confidence": 0.253578245639801},
+                                                   {"name": "goodbye", "confidence": 0.1504897326231},
+                                                   {"name": "greet", "confidence": 0.138640150427818},
+                                                   {"name": "affirm", "confidence": 0.0857767835259438},
+                                                   {"name": "smalltalk_human", "confidence": 0.0721133947372437},
+                                                   {"name": "deny", "confidence": 0.069614589214325},
+                                                   {"name": "bot_challenge", "confidence": 0.0664894133806229},
+                                                   {"name": "faq_vaccine", "confidence": 0.062177762389183},
+                                                   {"name": "faq_testing", "confidence": 0.0530692934989929},
+                                                   {"name": "out_of_scope", "confidence": 0.0480506233870983}],
+                                "response_selector": {
+                                    "default": {"response": {"name": None, "confidence": 0}, "ranking": [],
+                                                "full_retrieval_intent": None}}, "text": "can\"t"},
+                 "input_channel": None, "message_id": "e96e2a85de0748798748385503c65fb3", "metadata": {}},
+                {"event": "action", "timestamp": 1594907117.04547, "name": "utter_test intent",
+                 "policy": "policy_1_TEDPolicy", "confidence": 0.978452920913696},
+                {"event": "bot", "timestamp": 1594907117.04548, "text": "can not = can't",
+                 "data": {"elements": None, "quick_replies": None, "buttons": None, "attachment": None,
+                          "image": None, "custom": None}, "metadata": {}}],
+            "latest_input_channel": "rest",
+            "active_loop": {},
+            "latest_action": {},
+        },
+        "domain": {
+            "config": {},
+            "session_config": {},
+            "intents": [],
+            "entities": [],
+            "slots": {"bot": "5f50fd0a56b698ca10d35d2e"},
+            "responses": {},
+            "actions": [],
+            "forms": {},
+            "e2e_actions": []
+        },
+        "version": "version"
+    }
+    mock_action.side_effect = _get_action
+    mock_action_config.side_effect = _get_action_config
+    response = client.post("/webhook", json=request_object)
+    response_json = response.json()
+    assert response.status_code == 200
+    assert len(response_json['events']) == 1
+    assert len(response_json['responses']) == 1
+    assert response_json['events'] == [
+        {'event': 'slot', 'timestamp': None, 'name': 'kairon_action_response',
+         'value': "I have failed to process your request"}]
+    assert response_json['responses'][0]['text'] == "I have failed to process your request"
+    logs = ActionServerLogs.objects(type=ActionType.email_action.value).order_by("-id").first()
+    assert logs.status == "FAILURE"
+    assert logs.exception == "Invalid 'from_email' type. It must be of type str."
+
+
+@patch("kairon.shared.actions.utils.ActionUtility.get_action")
+@patch("kairon.actions.definitions.email.ActionEmail.retrieve_config")
+@patch("kairon.shared.utils.SMTP", autospec=True)
+def test_email_action_execution_with_invalid_to_email(mock_smtp, mock_action_config, mock_action):
+    Utility.email_conf['email']['templates']['conversation'] = open('template/emails/conversation.html',
+                                                                    'rb').read().decode()
+    Utility.email_conf['email']['templates']['bot_msg_conversation'] = open(
+        'template/emails/bot_msg_conversation.html', 'rb').read().decode()
+    Utility.email_conf['email']['templates']['user_msg_conversation'] = open(
+        'template/emails/user_msg_conversation.html', 'rb').read().decode()
+    Utility.email_conf['email']['templates']['button_template'] = open('template/emails/button.html',
+                                                                       'rb').read().decode()
+
+    action_name = "test_email_action_execution_with_invalid_to_email"
+    action = Actions(name=action_name, type=ActionType.email_action.value, bot="bot", user="user")
+    action_config = EmailActionConfig(
+        action_name=action_name,
+        smtp_url="test.localhost",
+        smtp_port=293,
+        smtp_password=CustomActionRequestParameters(key='smtp_password', value="test"),
+        from_email=CustomActionRequestParameters(value="test@demo.com", parameter_type="value"),
+        to_email=CustomActionParameters(value={"to_email": "test@test.com"}, parameter_type="value"),
+        subject="test",
+        response="Email Triggered",
+        bot="bot",
+        user="user"
+    )
+
+    def _get_action(*arge, **kwargs):
+        return action.to_mongo().to_dict()
+
+    def _get_action_config(*arge, **kwargs):
+        return action_config.to_mongo().to_dict()
+
+    request_object = {
+        "next_action": action_name,
+        "tracker": {
+            "sender_id": "mahesh.sattala",
+            "conversation_id": "default",
+            "slots": {"bot": "5f50fd0a56b698ca10d35d2e", "requested_slot": "to_email",
+                      "to_email": "example@gmail.com"},
+            "latest_message": {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]},
+            "latest_event_time": 1537645578.314389,
+            "followup_action": "action_listen",
+            "paused": False,
+            "events": [
+                {"event": "action", "timestamp": 1594907100.12764, "name": "action_session_start", "policy": None,
+                 "confidence": None}, {"event": "session_started", "timestamp": 1594907100.12765},
+                {"event": "action", "timestamp": 1594907100.12767, "name": "action_listen", "policy": None,
+                 "confidence": None}, {"event": "user", "timestamp": 1594907100.42744, "text": "can't",
+                                       "parse_data": {
+                                           "intent": {"name": "test intent", "confidence": 0.253578245639801},
+                                           "entities": [], "intent_ranking": [
+                                               {"name": "test intent", "confidence": 0.253578245639801},
+                                               {"name": "goodbye", "confidence": 0.1504897326231},
+                                               {"name": "greet", "confidence": 0.138640150427818},
+                                               {"name": "affirm", "confidence": 0.0857767835259438},
+                                               {"name": "smalltalk_human", "confidence": 0.0721133947372437},
+                                               {"name": "deny", "confidence": 0.069614589214325},
+                                               {"name": "bot_challenge", "confidence": 0.0664894133806229},
+                                               {"name": "faq_vaccine", "confidence": 0.062177762389183},
+                                               {"name": "faq_testing", "confidence": 0.0530692934989929},
+                                               {"name": "out_of_scope", "confidence": 0.0480506233870983}],
+                                           "response_selector": {
+                                               "default": {"response": {"name": None, "confidence": 0},
+                                                           "ranking": [], "full_retrieval_intent": None}},
+                                           "text": "can't"}, "input_channel": None,
+                                       "message_id": "bbd413bf5c834bf3b98e0da2373553b2", "metadata": {}},
+                {"event": "action", "timestamp": 1594907100.4308, "name": "utter_test intent",
+                 "policy": "policy_0_MemoizationPolicy", "confidence": 1},
+                {"event": "bot", "timestamp": 1594907100.4308, "text": "will not = won\"t",
+                 "data": {"elements": None, "quick_replies": None, "buttons": None, "attachment": None,
+                          "image": None, "custom": None}, "metadata": {}},
+                {"event": "action", "timestamp": 1594907100.43384, "name": "action_listen",
+                 "policy": "policy_0_MemoizationPolicy", "confidence": 1},
+                {"event": "user", "timestamp": 1594907117.04194, "text": "can\"t",
+                 "parse_data": {"intent": {"name": "test intent", "confidence": 0.253578245639801}, "entities": [],
+                                "intent_ranking": [{"name": "test intent", "confidence": 0.253578245639801},
+                                                   {"name": "goodbye", "confidence": 0.1504897326231},
+                                                   {"name": "greet", "confidence": 0.138640150427818},
+                                                   {"name": "affirm", "confidence": 0.0857767835259438},
+                                                   {"name": "smalltalk_human", "confidence": 0.0721133947372437},
+                                                   {"name": "deny", "confidence": 0.069614589214325},
+                                                   {"name": "bot_challenge", "confidence": 0.0664894133806229},
+                                                   {"name": "faq_vaccine", "confidence": 0.062177762389183},
+                                                   {"name": "faq_testing", "confidence": 0.0530692934989929},
+                                                   {"name": "out_of_scope", "confidence": 0.0480506233870983}],
+                                "response_selector": {
+                                    "default": {"response": {"name": None, "confidence": 0}, "ranking": [],
+                                                "full_retrieval_intent": None}}, "text": "can\"t"},
+                 "input_channel": None, "message_id": "e96e2a85de0748798748385503c65fb3", "metadata": {}},
+                {"event": "action", "timestamp": 1594907117.04547, "name": "utter_test intent",
+                 "policy": "policy_1_TEDPolicy", "confidence": 0.978452920913696},
+                {"event": "bot", "timestamp": 1594907117.04548, "text": "can not = can't",
+                 "data": {"elements": None, "quick_replies": None, "buttons": None, "attachment": None,
+                          "image": None, "custom": None}, "metadata": {}}],
+            "latest_input_channel": "rest",
+            "active_loop": {},
+            "latest_action": {},
+        },
+        "domain": {
+            "config": {},
+            "session_config": {},
+            "intents": [],
+            "entities": [],
+            "slots": {"bot": "5f50fd0a56b698ca10d35d2e"},
+            "responses": {},
+            "actions": [],
+            "forms": {},
+            "e2e_actions": []
+        },
+        "version": "version"
+    }
+    mock_action.side_effect = _get_action
+    mock_action_config.side_effect = _get_action_config
+    response = client.post("/webhook", json=request_object)
+    response_json = response.json()
+    assert response.status_code == 200
+    assert len(response_json['events']) == 1
+    assert len(response_json['responses']) == 1
+    assert response_json['events'] == [
+        {'event': 'slot', 'timestamp': None, 'name': 'kairon_action_response',
+         'value': "I have failed to process your request"}]
+    assert response_json['responses'][0]['text'] == "I have failed to process your request"
+    logs = ActionServerLogs.objects(type=ActionType.email_action.value).order_by("-id").first()
+    print(logs.to_mongo().to_dict())
+    assert logs.status == "FAILURE"
+    assert logs.exception == "Invalid 'to_email' type. It must be of type str or list."
 
 
 @patch("kairon.shared.actions.utils.ActionUtility.get_action")
@@ -5551,9 +6398,9 @@ def test_email_action_execution_varied_utterances(mock_smtp, mock_action_config,
         smtp_url="test.localhost",
         smtp_port=293,
         smtp_password=CustomActionRequestParameters(key='smtp_password', value="test"),
-        from_email="test@demo.com",
+        from_email=CustomActionRequestParameters(value="test@demo.com", parameter_type="value"),
+        to_email=CustomActionParameters(value=["test@test.com"], parameter_type="value"),
         subject="test",
-        to_email=["test@test.com"],
         response="Email Triggered",
         bot="bot",
         user="user"
@@ -5875,14 +6722,14 @@ def test_email_action_execution_varied_utterances(mock_smtp, mock_action_config,
     assert {} == kwargs
 
     from_email, password = args
-    assert from_email == action_config.from_email
+    assert from_email == action_config.from_email.value
     assert password == action_config.smtp_password.value
 
     name, args, kwargs = mock_smtp.method_calls.pop(0)
     assert name == '().sendmail'
     assert {} == kwargs
 
-    assert args[0] == action_config.from_email
+    assert args[0] == action_config.from_email.value
     assert args[1] == ["test@test.com"]
     assert str(args[2]).__contains__(action_config.subject)
     assert str(args[2]).__contains__("Content-Type: text/html")
@@ -5997,9 +6844,9 @@ def test_email_action_failed_execution(mock_action_config, mock_action):
         smtp_url="test.localhost",
         smtp_port=293,
         smtp_password=CustomActionRequestParameters(value="test"),
-        from_email="test@demo.com",
+        from_email=CustomActionRequestParameters(value="test@demo.com", parameter_type="value"),
+        to_email=CustomActionParameters(value="test@test.com", parameter_type="value"),
         subject="test",
-        to_email="test@test.com",
         response="Email Triggered",
         bot="bot",
         user="user"

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -17199,8 +17199,8 @@ def test_add_email_action(mock_smtp):
         "smtp_port": 25,
         "smtp_userid": None,
         "smtp_password": {"value": "test"},
-        "from_email": "test@demo.com",
-        "to_email": ["test@test.com", "test1@test.com"],
+        "from_email": {"value": "from_email", "parameter_type": "slot"},
+        "to_email": {"value": ["test@test.com", "test1@test.com"], "parameter_type": "value"},
         "subject": "Test Subject",
         "response": "Test Response",
         "tls": False,
@@ -17224,8 +17224,8 @@ def test_add_email_action_from_different_parameter_type(mock_smtp):
         "smtp_port": 25,
         "smtp_userid": None,
         "smtp_password": {"value": "test", "parameter_type": "slot"},
-        "from_email": "test@demo.com",
-        "to_email": ["test@test.com", "test1@test.com"],
+        "from_email": {"value": "test@demo.com", "parameter_type": "value"},
+        "to_email": {"value": "to_email", "parameter_type": "slot"},
         "subject": "Test Subject",
         "response": "Test Response",
         "tls": False,
@@ -17246,8 +17246,8 @@ def test_add_email_action_from_different_parameter_type(mock_smtp):
         "smtp_port": 25,
         "smtp_userid": None,
         "smtp_password": {"value": "test", "parameter_type": "key_vault"},
-        "from_email": "test@demo.com",
-        "to_email": ["test@test.com", "test1@test.com"],
+        "from_email": {"value": "test@demo.com", "parameter_type": "value"},
+        "to_email": {"value": "to_email", "parameter_type": "slot"},
         "subject": "Test Subject",
         "response": "Test Response",
         "tls": False,
@@ -17271,8 +17271,8 @@ def test_add_email_action_from_invalid_parameter_type(mock_smtp):
         "smtp_port": 25,
         "smtp_userid": None,
         "smtp_password": {"value": "test", "parameter_type": "intent"},
-        "from_email": "test@demo.com",
-        "to_email": ["test@test.com", "test1@test.com"],
+        "from_email": {"value": "test@demo.com", "parameter_type": "value"},
+        "to_email": {"value": "to_email", "parameter_type": "slot"},
         "subject": "Test Subject",
         "response": "Test Response",
         "tls": False,
@@ -17292,8 +17292,8 @@ def test_add_email_action_from_invalid_parameter_type(mock_smtp):
         "smtp_port": 25,
         "smtp_userid": None,
         "smtp_password": {"value": "", "parameter_type": "slot"},
-        "from_email": "test@demo.com",
-        "to_email": ["test@test.com", "test1@test.com"],
+        "from_email": {"value": "test@demo.com", "parameter_type": "value"},
+        "to_email": {"value": "to_email", "parameter_type": "slot"},
         "subject": "Test Subject",
         "response": "Test Response",
         "tls": False,
@@ -17313,8 +17313,8 @@ def test_add_email_action_from_invalid_parameter_type(mock_smtp):
         "smtp_port": 25,
         "smtp_userid": None,
         "smtp_password": {"value": "", "parameter_type": "key_vault"},
-        "from_email": "test@demo.com",
-        "to_email": ["test@test.com", "test1@test.com"],
+        "from_email": {"value": "test@demo.com", "parameter_type": "value"},
+        "to_email": {"value": "to_email", "parameter_type": "slot"},
         "subject": "Test Subject",
         "response": "Test Response",
         "tls": False,
@@ -17327,6 +17327,139 @@ def test_add_email_action_from_invalid_parameter_type(mock_smtp):
     actual = response.json()
     assert not actual["success"]
     assert actual["error_code"] == 422
+
+
+@patch("kairon.shared.utils.SMTP", autospec=True)
+def test_add_email_action_from_invalid_parameter_type_1(mock_smtp):
+    request = {"action_name": "email_config_invalid_parameter_type",
+               "smtp_url": "test.test.com",
+               "smtp_port": 25,
+               "smtp_userid": None,
+               "smtp_password": {'value': "test", "parameter_type": "slot"},
+               "from_email": {"value": "test@demo.com", "parameter_type": "value"},
+               "to_email": {"value": "to_email", "parameter_type": "intent"},
+               "subject": "Test Subject",
+               "response": "Test Response",
+               "tls": False
+               }
+    response = client.post(
+        f"/api/bot/{pytest.bot}/action/email",
+        json=request,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+
+    request = {"action_name": "email_config_invalid_parameter_type",
+               "smtp_url": "test.test.com",
+               "smtp_port": 25,
+               "smtp_userid": None,
+               "smtp_password": {'value': "test", "parameter_type": "slot"},
+               "from_email": {"value": "test@demo.com", "parameter_type": "value"},
+               "to_email": {"value": "", "parameter_type": "slot"},
+               "subject": "Test Subject",
+               "response": "Test Response",
+               "tls": False
+               }
+    response = client.post(
+        f"/api/bot/{pytest.bot}/action/email",
+        json=request,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+    assert actual["message"] == [{'loc': ['body', 'to_email', '__root__'],
+                                  'msg': 'Provide name of the slot as value', 'type': 'value_error'}]
+    assert str(actual['message']).__contains__("Provide name of the slot as value")
+
+    request = {"action_name": "email_config_invalid_parameter_type",
+               "smtp_url": "test.test.com",
+               "smtp_port": 25,
+               "smtp_userid": None,
+               "smtp_password": {'value': "test", "parameter_type": "key_vault"},
+               "from_email": {"value": "test@demo.com", "parameter_type": "value"},
+               "to_email": {"value": "", "parameter_type": "value"},
+               "subject": "Test Subject",
+               "response": "Test Response",
+               "tls": False
+               }
+    response = client.post(
+        f"/api/bot/{pytest.bot}/action/email",
+        json=request,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+    assert actual["message"] == [{'loc': ['body', 'to_email', '__root__'],
+                                  'msg': 'Provide list of emails as value', 'type': 'value_error'}]
+    assert str(actual['message']).__contains__("Provide list of emails as value")
+
+    request = {"action_name": "email_config_invalid_parameter_type",
+               "smtp_url": "test.test.com",
+               "smtp_port": 25,
+               "smtp_userid": None,
+               "smtp_password": {'value': "test", "parameter_type": "slot"},
+               "from_email": {"value": "test@demo.com", "parameter_type": "intent"},
+               "to_email": {"value": "to_email", "parameter_type": "slot"},
+               "subject": "Test Subject",
+               "response": "Test Response",
+               "tls": False
+               }
+    response = client.post(
+        f"/api/bot/{pytest.bot}/action/email",
+        json=request,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+
+    request = {"action_name": "email_config_invalid_parameter_type",
+               "smtp_url": "test.test.com",
+               "smtp_port": 25,
+               "smtp_userid": None,
+               "smtp_password": {'value': "test", "parameter_type": "slot"},
+               "from_email": {"value": "", "parameter_type": "slot"},
+               "to_email": {"value": ["test@demo.com"], "parameter_type": "value"},
+               "subject": "Test Subject",
+               "response": "Test Response",
+               "tls": False
+               }
+    response = client.post(
+        f"/api/bot/{pytest.bot}/action/email",
+        json=request,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+    assert actual["message"] == [{'loc': ['body', 'from_email', '__root__'],
+                                  'msg': 'Provide name of the slot as value', 'type': 'value_error'}]
+    assert str(actual['message']).__contains__("Provide name of the slot as value")
+
+    request = {"action_name": "email_config_invalid_parameter_type",
+               "smtp_url": "test.test.com",
+               "smtp_port": 25,
+               "smtp_userid": None,
+               "smtp_password": {'value': "test", "parameter_type": "key_vault"},
+               "from_email": {"value": "", "parameter_type": "value"},
+               "to_email": {"value": ["test@demo.com"], "parameter_type": "value"},
+               "subject": "Test Subject",
+               "response": "Test Response",
+               "tls": False
+               }
+    response = client.post(
+        f"/api/bot/{pytest.bot}/action/email",
+        json=request,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+    assert actual["message"] == 'Invalid From or To email address'
 
 
 def test_list_email_actions():
@@ -17351,11 +17484,13 @@ def test_list_email_actions():
                 "value": "test",
                 "parameter_type": "value",
             },
-            "from_email": "test@demo.com",
-            "subject": "Test Subject",
-            "to_email": ["test@test.com", "test1@test.com"],
-            "response": "Test Response",
-            "tls": False,
+           'from_email': {'_cls': 'CustomActionRequestParameters', 'encrypt': False,
+                          'value': 'from_email', 'parameter_type': 'slot'},
+           'subject': 'Test Subject',
+           'to_email': {'_cls': 'CustomActionParameters', 'encrypt': False,
+                        'value': ['test@test.com', 'test1@test.com'], 'parameter_type': 'value'},
+           'response': 'Test Response',
+            'tls': False
         },
         {
             "action_name": "email_config_with_slot",
@@ -17368,10 +17503,12 @@ def test_list_email_actions():
                 "value": "test",
                 "parameter_type": "slot",
             },
-            "from_email": "test@demo.com",
-            "subject": "Test Subject",
-            "to_email": ["test@test.com", "test1@test.com"],
-            "response": "Test Response",
+           'from_email': {'_cls': 'CustomActionRequestParameters', 'encrypt': False,
+                          'value': 'test@demo.com', 'parameter_type': 'value'},
+           'subject': 'Test Subject',
+           'to_email': {'_cls': 'CustomActionParameters', 'encrypt': False, 'value': 'to_email',
+                        'parameter_type': 'slot'},
+            'response': 'Test Response',
             "tls": False,
         },
         {
@@ -17385,10 +17522,12 @@ def test_list_email_actions():
                 "value": "test",
                 "parameter_type": "key_vault",
             },
-            "from_email": "test@demo.com",
-            "subject": "Test Subject",
-            "to_email": ["test@test.com", "test1@test.com"],
-            "response": "Test Response",
+            'from_email': {'_cls': 'CustomActionRequestParameters', 'encrypt': False,
+                           'value': 'test@demo.com', 'parameter_type': 'value'},
+            'subject': 'Test Subject',
+            'to_email': {'_cls': 'CustomActionParameters', 'encrypt': False, 'value': 'to_email',
+                         'parameter_type': 'slot'},
+            'response': 'Test Response',
             "tls": False,
         },
     ]
@@ -17402,8 +17541,8 @@ def test_edit_email_action(mock_smtp):
         "smtp_port": 25,
         "smtp_userid": None,
         "smtp_password": {"value": "test"},
-        "from_email": "test@demo.com",
-        "to_email": ["test@test.com", "test1@test.com"],
+        "from_email": {"value": "test@demo.com", "parameter_type": "value"},
+        "to_email": {"value": "to_email", "parameter_type": "slot"},
         "subject": "Test Subject",
         "response": "Test Response",
         "tls": False,
@@ -17427,8 +17566,8 @@ def test_edit_email_action_different_parameter_type(mock_smtp):
         "smtp_port": 25,
         "smtp_userid": None,
         "smtp_password": {"value": "test", "parameter_type": "slot"},
-        "from_email": "test@demo.com",
-        "to_email": ["test@test.com", "test1@test.com"],
+        "from_email": {"value": "from_email", "parameter_type": "slot"},
+        "to_email": {"value": ["test@test.com", "test1@test.com"], "parameter_type": "value"},
         "subject": "Test Subject",
         "response": "Test Response",
         "tls": False,
@@ -17449,8 +17588,8 @@ def test_edit_email_action_different_parameter_type(mock_smtp):
         "smtp_port": 25,
         "smtp_userid": None,
         "smtp_password": {"value": "test", "parameter_type": "key_vault"},
-        "from_email": "test@demo.com",
-        "to_email": ["test@test.com", "test1@test.com"],
+        "from_email": {"value": "test@demo.com", "parameter_type": "value"},
+        "to_email": {"value": "to_email", "parameter_type": "slot"},
         "subject": "Test Subject",
         "response": "Test Response",
         "tls": False,
@@ -17473,12 +17612,12 @@ def test_edit_email_action_invalid_parameter_type(mock_smtp):
         "smtp_url": "test.test.com",
         "smtp_port": 25,
         "smtp_userid": None,
-        "smtp_password": {"value": "test", "parameter_type": "intent"},
-        "from_email": "test@demo.com",
-        "to_email": ["test@test.com", "test1@test.com"],
+        "smtp_password": {'value': "test", "parameter_type": "slot"},
+        "from_email": {"value": "test@demo.com", "parameter_type": "intent"},
+        "to_email": {"value": "to_email", "parameter_type": "slot"},
         "subject": "Test Subject",
         "response": "Test Response",
-        "tls": False,
+        "tls": False
     }
     response = client.put(
         f"/api/bot/{pytest.bot}/action/email",
@@ -17491,6 +17630,139 @@ def test_edit_email_action_invalid_parameter_type(mock_smtp):
 
 
 @patch("kairon.shared.utils.SMTP", autospec=True)
+def test_edit_email_action_invalid_parameter_type_1(mock_smtp):
+    request = {"action_name": "email_config_with_slot",
+               "smtp_url": "test.test.com",
+               "smtp_port": 25,
+               "smtp_userid": None,
+               "smtp_password": {'value': "test", "parameter_type": "slot"},
+               "from_email": {"value": "test@demo.com", "parameter_type": "value"},
+               "to_email": {"value": "to_email", "parameter_type": "intent"},
+               "subject": "Test Subject",
+               "response": "Test Response",
+               "tls": False
+               }
+    response = client.put(
+        f"/api/bot/{pytest.bot}/action/email",
+        json=request,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+
+    request = {"action_name": "email_config_with_slot",
+               "smtp_url": "test.test.com",
+               "smtp_port": 25,
+               "smtp_userid": None,
+               "smtp_password": {'value': "test", "parameter_type": "slot"},
+               "from_email": {"value": "test@demo.com", "parameter_type": "value"},
+               "to_email": {"value": "", "parameter_type": "slot"},
+               "subject": "Test Subject",
+               "response": "Test Response",
+               "tls": False
+               }
+    response = client.put(
+        f"/api/bot/{pytest.bot}/action/email",
+        json=request,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+    assert actual["message"] == [{'loc': ['body', 'to_email', '__root__'],
+                                  'msg': 'Provide name of the slot as value', 'type': 'value_error'}]
+    assert str(actual['message']).__contains__("Provide name of the slot as value")
+
+    request = {"action_name": "email_config_with_slot",
+               "smtp_url": "test.test.com",
+               "smtp_port": 25,
+               "smtp_userid": None,
+               "smtp_password": {'value': "test", "parameter_type": "key_vault"},
+               "from_email": {"value": "test@demo.com", "parameter_type": "value"},
+               "to_email": {"value": "test@demo.com", "parameter_type": "value"},
+               "subject": "Test Subject",
+               "response": "Test Response",
+               "tls": False
+               }
+    response = client.put(
+        f"/api/bot/{pytest.bot}/action/email",
+        json=request,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+    assert actual["message"] == [{'loc': ['body', 'to_email', '__root__'],
+                                  'msg': 'Provide list of emails as value', 'type': 'value_error'}]
+    assert str(actual['message']).__contains__("Provide list of emails as value")
+
+    request = {"action_name": "email_config_with_slot",
+               "smtp_url": "test.test.com",
+               "smtp_port": 25,
+               "smtp_userid": None,
+               "smtp_password": {'value': "test", "parameter_type": "slot"},
+               "from_email": {"value": "test@demo.com", "parameter_type": "intent"},
+               "to_email": {"value": "to_email", "parameter_type": "slot"},
+               "subject": "Test Subject",
+               "response": "Test Response",
+               "tls": False
+               }
+    response = client.put(
+        f"/api/bot/{pytest.bot}/action/email",
+        json=request,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+
+    request = {"action_name": "email_config_with_slot",
+               "smtp_url": "test.test.com",
+               "smtp_port": 25,
+               "smtp_userid": None,
+               "smtp_password": {'value': "test", "parameter_type": "slot"},
+               "from_email": {"value": "", "parameter_type": "slot"},
+               "to_email": {"value": ["test@demo.com"], "parameter_type": "value"},
+               "subject": "Test Subject",
+               "response": "Test Response",
+               "tls": False
+               }
+    response = client.put(
+        f"/api/bot/{pytest.bot}/action/email",
+        json=request,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+    assert actual["message"] == [{'loc': ['body', 'from_email', '__root__'],
+                                  'msg': 'Provide name of the slot as value', 'type': 'value_error'}]
+    assert str(actual['message']).__contains__("Provide name of the slot as value")
+
+    request = {"action_name": "email_config_with_slot",
+               "smtp_url": "test.test.com",
+               "smtp_port": 25,
+               "smtp_userid": None,
+               "smtp_password": {'value': "test", "parameter_type": "key_vault"},
+               "from_email": {"value": "", "parameter_type": "value"},
+               "to_email": {"value": ["test@demo.com"], "parameter_type": "value"},
+               "subject": "Test Subject",
+        "response": "Test Response",
+        "tls": False,
+    }
+    response = client.put(
+        f"/api/bot/{pytest.bot}/action/email",
+        json=request,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["error_code"] == 422
+    assert actual["message"] == 'Invalid From or To email address'
+
+
+@patch("kairon.shared.utils.SMTP", autospec=True)
 def test_edit_email_action_does_not_exists(mock_smtp):
     request = {
         "action_name": "email_config1",
@@ -17498,8 +17770,8 @@ def test_edit_email_action_does_not_exists(mock_smtp):
         "smtp_port": 25,
         "smtp_userid": None,
         "smtp_password": {"value": "test"},
-        "from_email": "test@demo.com",
-        "to_email": ["test@test.com", "test1@test.com"],
+        "from_email": {"value": "test@demo.com", "parameter_type": "value"},
+        "to_email": {"value": "to_email", "parameter_type": "slot"},
         "subject": "Test Subject",
         "response": "Test Response",
         "tls": False,

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -1192,6 +1192,32 @@ def test_get_client_config_with_nudge_server_url():
     assert actual["data"]["api_server_host_url"] == expected_app_server_url
     assert actual["data"]["chat_server_base_url"] == expected_chat_server_url
 
+@responses.activate
+def test_default_values():
+    response = client.get(
+        f"/api/system/default/names"
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    expected_default_intents = [
+        "restart", "back", "out_of_scope", "session_start", "nlu_fallback"
+    ]
+    expected_default_action_names = [
+        "action_listen", "action_restart", "action_session_start",
+        "action_default_fallback", "action_deactivate_loop",
+        "action_revert_fallback_events", "action_default_ask_affirmation",
+        "action_default_ask_rephrase", "action_two_stage_fallback",
+        "action_unlikely_intent", "action_back", "...", "action_extract_slots"
+    ]
+    expected_default_slot_names = [
+        "knowledge_base_last_object_type", "session_started_metadata",
+        "knowledge_base_listed_objects", "requested_slot", "knowledge_base_last_object"
+    ]
+
+    assert sorted(actual["data"]["default_intents"]) == sorted(expected_default_intents)
+    assert sorted(actual["data"]["default_action_names"]) == sorted(expected_default_action_names)
+    assert sorted(actual["data"]["default_slot_names"]) == sorted(expected_default_slot_names)
 
 @responses.activate
 def test_upload_with_bot_content_only_validate_content_data():

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -1195,7 +1195,7 @@ def test_get_client_config_with_nudge_server_url():
 @responses.activate
 def test_default_values():
     response = client.get(
-        f"/api/system/default/names"
+        "/api/system/default/names"
     )
     actual = response.json()
     assert actual["success"]
@@ -2056,6 +2056,39 @@ def test_list_pyscript_actions_after_action_deleted():
     assert actual["data"][0]["name"] == "test_add_pyscript_action_case_insensitivity"
     assert actual["data"][0]["source_code"] == script2
     assert actual["data"][0]["dispatch_response"]
+
+
+def test_list_available_actions():
+    script = """
+    data = [1, 2, 3, 4, 5, 6]
+    total = 0
+    for i in data:
+        total += i
+    print(total)
+    """
+    request_body = {
+        "name": "test_list_available_actions_pyscript_action",
+        "source_code": script,
+        "dispatch_response": False,
+    }
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/action/pyscript",
+        json=request_body,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+
+    actual = response.json()
+    assert actual["success"]
+
+    response = client.get(
+        url=f"/api/bot/{pytest.bot}/action/actions",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual=response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual['data'][-1]['name'] == 'test_list_available_actions_pyscript_action'
+    assert actual['data'][-1]['type'] == 'pyscript_action'
 
 
 def test_get_client_config_url_with_ip_info(monkeypatch):

--- a/tests/testing_data/actions/actions.yml
+++ b/tests/testing_data/actions/actions.yml
@@ -179,11 +179,17 @@ email_action:
     key: smtp_password
     value: dfgh4567
     parameter_type: value
-  from_email: udit.pandey@digite.com
+  from_email:
+    key: from_email
+    value: udit.pandey@digite.com
+    parameter_type: value
   subject: bot fallback
   to_email:
-  - udit.pandey@digite.com
-  - ritika.gupta@digite.com
+    key: to_email
+    value:
+      - udit.pandey@digite.com
+      - ritika.gupta@digite.com
+    parameter_type: value
   response: email sent
   tls: False
 - action_name: email_action_2
@@ -193,11 +199,17 @@ email_action:
     key: smtp_password
     value: sdfgh5678
     parameter_type: value
-  from_email: udit.pandey@digite.com
+  from_email:
+    key: from_email
+    value: udit.pandey@digite.com
+    parameter_type: value
   subject: bot fallback
   to_email:
-  - udit.pandey@digite.com
-  - ritika.gupta@digite.com
+    key: to_email
+    value:
+      - udit.pandey@digite.com
+      - ritika.gupta@digite.com
+    parameter_type: value
   response: email sent
 
 pipedrive_leads_action:

--- a/tests/unit_test/action/action_test.py
+++ b/tests/unit_test/action/action_test.py
@@ -37,7 +37,8 @@ from kairon.shared.actions.models import ActionType, HttpRequestContentType
 from kairon.shared.actions.data_objects import HttpActionRequestBody, HttpActionConfig, ActionServerLogs, SlotSetAction, \
     Actions, FormValidationAction, EmailActionConfig, GoogleSearchAction, JiraAction, ZendeskAction, \
     PipedriveLeadsAction, SetSlots, HubspotFormsAction, HttpActionResponse, CustomActionRequestParameters, \
-    KaironTwoStageFallbackAction, SetSlotsFromResponse, PromptAction, PyscriptActionConfig, WebSearchAction
+    KaironTwoStageFallbackAction, SetSlotsFromResponse, PromptAction, PyscriptActionConfig, WebSearchAction, \
+    CustomActionParameters
 from kairon.actions.handlers.processor import ActionProcessor
 from kairon.shared.actions.utils import ActionUtility
 from kairon.shared.actions.exception import ActionFailure
@@ -2568,9 +2569,9 @@ class TestActions:
                 smtp_url="test.localhost",
                 smtp_port=293,
                 smtp_password=CustomActionRequestParameters(key='smtp_password', value="test"),
-                from_email="test@demo.com",
+                from_email=CustomActionRequestParameters(value="test@demo.com", parameter_type="value"),
+                to_email=CustomActionParameters(value=["test@test.com"], parameter_type="value"),
                 subject="test",
-                to_email=["test@test.com","test1@test.com"],
                 response="Validated",
                 bot="bot",
                 user="user"
@@ -2584,8 +2585,10 @@ class TestActions:
             assert expected['smtp_port'] == actual['smtp_port']
             assert {'_cls': 'CustomActionRequestParameters', 'key': 'smtp_password', 'encrypt': False, 'value': 'test',
                     'parameter_type': 'value'} == actual['smtp_password']
-            assert 'test@demo.com' == actual['from_email']
-            assert expected['to_email'] == actual['to_email']
+            assert 'test@demo.com' == actual['from_email']['value']
+            assert 'value' == actual['from_email']['parameter_type']
+            assert expected['to_email']['value'] == actual['to_email']['value']
+            assert expected['to_email']['parameter_type'] == actual['to_email']['parameter_type']
             assert expected.get("smtp_userid") == actual.get("smtp_userid")
 
             expected = EmailActionConfig(
@@ -2594,9 +2597,9 @@ class TestActions:
                 smtp_port=293,
                 smtp_userid=CustomActionRequestParameters(value='test.user_id'),
                 smtp_password=CustomActionRequestParameters(value="test"),
-                from_email="test@demo.com",
+                from_email=CustomActionRequestParameters(value="test@demo.com", parameter_type="value"),
+                to_email=CustomActionParameters(value=["test@test.com", "test1@test.com"], parameter_type="value"),
                 subject="test",
-                to_email=["test@test.com", "test1@test.com"],
                 response="Validated",
                 bot="bot",
                 user="user"
@@ -2610,8 +2613,10 @@ class TestActions:
             assert expected['smtp_port'] == actual['smtp_port']
             assert {'_cls': 'CustomActionRequestParameters', 'key': 'smtp_password', 'encrypt': False, 'value': 'test',
                     'parameter_type': 'value'} == actual['smtp_password'] == actual['smtp_password']
-            assert 'test@demo.com' == actual['from_email']
-            assert expected['to_email'] == actual['to_email']
+            assert 'test@demo.com' == actual['from_email']['value']
+            assert 'value' == actual['from_email']['parameter_type']
+            assert expected['to_email']['value'] == actual['to_email']['value']
+            assert expected['to_email']['parameter_type'] == actual['to_email']['parameter_type']
             assert {'_cls': 'CustomActionRequestParameters', 'key': 'smtp_userid', 'encrypt': False,
                     'value': 'test.user_id', 'parameter_type': 'value'} == actual['smtp_userid'] == actual.get(
                 "smtp_userid")

--- a/tests/unit_test/data_processor/data_processor_test.py
+++ b/tests/unit_test/data_processor/data_processor_test.py
@@ -13970,6 +13970,42 @@ class TestMongoProcessor:
         with pytest.raises(AppException, match=f"{KAIRON_TWO_STAGE_FALLBACK} is a reserved keyword"):
             processor.add_hubspot_forms_action(action, bot, user)
 
+
+    def test_list_all_actions(self):
+        bot = 'test_bot'
+        user = 'test_user'
+        action = "test_list_all_action_pyscript_action"
+        script = """
+                data = [1, 2, 3, 4, 5, 6]
+                total = 0
+                for i in data:
+                    total += i
+                print(total)
+                """
+        processor = MongoProcessor()
+        pyscript_config = PyscriptActionRequest(
+            name=action,
+            source_code=script,
+            dispatch_response=False,
+        )
+        action_id = processor.add_pyscript_action(pyscript_config.dict(), user, bot)
+
+        action = {
+            'name': 'test_list_all_action_google_action',
+            'api_key': {'value': '12345678'},
+            'search_engine_id': 'asdfg:123456', "dispatch_response": False, "set_slot": "google_search_result",
+            'failure_response': 'I have failed to process your request',
+            'website': 'https://www.google.com',
+        }
+
+        action_id = processor.add_google_search_action(action, bot, user)
+
+        actions_list = list(processor.list_all_actions(bot=bot))
+
+        assert actions_list[-1]['name'] == 'test_list_all_action_google_action'
+        assert actions_list[-2]['name'] == 'test_list_all_action_pyscript_action'
+
+
     def test_add_custom_2_stage_fallback_action_validation_error(self):
         processor = MongoProcessor()
         bot = 'test'

--- a/tests/unit_test/data_processor/data_processor_test.py
+++ b/tests/unit_test/data_processor/data_processor_test.py
@@ -13213,8 +13213,8 @@ class TestMongoProcessor:
                         "smtp_port": 25,
                         "smtp_userid": None,
                         "smtp_password": {'value': "test"},
-                        "from_email": "test@demo.com",
-                        "to_email": ["test@test.com", "test1@test.com"],
+                        "from_email": {"value": "from_email", "parameter_type": "slot"},
+                        "to_email": {"value": ["test@test.com", "test1@test.com"], "parameter_type": "value"},
                         "subject": "Test Subject",
                         "response": "Test Response",
                         "tls": False
@@ -13229,8 +13229,8 @@ class TestMongoProcessor:
                         "smtp_port": 25,
                         "smtp_userid": None,
                         "smtp_password": {'value': "test"},
-                        "from_email": "test@demo.com",
-                        "to_email": ["test@test.com", "test1@test.com"],
+                        "from_email": {"value": "from_email", "parameter_type": "slot"},
+                        "to_email": {"value": ["test@test.com", "test1@test.com"], "parameter_type": "value"},
                         "subject": "Test Subject",
                         "response": "Test Response",
                         "tls": False,
@@ -13267,8 +13267,8 @@ class TestMongoProcessor:
                         "smtp_port": 25,
                         "smtp_userid": None,
                         "smtp_password": {'value': "test"},
-                        "from_email": "test@demo.com",
-                        "to_email": "test@test.com",
+                        "from_email": {"value": "from_email", "parameter_type": "slot"},
+                        "to_email": {"value": ["test@test.com", "test1@test.com"], "parameter_type": "value"},
                         "subject": "Test Subject",
                         "response": "Test Response",
                         "tls": False
@@ -13292,16 +13292,29 @@ class TestMongoProcessor:
             email_config['smtp_url'] = temp
 
             temp = email_config['from_email']
-            email_config['from_email'] = "test@test"
+            email_config['from_email'] = {"value": "test@test", "parameter_type": "value"}
             with pytest.raises(ValidationError, match="Invalid From or To email address"):
+                processor.add_email_action(email_config, "TEST", "tests")
+
+            email_config['from_email'] = {"value": "", "parameter_type": "slot"}
+            with pytest.raises(ValidationError, match="Provide name of the slot as value"):
                 processor.add_email_action(email_config, "TEST", "tests")
             email_config['from_email'] = temp
 
             temp = email_config['to_email']
-            email_config['to_email'] = "test@test"
+            email_config['to_email'] = {"value": "test@test", "parameter_type": "value"}
+            with pytest.raises(ValidationError, match="Provide list of emails as value"):
+                processor.add_email_action(email_config, "TEST", "tests")
+
+            email_config['to_email'] = {"value": ["test@test"], "parameter_type": "value"}
             with pytest.raises(ValidationError, match="Invalid From or To email address"):
                 processor.add_email_action(email_config, "TEST", "tests")
-            email_config['to_email'] = ["test@demo.com"]
+
+            email_config['to_email'] = {"value": "", "parameter_type": "slot"}
+            with pytest.raises(ValidationError, match="Provide name of the slot as value"):
+                processor.add_email_action(email_config, "TEST", "tests")
+            email_config['to_email'] = temp
+
             email_config["custom_text"] = {"value": "custom_text_slot", "parameter_type": "sender_id"}
             with pytest.raises(ValidationError, match="custom_text can only be of type value or slot!"):
                 processor.add_email_action(email_config, "TEST", "tests")
@@ -13313,8 +13326,8 @@ class TestMongoProcessor:
                         "smtp_port": 25,
                         "smtp_userid": None,
                         "smtp_password": {'value': "test"},
-                        "from_email": "test@demo.com",
-                        "to_email": ["test@test.com"],
+                        "from_email": {"value": "from_email", "parameter_type": "slot"},
+                        "to_email": {"value": ["test@test.com", "test1@test.com"], "parameter_type": "value"},
                         "subject": "Test Subject",
                         "response": "Test Response",
                         "tls": False
@@ -13330,8 +13343,8 @@ class TestMongoProcessor:
                         "smtp_port": 25,
                         "smtp_userid": None,
                         "smtp_password": {'value': "test"},
-                        "from_email": "test@demo.com",
-                        "to_email": ["test@test.com"],
+                        "from_email": {"value": "test@demo.com", "parameter_type": "value"},
+                        "to_email": {"value": "to_email", "parameter_type": "slot"},
                         "subject": "Test Subject",
                         "response": "Test Response",
                         "tls": False
@@ -13347,8 +13360,8 @@ class TestMongoProcessor:
                         "smtp_port": 25,
                         "smtp_userid": None,
                         "smtp_password": {'value': "test"},
-                        "from_email": "test@demo.com",
-                        "to_email": ["test@test.com", "test1@test.com"],
+                        "from_email": {"value": "test@demo.com", "parameter_type": "value"},
+                        "to_email": {"value": "to_email", "parameter_type": "slot"},
                         "subject": "Test Subject",
                         "response": "Test Response",
                         "tls": False
@@ -13367,8 +13380,8 @@ class TestMongoProcessor:
                         "smtp_port": 25,
                         "smtp_userid": None,
                         "smtp_password": {'value': "test"},
-                        "from_email": "test@demo.com",
-                        "to_email": "test@test.com",
+                        "from_email": {"value": "test@demo.com", "parameter_type": "value"},
+                        "to_email": {"value": "to_email", "parameter_type": "slot"},
                         "subject": "Test Subject",
                         "response": "Test Response",
                         "tls": False
@@ -13392,14 +13405,26 @@ class TestMongoProcessor:
             email_config['smtp_url'] = temp
 
             temp = email_config['from_email']
-            email_config['from_email'] = "test@test"
+            email_config['from_email'] = {"value": "test@demo", "parameter_type": "value"}
             with pytest.raises(ValidationError, match="Invalid From or To email address"):
+                processor.edit_email_action(email_config, "TEST", "tests")
+
+            email_config['from_email'] = {"value": "", "parameter_type": "slot"}
+            with pytest.raises(ValidationError, match="Provide name of the slot as value"):
                 processor.edit_email_action(email_config, "TEST", "tests")
             email_config['from_email'] = temp
 
             temp = email_config['to_email']
-            email_config['to_email'] = "test@test"
+            email_config['to_email'] = {"value": "test@test", "parameter_type": "value"}
+            with pytest.raises(ValidationError, match="Provide list of emails as value"):
+                processor.edit_email_action(email_config, "TEST", "tests")
+
+            email_config['to_email'] = {"value": ["test@test"], "parameter_type": "value"}
             with pytest.raises(ValidationError, match="Invalid From or To email address"):
+                processor.edit_email_action(email_config, "TEST", "tests")
+
+            email_config['to_email'] = {"value": "", "parameter_type": "slot"}
+            with pytest.raises(ValidationError, match="Provide name of the slot as value"):
                 processor.edit_email_action(email_config, "TEST", "tests")
             email_config['to_email'] = temp
 
@@ -13410,8 +13435,8 @@ class TestMongoProcessor:
                         "smtp_port": 25,
                         "smtp_userid": None,
                         "smtp_password": {'value': "test"},
-                        "from_email": "test@demo.com",
-                        "to_email": "test@test.com",
+                        "from_email": {"value": "test@demo.com", "parameter_type": "value"},
+                        "to_email": {"value": "to_email", "parameter_type": "slot"},
                         "subject": "Test Subject",
                         "response": "Test Response",
                         "tls": False
@@ -14265,8 +14290,8 @@ class TestMongoProcessor:
                         "smtp_port": 25,
                         "smtp_userid": smtp_userid_list,
                         "smtp_password": {'value': "test"},
-                        "from_email": "test@demo.com",
-                        "to_email": ["test@test.com", "test1@test.com"],
+                        "from_email": {"value": "test@demo.com", "parameter_type": "value"},
+                        "to_email": {"value": "to_email", "parameter_type": "slot"},
                         "subject": "Test Subject",
                         "response": "Test Response",
                         "tls": False

--- a/tests/unit_test/data_processor/data_processor_test.py
+++ b/tests/unit_test/data_processor/data_processor_test.py
@@ -67,7 +67,8 @@ from kairon.shared.data.data_objects import (TrainingExamples,
                                              Utterances, BotSettings, ChatClientConfig, LookupTables, Forms,
                                              SlotMapping, KeyVault, MultiflowStories, LLMSettings,
                                              MultiflowStoryEvents, Synonyms,
-                                             Lookup
+                                             Lookup,
+                                             DemoRequestLogs
                                              )
 from kairon.shared.data.history_log_processor import HistoryDeletionLogProcessor
 from kairon.shared.data.model_processor import ModelProcessor
@@ -150,6 +151,50 @@ class TestMongoProcessor:
                                        {'name': 'is_new_user', 'type': 'SLOT', 'value': None},
                                        {'name': 'persona', 'type': 'SLOT', 'value': 'positive'},
                                        {'name': 'utter_welcome_user', 'type': 'BOT'}]
+
+    def test_add_demo_request_with_empty_first_name(self):
+        processor = MongoProcessor()
+        processor.add_demo_request(
+            first_name="", last_name="Sattala", email="mahesh.sattala@digite.com", phone="+919876543210",
+            message="This is test message", recaptcha_response="Svw2mPVxM0SkO4_2yxTcDQQ7iKNUDeDhGf4l6C2i"
+        )
+
+    def test_add_demo_request_with_empty_last_name(self):
+        processor = MongoProcessor()
+        processor.add_demo_request(
+            first_name="Mahesh", last_name="", email="mahesh.sattala@digite.com", phone="+919876543210",
+            message="This is test message", recaptcha_response="Svw2mPVxM0SkO4_2yxTcDQQ7iKNUDeDhGf4l6C2i"
+        )
+
+    def test_add_demo_request_with_invalid_email(self):
+        processor = MongoProcessor()
+        processor.add_demo_request(
+            first_name="Mahesh", last_name="Sattala", email="mahesh.sattala", phone="+919876543210",
+            message="This is test message", recaptcha_response="Svw2mPVxM0SkO4_2yxTcDQQ7iKNUDeDhGf4l6C2i"
+        )
+
+    def test_add_demo_request_with_invalid_status(self):
+        processor = MongoProcessor()
+        processor.add_demo_request(
+            first_name="Mahesh", last_name="Sattala", email="mahesh.sattala@digite.com",
+            phone="+919876543210", message="This is test message", status="Invalid_status",
+            recaptcha_response="Svw2mPVxM0SkO4_2yxTcDQQ7iKNUDeDhGf4l6C2i"
+        )
+
+    def test_add_demo_request(self):
+        processor = MongoProcessor()
+        processor.add_demo_request(first_name="Mahesh", last_name="Sattala", email="mahesh.sattala@nimblework.com",
+                                   phone="+919876543210", message="This is test message", status="demo_given",
+                                   recaptcha_response="Svw2mPVxM0SkO4_2yxTcDQQ7iKNUDeDhGf4l6C2i")
+        demo_request_logs = DemoRequestLogs.objects(first_name="Mahesh", last_name="Sattala",
+                                                    email="mahesh.sattala@nimblework.com").get().to_mongo().to_dict()
+        assert demo_request_logs['first_name'] == "Mahesh"
+        assert demo_request_logs['last_name'] == "Sattala"
+        assert demo_request_logs['email'] == "mahesh.sattala@nimblework.com"
+        assert demo_request_logs['phone'] == "+919876543210"
+        assert demo_request_logs['status'] == "demo_given"
+        assert demo_request_logs['message'] == "This is test message"
+        assert demo_request_logs['recaptcha_response'] == "Svw2mPVxM0SkO4_2yxTcDQQ7iKNUDeDhGf4l6C2i"
 
     def test_add_prompt_action_with_gpt_feature_disabled(self):
         processor = MongoProcessor()

--- a/tests/unit_test/multilingual/multilingual_processor_test.py
+++ b/tests/unit_test/multilingual/multilingual_processor_test.py
@@ -266,9 +266,9 @@ class TestMultilingualProcessor:
                 smtp_url="test.localhost",
                 smtp_port=293,
                 smtp_password={"value": "test"},
-                from_email="test@demo.com",
+                from_email={"value": "from_email", "parameter_type": "slot"},
                 subject="test",
-                to_email=["test@test.com","test1@test.com"],
+                to_email={"value": ["test@test.com", "test1@test.com"], "parameter_type": "value"},
                 response="Validated",
                 bot="test_bot",
                 user="test_user"


### PR DESCRIPTION
Added endpoints to list all actions and fetch rasa default intents, actions, and slot names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic retrieval of `from_email` and `to_email` for email actions.
  - Added a new class for handling custom action parameters.
  - Introduced demo request logging and status tracking.

- **Bug Fixes**
  - Enhanced email parameter validation to handle various input types.

- **Tests**
  - Added tests for email actions with dynamic parameters.
  - Introduced tests for demo request scenarios.
  - Updated existing tests to align with new email parameter structures.

- **Chores**
  - Refactored email action configuration for better clarity and organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->