### PR TITLE
Cognition schema float data type addition

### DIFF
--- a/kairon/api/models.py
+++ b/kairon/api/models.py
@@ -1113,8 +1113,8 @@ class ColumnMetadata(BaseModel):
     def check(cls, values):
         from kairon.shared.utils import Utility
 
-        if values.get('data_type') not in [CognitionMetadataType.str.value, CognitionMetadataType.int.value]:
-            raise ValueError("Only str and int data types are supported")
+        if values.get('data_type') not in [CognitionMetadataType.str.value, CognitionMetadataType.int.value, CognitionMetadataType.float.value]:
+            raise ValueError("Only str, int and float data types are supported")
         if Utility.check_empty_string(values.get('column_name')):
             raise ValueError("Column name cannot be empty")
         return values

--- a/kairon/shared/cognition/data_objects.py
+++ b/kairon/shared/cognition/data_objects.py
@@ -11,7 +11,7 @@ from kairon.shared.models import CognitionMetadataType, CognitionDataType
 class ColumnMetadata(EmbeddedDocument):
     column_name = StringField(required=True)
     data_type = StringField(required=True, default=CognitionMetadataType.str.value,
-                            choices=[CognitionMetadataType.str.value, CognitionMetadataType.int.value])
+                            choices=[CognitionMetadataType.str.value, CognitionMetadataType.int.value, CognitionMetadataType.float.value])
     enable_search = BooleanField(default=True)
     create_embeddings = BooleanField(default=True)
 
@@ -20,8 +20,8 @@ class ColumnMetadata(EmbeddedDocument):
 
         if clean:
             self.clean()
-        if self.data_type not in [CognitionMetadataType.str.value, CognitionMetadataType.int.value]:
-            raise ValidationError("Only str and int data types are supported")
+        if self.data_type not in [CognitionMetadataType.str.value, CognitionMetadataType.int.value, CognitionMetadataType.float.value]:
+            raise ValidationError("Only str,int and float data types are supported")
         if Utility.check_empty_string(self.column_name):
             raise ValidationError("Column name cannot be empty")
 

--- a/kairon/shared/cognition/processor.py
+++ b/kairon/shared/cognition/processor.py
@@ -229,6 +229,11 @@ class CognitionDataProcessor:
                     return int(data[column_name])
                 except ValueError:
                     raise AppException("Invalid data type!")
+            elif column_name in data and data[column_name] and data_type == CognitionMetadataType.float.value:
+                try:
+                    return float(data[column_name])
+                except ValueError:
+                    raise AppException("Invalid data type!")
             else:
                 return data[column_name]
 

--- a/kairon/shared/models.py
+++ b/kairon/shared/models.py
@@ -113,3 +113,4 @@ class CognitionDataType(str, Enum):
 class CognitionMetadataType(str, Enum):
     str = "str"
     int = "int"
+    float = "float"

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -2303,10 +2303,10 @@ def test_metadata_upload_invalid_data_type():
     )
     actual = response.json()
     assert actual["message"] == [{'loc': ['body', 'metadata', 0, 'data_type'],
-                                  'msg': "value is not a valid enumeration member; permitted: 'str', 'int'",
-                                  'type': 'type_error.enum', 'ctx': {'enum_values': ['str', 'int']}},
+                                  'msg': "value is not a valid enumeration member; permitted: 'str', 'int', 'float'",
+                                  'type': 'type_error.enum', 'ctx': {'enum_values': ['str', 'int', 'float']}},
                                  {'loc': ['body', 'metadata', 0, '__root__'],
-                                  'msg': 'Only str and int data types are supported', 'type': 'value_error'}]
+                                  'msg': 'Only str, int and float data types are supported', 'type': 'value_error'}]
     assert not actual["data"]
     assert actual["error_code"] == 422
 

--- a/tests/unit_test/data_processor/data_processor_test.py
+++ b/tests/unit_test/data_processor/data_processor_test.py
@@ -14925,7 +14925,7 @@ class TestMongoProcessor:
             "bot": bot,
             "user": user
         }
-        with pytest.raises(ValidationError, match="Only str and int data types are supported"):
+        with pytest.raises(ValidationError, match="Only str,int and float data types are supported"):
             CognitionSchema(**schema).save()
 
     def test_get_payload_metadata(self):


### PR DESCRIPTION
added float data type for cognition schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `float` data type across various functionalities including validation and metadata handling.
  
- **Tests**
  - Updated existing test cases to include validation for `float` data type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->