### PR TITLE
resend_fix

### DIFF
--- a/kairon/events/definitions/message_broadcast.py
+++ b/kairon/events/definitions/message_broadcast.py
@@ -57,7 +57,7 @@ class MessageBroadcastEvent(ScheduledEventsBase):
         reference_id = None
         status = EVENT_STATUS.FAIL.value
         exception = None
-        is_resend = kwargs.get('is_resend', False)
+        is_resend = bool(kwargs.get('is_resend', False))
         try:
             config, reference_id = self.__retrieve_config(event_id, is_resend)
             broadcast = MessageBroadcastFactory.get_instance(config["connector_type"]).from_config(config, event_id,
@@ -115,7 +115,7 @@ class MessageBroadcastEvent(ScheduledEventsBase):
     def _resend_broadcast(self, msg_broadcast_id: Text):
         try:
             payload = {'bot': self.bot, 'user': self.user,
-                       "event_id": msg_broadcast_id, "is_resend": True}
+                       "event_id": msg_broadcast_id, "is_resend": "True"}
             Utility.request_event_server(EventClass.message_broadcast, payload)
             return msg_broadcast_id
         except Exception as e:


### PR DESCRIPTION
Made the is_resend to string instead of bool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced handling of the `is_resend` parameter for improved clarity and consistency.
	- Updated type treatment for `is_resend` to ensure it is always a boolean in the `execute` method.
	- Changed the representation of `is_resend` in the payload to a string in the `_resend_broadcast` method, impacting downstream event processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->