### PR TITLE
Action with utter

### DIFF
--- a/kairon/shared/utils.py
+++ b/kairon/shared/utils.py
@@ -1920,6 +1920,8 @@ class Utility:
 
         if Utility.is_reserved_keyword(name):
             raise AppException(f"{name} is a reserved keyword")
+        if name.startswith("utter_"):
+            raise AppException("Action name cannot start with utter_")
         q_filter = {
             "name__iexact": name,
             "bot": bot,

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -11284,6 +11284,7 @@ def test_add_vectordb_action_with_utter():
         }],
         "response": {"value": "0"},
     }
+
     response = client.post(
         url=f"/api/bot/{pytest.bot}/action/db",
         json=request_body,


### PR DESCRIPTION
Added validation to avoid action name start with utter_ and fixed and added test cases to the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented validation to prevent action names from starting with "utter_".

- **Tests**
  - Added new test cases to ensure validation for action names starting with "utter_" across various action types (e.g., Python scripts, prompt actions, VectorDB actions, HTTP actions).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->