### PR TITLE
fixed when user can leave bot with viewer and agent access

### DIFF
--- a/kairon/api/app/routers/user.py
+++ b/kairon/api/app/routers/user.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Path, Security
 from starlette.requests import Request
 
-from kairon.shared.constants import ADMIN_ACCESS, TESTER_ACCESS, OWNER_ACCESS
+from kairon.shared.constants import ADMIN_ACCESS, TESTER_ACCESS, OWNER_ACCESS, AGENT_ACCESS
 from kairon.shared.data.constant import ACCESS_ROLES, ACTIVITY_STATUS
 from kairon.shared.multilingual.utils.translator import Translator
 from kairon.shared.utils import Utility, MailUtility
@@ -244,7 +244,7 @@ async def get_model_testing_logs_accuracy(
 async def leave_bot(
     background_tasks: BackgroundTasks,
     bot: str = Path(description="bot id", examples=["613f63e87a1d435607c3c183"]),
-    current_user: User = Security(Authentication.get_current_user_and_bot, scopes=TESTER_ACCESS)
+    current_user: User = Security(Authentication.get_current_user_and_bot, scopes=AGENT_ACCESS)
 ):
     """
     Allows a user except owner to leave a bot.

--- a/kairon/shared/callback/data_objects.py
+++ b/kairon/shared/callback/data_objects.py
@@ -225,7 +225,6 @@ class CallbackConfig(Auditlog):
         return callback_url
 
 
-
 class CallbackRecordStatusType(Enum):
     SUCCESS = "SUCCESS"
     FAILED = "FAILED"

--- a/kairon/shared/data/data_validation.py
+++ b/kairon/shared/data/data_validation.py
@@ -59,8 +59,8 @@ class DataValidation:
     def validate_database_action(bot: str, data: dict):
         data_error = []
         for idx, item in enumerate(data.get('payload', [])):
-            if not item.get('query_type') or not item.get('type') or not item.get('value'):
-                data_error.append(f"Payload {idx} must contain fields 'query_type', 'type' and 'value'!")
+            if not item.get('query_type') or not item.get('type'):
+                data_error.append(f"Payload {idx} must contain fields 'query_type' and 'type'!")
             if item.get('query_type') not in [qtype.value for qtype in DbActionOperationType]:
                 data_error.append(f"Unknown query_type found: {item['query_type']} in payload {idx}")
         return data_error

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -67,3 +67,4 @@ jsonschema_rs==0.18.1
 mongoengine-jsonschema==0.1.3
 fernet==1.0.1
 google-generativeai
+huggingface-hub==0.25.2

--- a/tests/unit_test/data_processor/action_serializer_test.py
+++ b/tests/unit_test/data_processor/action_serializer_test.py
@@ -254,19 +254,16 @@ def test_data_validator_validate_database_action():
 
     # Test case 2: Invalid payload (missing query_type)
     data["payload"][0]["query_type"] = None
-    assert DataValidation.validate_database_action(bot, data) == ["Payload 0 must contain fields 'query_type', 'type' and 'value'!", 'Unknown query_type found: None in payload 0']
+    assert DataValidation.validate_database_action(bot, data) == ["Payload 0 must contain fields 'query_type' and 'type'!", 'Unknown query_type found: None in payload 0']
 
     # Test case 3: Invalid payload (missing type)
     data["payload"][0]["query_type"] = list(db_action_operation_types)[0]
     data["payload"][0]["type"] = None
-    assert DataValidation.validate_database_action(bot, data) == ["Payload 0 must contain fields 'query_type', 'type' and 'value'!"]
+    assert DataValidation.validate_database_action(bot, data) == ["Payload 0 must contain fields 'query_type' and 'type'!"]
 
-    # Test case 4: Invalid payload (missing value)
-    data["payload"][0]["type"] = "type1"
-    data["payload"][0]["value"] = None
-    assert DataValidation.validate_database_action(bot, data) == ["Payload 0 must contain fields 'query_type', 'type' and 'value'!"]
 
-    # Test case 5: Invalid payload (invalid query_type)
+    # Test case 4: Invalid payload (invalid query_type)
+    data["payload"][0]["type"] = 'type1'
     data["payload"][0]["value"] = "value1"
     data["payload"][0]["query_type"] = "invalid_query_type"
     assert DataValidation.validate_database_action(bot, data) == ["Unknown query_type found: invalid_query_type in payload 0", ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded user roles for the `leave_bot` functionality, allowing users with `AGENT_ACCESS` to leave a bot.
	- Introduced a new method to construct callback URLs based on bot and callback names.
	- Added logging capabilities for callback failures.
- **Bug Fixes**
	- Maintained existing email notification logic for bot owners when a user leaves.
	- Simplified validation process for database actions by adjusting required fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->