### PR TITLE
Manage Callback Access

### DIFF
--- a/metadata/roles.yml
+++ b/metadata/roles.yml
@@ -18,6 +18,7 @@ roles:
       logs: true
       generateStories: true
       manageQnaStories: true
+      manageCallbacks: true
       broadcast: true
       customAnalytics: true
       liveAgent: true
@@ -104,6 +105,12 @@ roles:
         delete: true
         augment: true
         download: true
+      manageCallbacks:
+        add: true
+        edit: true
+        delete: true
+        augment: true
+        download: true
       broadcast:
         add: true
         edit: true
@@ -132,6 +139,7 @@ roles:
       logs: true
       generateStories: true
       manageQnaStories: true
+      manageCallbacks: true
       broadcast: true
       customAnalytics: true
       liveAgent: true
@@ -218,6 +226,12 @@ roles:
         delete: true
         augment: true
         download: true
+      manageCallbacks:
+        add: true
+        edit: true
+        delete: true
+        augment: true
+        download: true
       broadcast:
         add: true
         edit: true
@@ -246,6 +260,7 @@ roles:
       logs: true
       generateStories: true
       manageQnaStories: true
+      manageCallbacks: true
       broadcast: true
       customAnalytics: true
       liveAgent: false
@@ -332,6 +347,12 @@ roles:
         delete: true
         augment: true
         download: true
+      manageCallbacks:
+        add: true
+        edit: true
+        delete: true
+        augment: true
+        download: true
       broadcast:
         add: true
         edit: true
@@ -360,6 +381,7 @@ roles:
       logs: true
       generateStories: false
       manageQnaStories: true
+      manageCallbacks: true
       broadcast: false
       customAnalytics: true
       liveAgent: false
@@ -446,6 +468,12 @@ roles:
         delete: false
         augment: false
         download: false
+      manageCallbacks:
+        add: false
+        edit: false
+        delete: false
+        augment: false
+        download: false
       broadcast:
         add: false
         edit: false
@@ -474,6 +502,7 @@ roles:
       logs: false
       generateStories: false
       manageQnaStories: false
+      manageCallbacks: false
       broadcast: false
       customAnalytics: false
       liveAgent: true
@@ -560,6 +589,12 @@ roles:
         delete: false
         augment: false
         download: false
+      manageCallbacks:
+        add: false
+        edit: false
+        delete: false
+        augment: false
+        download: false
       broadcast:
         add: false
         edit: false
@@ -590,6 +625,7 @@ roles:
       logs: false
       generateStories: false
       manageQnaStories: false
+      manageCallbacks: false
       broadcast: false
       customAnalytics: true
       liveAgent: false
@@ -671,6 +707,12 @@ roles:
         viewLogs: false
         testModel: false
       manageQnaStories:
+        add: false
+        edit: false
+        delete: false
+        augment: false
+        download: false
+      manageCallbacks:
         add: false
         edit: false
         delete: false


### PR DESCRIPTION
added access for the manage callbacks as well in roles.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new permission category, `manageCallbacks`, allowing specified roles (owner, admin, designer, tester, and view) to manage callbacks with full access.
- **Bug Fixes**
	- Corrected indentation for existing permissions to improve readability and structure in the role configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->