### PR TITLE
resend_flag_fix

### DIFF
--- a/kairon/events/definitions/message_broadcast.py
+++ b/kairon/events/definitions/message_broadcast.py
@@ -57,7 +57,7 @@ class MessageBroadcastEvent(ScheduledEventsBase):
         reference_id = None
         status = EVENT_STATUS.FAIL.value
         exception = None
-        is_resend = bool(kwargs.get('is_resend', False))
+        is_resend = kwargs.get('is_resend', "False") == "True"
         try:
             config, reference_id = self.__retrieve_config(event_id, is_resend)
             broadcast = MessageBroadcastFactory.get_instance(config["connector_type"]).from_config(config, event_id,

--- a/tests/unit_test/events/events_test.py
+++ b/tests/unit_test/events/events_test.py
@@ -2433,7 +2433,7 @@ class TestEventExecution:
             event.validate()
             event_id = event.enqueue(EventRequestType.resend_broadcast.value,
                                      msg_broadcast_id=msg_broadcast_id)
-            event.execute(event_id, is_resend=True)
+            event.execute(event_id, is_resend="True")
 
         logs = MessageBroadcastProcessor.get_broadcast_logs(bot)
         assert len(logs[0]) == logs[1] == 4
@@ -2791,7 +2791,7 @@ class TestEventExecution:
             event.validate()
             event_id = event.enqueue(EventRequestType.resend_broadcast.value,
                                      msg_broadcast_id=msg_broadcast_id)
-            event.execute(event_id, is_resend=True)
+            event.execute(event_id, is_resend="True")
 
         logs = MessageBroadcastProcessor.get_broadcast_logs(bot)
         assert len(logs[0]) == logs[1] == 4
@@ -3224,7 +3224,7 @@ class TestEventExecution:
             event.validate()
             event_id = event.enqueue(EventRequestType.resend_broadcast.value,
                                      msg_broadcast_id=msg_broadcast_id)
-            event.execute(event_id, is_resend=True)
+            event.execute(event_id, is_resend="True")
 
         logs = MessageBroadcastProcessor.get_broadcast_logs(bot)
         assert len(logs[0]) == logs[1] == 5
@@ -3778,7 +3778,7 @@ class TestEventExecution:
             event.validate()
             event_id = event.enqueue(EventRequestType.resend_broadcast.value,
                                      msg_broadcast_id=msg_broadcast_id)
-            event.execute(event_id, is_resend=True)
+            event.execute(event_id, is_resend="True")
 
         logs = MessageBroadcastProcessor.get_broadcast_logs(bot)
         assert len(logs[0]) == logs[1] == 6
@@ -4333,7 +4333,7 @@ class TestEventExecution:
             event.validate()
             event_id = event.enqueue(EventRequestType.resend_broadcast.value,
                                      msg_broadcast_id=msg_broadcast_id)
-            event.execute(event_id, is_resend=True)
+            event.execute(event_id, is_resend="True")
 
         logs = MessageBroadcastProcessor.get_broadcast_logs(bot)
         assert len(logs[0]) == logs[1] == 6


### PR DESCRIPTION
added is_resend flag for every event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved logic for determining the `is_resend` variable to ensure it accurately reflects whether an event should be resent based on the input value.

This change enhances the reliability of event handling in the application, resulting in more consistent behavior when managing message broadcasts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->