### PR TITLE
resend broadcast fix

### DIFF
--- a/kairon/cli/message_broadcast.py
+++ b/kairon/cli/message_broadcast.py
@@ -43,8 +43,8 @@ def add_subparser(subparsers: SubParsersAction, parents: List[ArgumentParser]):
                           type=str,
                           help="Broadcast config document id or broadcast log reference id", action='store')
     notifier.add_argument('is_resend',
-                          type=bool,
-                          default=False,
+                          type=str,
+                          default="False",
                           help="Specify if the broadcast is a resend (True) or a normal broadcast (False).",
                           action='store')
     notifier.set_defaults(func=send_notifications)

--- a/kairon/events/definitions/message_broadcast.py
+++ b/kairon/events/definitions/message_broadcast.py
@@ -57,7 +57,7 @@ class MessageBroadcastEvent(ScheduledEventsBase):
         reference_id = None
         status = EVENT_STATUS.FAIL.value
         exception = None
-        is_resend = kwargs.get('is_resend', False)
+        is_resend = bool(kwargs.get('is_resend', False))
         try:
             config, reference_id = self.__retrieve_config(event_id, is_resend)
             broadcast = MessageBroadcastFactory.get_instance(config["connector_type"]).from_config(config, event_id,
@@ -115,7 +115,7 @@ class MessageBroadcastEvent(ScheduledEventsBase):
     def _resend_broadcast(self, msg_broadcast_id: Text):
         try:
             payload = {'bot': self.bot, 'user': self.user,
-                       "event_id": msg_broadcast_id, "is_resend": True}
+                       "event_id": msg_broadcast_id, "is_resend": "True"}
             Utility.request_event_server(EventClass.message_broadcast, payload)
             return msg_broadcast_id
         except Exception as e:

--- a/tests/unit_test/cli_test.py
+++ b/tests/unit_test/cli_test.py
@@ -398,7 +398,7 @@ class TestMessageBroadcastCli:
 
     @mock.patch('argparse.ArgumentParser.parse_args',
                 return_value=argparse.Namespace(func=send_notifications, bot="test_cli", user="testUser",
-                                                event_id="65432123456789876543", is_resend=True))
+                                                event_id="65432123456789876543", is_resend="True"))
     def test_message_broadcast_all_arguments(self, mock_namespace):
         with mock.patch('kairon.events.definitions.message_broadcast.MessageBroadcastEvent.execute', autospec=True):
 


### PR DESCRIPTION
Added code related to cli for resend broadcast and added tests for the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced input handling for the `is_resend` parameter, now accepting string values.
  
- **Bug Fixes**
	- Improved type safety for the `is_resend` parameter within the execution methods to ensure consistent boolean handling.

- **Tests**
	- Updated unit tests to reflect changes in the `is_resend` argument type from boolean to string.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->