### PR TITLE
Executor logs error fix

### DIFF
--- a/kairon/shared/cloud/utils.py
+++ b/kairon/shared/cloud/utils.py
@@ -83,7 +83,8 @@ class CloudUtility:
             logger.info(response)
 
             if CloudUtility.lambda_execution_failed(response):
-                raise AppException(response)
+                err = response['Payload'].get('body') or response
+                raise AppException(f"{err}")
         except Exception as e:
             exception = str(e)
             CloudUtility.log_task(event_class=event_class, task_type=task_type, data=env_data,

--- a/kairon/shared/cloud/utils.py
+++ b/kairon/shared/cloud/utils.py
@@ -84,7 +84,7 @@ class CloudUtility:
 
             if CloudUtility.lambda_execution_failed(response):
                 err = response['Payload'].get('body') or response
-                raise AppException(f"{err}")
+                raise AppException(err)
         except Exception as e:
             exception = str(e)
             CloudUtility.log_task(event_class=event_class, task_type=task_type, data=env_data,


### PR DESCRIPTION
Raised the specific error from response-payload-body instead of all the response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for lambda execution failures, providing clearer error messages for better user understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->