### PR TITLE
resend broadcast cli fix

### DIFF
--- a/kairon/__init__.py
+++ b/kairon/__init__.py
@@ -35,7 +35,7 @@ Usage:
         kairon generate-data <botid> <userid> --from-document
         
     Message broadcast:
-        kairon broadcast <botid> <userid> <eventid>
+        kairon broadcast <botid> <userid> <eventid> <is_resend>
     
     Delete audit logs:
         kairon delete-logs

--- a/kairon/cli/message_broadcast.py
+++ b/kairon/cli/message_broadcast.py
@@ -44,6 +44,7 @@ def add_subparser(subparsers: SubParsersAction, parents: List[ArgumentParser]):
                           help="Broadcast config document id or broadcast log reference id", action='store')
     notifier.add_argument('is_resend',
                           type=bool,
+                          default=False,
                           help="Specify if the broadcast is a resend (True) or a normal broadcast (False).",
                           action='store')
     notifier.set_defaults(func=send_notifications)

--- a/kairon/cli/message_broadcast.py
+++ b/kairon/cli/message_broadcast.py
@@ -14,11 +14,13 @@ def send_notifications(args):
     bot = args.bot
     user = args.user
     event_id = args.event_id
+    is_resend = args.is_resend
     logger.info("bot: {}", args.bot)
     logger.info("user: {}", args.user)
     logger.info("event_id: {}", args.event_id)
+    logger.info("is_resend: {}", args.is_resend)
     try:
-        MessageBroadcastEvent(bot, user).execute(event_id=event_id)
+        MessageBroadcastEvent(bot, user).execute(event_id=event_id, is_resend=is_resend)
     finally:
         ActorFactory.stop_all()
 
@@ -40,4 +42,8 @@ def add_subparser(subparsers: SubParsersAction, parents: List[ArgumentParser]):
     notifier.add_argument('event_id',
                           type=str,
                           help="Broadcast config document id or broadcast log reference id", action='store')
+    notifier.add_argument('is_resend',
+                          type=bool,
+                          help="Specify if the broadcast is a resend (True) or a normal broadcast (False).",
+                          action='store')
     notifier.set_defaults(func=send_notifications)

--- a/kairon/events/definitions/message_broadcast.py
+++ b/kairon/events/definitions/message_broadcast.py
@@ -57,7 +57,7 @@ class MessageBroadcastEvent(ScheduledEventsBase):
         reference_id = None
         status = EVENT_STATUS.FAIL.value
         exception = None
-        is_resend = bool(kwargs.get('is_resend', False))
+        is_resend = kwargs.get('is_resend', False)
         try:
             config, reference_id = self.__retrieve_config(event_id, is_resend)
             broadcast = MessageBroadcastFactory.get_instance(config["connector_type"]).from_config(config, event_id,
@@ -115,7 +115,7 @@ class MessageBroadcastEvent(ScheduledEventsBase):
     def _resend_broadcast(self, msg_broadcast_id: Text):
         try:
             payload = {'bot': self.bot, 'user': self.user,
-                       "event_id": msg_broadcast_id, "is_resend": "True"}
+                       "event_id": msg_broadcast_id, "is_resend": True}
             Utility.request_event_server(EventClass.message_broadcast, payload)
             return msg_broadcast_id
         except Exception as e:

--- a/tests/unit_test/cli_test.py
+++ b/tests/unit_test/cli_test.py
@@ -391,6 +391,14 @@ class TestMessageBroadcastCli:
     @mock.patch('argparse.ArgumentParser.parse_args',
                 return_value=argparse.Namespace(func=send_notifications, bot="test_cli", user="testUser",
                                                 event_id="65432123456789876543"))
+    def test_message_broadcast_no_is_resend(self, monkeypatch):
+        with pytest.raises(AttributeError) as e:
+            cli()
+        assert str(e).__contains__("'Namespace' object has no attribute 'is_resend'")
+
+    @mock.patch('argparse.ArgumentParser.parse_args',
+                return_value=argparse.Namespace(func=send_notifications, bot="test_cli", user="testUser",
+                                                event_id="65432123456789876543", is_resend=True))
     def test_message_broadcast_all_arguments(self, mock_namespace):
         with mock.patch('kairon.events.definitions.message_broadcast.MessageBroadcastEvent.execute', autospec=True):
 


### PR DESCRIPTION
Added code related to cli for resend broadcast and added tests for the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added an optional `<is_resend>` parameter to the `broadcast` command for enhanced message control.
	
- **Bug Fixes**
	- Improved handling of the `is_resend` flag in the notification process for better functionality.

- **Tests**
	- Introduced a new test to validate the handling of the `is_resend` attribute within CLI commands, improving test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->