### PR TITLE
Fix agent viewer access for leave bot 

### DIFF
--- a/kairon/api/app/routers/user.py
+++ b/kairon/api/app/routers/user.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Path, Security
 from starlette.requests import Request
 
-from kairon.shared.constants import ADMIN_ACCESS, TESTER_ACCESS, OWNER_ACCESS
+from kairon.shared.constants import ADMIN_ACCESS, TESTER_ACCESS, OWNER_ACCESS, AGENT_ACCESS
 from kairon.shared.data.constant import ACCESS_ROLES, ACTIVITY_STATUS
 from kairon.shared.multilingual.utils.translator import Translator
 from kairon.shared.utils import Utility, MailUtility
@@ -244,7 +244,7 @@ async def get_model_testing_logs_accuracy(
 async def leave_bot(
     background_tasks: BackgroundTasks,
     bot: str = Path(description="bot id", examples=["613f63e87a1d435607c3c183"]),
-    current_user: User = Security(Authentication.get_current_user_and_bot, scopes=TESTER_ACCESS)
+    current_user: User = Security(Authentication.get_current_user_and_bot, scopes=AGENT_ACCESS)
 ):
     """
     Allows a user except owner to leave a bot.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new access level for users with the AGENT role, enhancing role management for bot interactions.
  
- **Bug Fixes**
	- Updated the `leave_bot` endpoint to allow users with AGENT access to leave a bot, improving user permissions related to bot management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->