### PR TITLE
Test cases

### DIFF
--- a/kairon/cli/message_broadcast.py
+++ b/kairon/cli/message_broadcast.py
@@ -42,7 +42,7 @@ def add_subparser(subparsers: SubParsersAction, parents: List[ArgumentParser]):
     notifier.add_argument('event_id',
                           type=str,
                           help="Broadcast config document id or broadcast log reference id", action='store')
-    notifier.add_argument('is_resend',
+    notifier.add_argument('--is_resend',
                           type=str,
                           default="False",
                           help="Specify if the broadcast is a resend (True) or a normal broadcast (False).",

--- a/tests/unit_test/cli_test.py
+++ b/tests/unit_test/cli_test.py
@@ -405,3 +405,37 @@ class TestMessageBroadcastCli:
             cli()
         for proxy in ActorFactory._ActorFactory__actors.values():
             assert not proxy[1].actor_ref.is_alive()
+
+    def test_message_broadcast_with_is_resend(self, monkeypatch):
+        from kairon import create_argument_parser
+        import sys
+
+        test_args = ["kairon", "broadcast", "test_bot", "test_user", "65432123456789876543", "--is_resend", "True"]
+        monkeypatch.setattr(sys, 'argv', test_args)
+
+        parser = create_argument_parser()
+        args = parser.parse_args()
+
+        assert hasattr(args, 'is_resend')
+        assert args.is_resend == "True"
+
+        with mock.patch('kairon.events.definitions.message_broadcast.MessageBroadcastEvent.execute',
+                        autospec=True):
+            cli()
+
+    def test_message_broadcast_without_is_resend(self, monkeypatch):
+        from kairon import create_argument_parser
+        import sys
+
+        test_args = ["kairon", "broadcast", "test_bot", "test_user", "65432123456789876543"]
+        monkeypatch.setattr(sys, 'argv', test_args)
+
+        parser = create_argument_parser()
+        args = parser.parse_args()
+
+        assert hasattr(args, 'is_resend')
+        assert args.is_resend == "False"
+
+        with mock.patch('kairon.events.definitions.message_broadcast.MessageBroadcastEvent.execute',
+                        autospec=True):
+            cli()

--- a/tests/unit_test/events/events_test.py
+++ b/tests/unit_test/events/events_test.py
@@ -1267,7 +1267,7 @@ class TestEventExecution:
             event = MessageBroadcastEvent(bot, user)
             event.validate()
             event_id = event.enqueue(EventRequestType.trigger_async.value, config=config)
-            event.execute(event_id)
+            event.execute(event_id, is_resend="False")
 
         logs = MessageBroadcastProcessor.get_broadcast_logs(bot)
         assert len(logs[0]) == logs[1] == 2
@@ -1378,7 +1378,7 @@ class TestEventExecution:
             event = MessageBroadcastEvent(bot, user)
             event.validate()
             event_id = event.enqueue(EventRequestType.trigger_async.value, config=config)
-            event.execute(event_id)
+            event.execute(event_id, is_resend="False")
 
         logs = MessageBroadcastProcessor.get_broadcast_logs(bot)
         assert len(logs[0]) == logs[1] == 2
@@ -1491,7 +1491,7 @@ class TestEventExecution:
             event = MessageBroadcastEvent(bot, user)
             event.validate()
             event_id = event.enqueue(EventRequestType.trigger_async.value, config=config)
-            event.execute(event_id)
+            event.execute(event_id, is_resend="False")
 
         logs = MessageBroadcastProcessor.get_broadcast_logs(bot)
         print(logs)
@@ -1587,7 +1587,7 @@ class TestEventExecution:
         event = MessageBroadcastEvent(bot, user)
         event.validate()
         event_id = event.enqueue(EventRequestType.trigger_async.value, config=config)
-        event.execute(event_id)
+        event.execute(event_id, is_resend="False")
 
         logs = MessageBroadcastProcessor.get_broadcast_logs(bot)
         assert len(logs[0]) == logs[1] == 1
@@ -1643,7 +1643,7 @@ class TestEventExecution:
         event = MessageBroadcastEvent(bot, user)
         event.validate()
         event_id = event.enqueue(EventRequestType.trigger_async.value, config=config)
-        event.execute(event_id)
+        event.execute(event_id, is_resend="False")
 
         logs = MessageBroadcastProcessor.get_broadcast_logs(bot)
         assert len(logs[0]) == logs[1] == 1
@@ -1690,7 +1690,7 @@ class TestEventExecution:
                 "config": {"access_token": "shjkjhrefdfghjkl", "from_phone_number_id": "918958030415"}}
             event_id = event.enqueue(EventRequestType.trigger_async.value, config=config)
 
-        event.execute(event_id)
+        event.execute(event_id, is_resend="False")
 
         logs = MessageBroadcastProcessor.get_broadcast_logs(bot)
         assert len(logs[0]) == logs[1] == 1
@@ -1813,7 +1813,7 @@ class TestEventExecution:
             event = MessageBroadcastEvent(bot, user)
             event.validate()
             event_id = event.enqueue(EventRequestType.trigger_async.value, config=config)
-            event.execute(event_id)
+            event.execute(event_id, is_resend="False")
 
         logs = MessageBroadcastProcessor.get_broadcast_logs(bot)
 
@@ -1960,7 +1960,7 @@ class TestEventExecution:
             event = MessageBroadcastEvent(bot, user)
             event.validate()
             event_id = event.enqueue(EventRequestType.trigger_async.value, config=config)
-            event.execute(event_id)
+            event.execute(event_id, is_resend="False")
 
         logs = MessageBroadcastProcessor.get_broadcast_logs(bot)
 
@@ -2063,7 +2063,7 @@ class TestEventExecution:
         event = MessageBroadcastEvent(bot, user)
         event.validate()
         event_id = event.enqueue(EventRequestType.trigger_async.value, config=config)
-        event.execute(event_id)
+        event.execute(event_id, is_resend="False")
 
         logs = MessageBroadcastProcessor.get_broadcast_logs(bot)
         assert len(logs[0]) == logs[1] == 1
@@ -2122,7 +2122,7 @@ class TestEventExecution:
         event = MessageBroadcastEvent(bot, user)
         event.validate()
         event_id = event.enqueue(EventRequestType.trigger_async.value, config=config)
-        event.execute(event_id)
+        event.execute(event_id, is_resend="False")
 
         logs = MessageBroadcastProcessor.get_broadcast_logs(bot)
         assert len(logs[0]) == logs[1] == 1


### PR DESCRIPTION
Added test for the checking whether default values coming or not for parse_args

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Revised command-line argument handling for the message broadcast feature, allowing users to specify the `--is_resend` flag as optional.

- **Bug Fixes**
  - Enhanced testing coverage for the broadcast functionality, ensuring correct handling of the `is_resend` argument.

- **Tests**
  - Introduced new tests that validate the CLI behavior with and without the `--is_resend` argument.
  - Updated existing tests to consistently pass the new `is_resend` parameter in message broadcasting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->