### PR TITLE
content importer fixed add_subparser function

### DIFF
--- a/kairon/cli/content_importer.py
+++ b/kairon/cli/content_importer.py
@@ -43,10 +43,6 @@ def add_subparser(subparsers: SubParsersAction, parents: List[ArgumentParser]):
                                    type=str,
                                    help="Kairon user who is initiating the command",
                                    action='store')
-    doc_import_parser.add_argument('event_type',
-                                    type=str,
-                                    help="Event type: content_importer",
-                                    action='store')
     doc_import_parser.add_argument('table_name',
                                    type=str,
                                    help="The table name where data will be imported",

--- a/kairon/cli/content_importer.py
+++ b/kairon/cli/content_importer.py
@@ -43,6 +43,10 @@ def add_subparser(subparsers: SubParsersAction, parents: List[ArgumentParser]):
                                    type=str,
                                    help="Kairon user who is initiating the command",
                                    action='store')
+    doc_import_parser.add_argument('event_type',
+                                    type=str,
+                                    help="Event type: content_importer",
+                                    action='store')
     doc_import_parser.add_argument('table_name',
                                    type=str,
                                    help="The table name where data will be imported",

--- a/kairon/events/definitions/content_importer.py
+++ b/kairon/events/definitions/content_importer.py
@@ -49,7 +49,6 @@ class DocContentImporterEvent(EventsBase):
         payload = {
             'bot': self.bot,
             'user': self.user,
-            'event_type': EventClass.content_importer,
             'table_name': self.table_name,
             'overwrite': overwrite
         }

--- a/tests/unit_test/cli_test.py
+++ b/tests/unit_test/cli_test.py
@@ -435,7 +435,7 @@ class TestDocContentImporterCli:
 
     @mock.patch('argparse.ArgumentParser.parse_args',
                 return_value=argparse.Namespace(func=import_doc_content, bot="test_cli", user="testUser",
-                                                table_name="documents", overwrite=False, event_type=EventClass.content_importer))
+                                                table_name="documents", overwrite=False))
     def test_doc_importer_with_defaults(self, monkeypatch):
         def mock_doc_content_importer(*args, **kwargs):
             return None
@@ -445,7 +445,7 @@ class TestDocContentImporterCli:
 
     @mock.patch('argparse.ArgumentParser.parse_args',
                 return_value=argparse.Namespace(func=import_doc_content, bot="test_cli", user="testUser",
-                                                table_name="documents", overwrite=True, event_type=EventClass.content_importer))
+                                                table_name="documents", overwrite=True))
     def test_doc_importer_all_arguments(self, monkeypatch):
         def mock_doc_content_importer(*args, **kwargs):
             return None
@@ -455,7 +455,7 @@ class TestDocContentImporterCli:
 
     @mock.patch('argparse.ArgumentParser.parse_args',
                 return_value=argparse.Namespace(func=import_doc_content, bot="test_cli", user="testUser",
-                                                table_name="documents", overwrite="yes", event_type=EventClass.content_importer))
+                                                table_name="documents", overwrite="yes"))
     def test_doc_importer_overwrite_as_string_argument(self, monkeypatch):
         """
         Test CLI command where 'overwrite' is passed as a string instead of a boolean.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line argument `event_type` for improved command functionality in the content importer. Users can now specify the event type when executing commands, enhancing operational granularity.

- **Bug Fixes**
	- Removed the association of the `event_type` from the payload in the content importer, streamlining the functionality.

- **Tests**
	- Added a new test class for the command-line interface related to document content importing, improving test coverage and validating various input scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->