### PR TITLE
activeStatus bool added for CognitionSchema

### DIFF
--- a/kairon/api/app/routers/bot/data.py
+++ b/kairon/api/app/routers/bot/data.py
@@ -93,6 +93,9 @@ async def delete_cognition_schema(
 
     CognitionDataProcessor.validate_collection_name(current_user.get_bot(), metadata['collection_name'])
 
+    metadata.activeStatus = False
+    metadata.save()
+
     actor = ActorFactory.get_instance(ActorType.callable_runner.value)
     actor.execute(cognition_processor.delete_cognition_schema, schema_id, current_user.get_bot(),
                   user=current_user.get_user())

--- a/kairon/shared/cognition/data_objects.py
+++ b/kairon/shared/cognition/data_objects.py
@@ -40,6 +40,7 @@ class CognitionSchema(Auditlog):
     user = StringField(required=True)
     bot = StringField(required=True)
     timestamp = DateTimeField(default=datetime.utcnow)
+    activeStatus = BooleanField(default=True)
 
     meta = {"indexes": [{"fields": ["bot"]}]}
 

--- a/kairon/shared/cognition/processor.py
+++ b/kairon/shared/cognition/processor.py
@@ -98,7 +98,7 @@ class CognitionDataProcessor:
         :param bot: bot id
         :return: yield dict
         """
-        for value in CognitionSchema.objects(bot=bot):
+        for value in CognitionSchema.objects(bot=bot, activeStatus=True):
             final_data = {}
             item = value.to_mongo().to_dict()
             metadata = item.pop("metadata")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an `activeStatus` field to track the active state of cognition schemas.
	- Updated the listing functionality to only display active schemas.

- **Bug Fixes**
	- Adjusted deletion logic to mark schemas as inactive instead of immediate deletion, enhancing data management.

These changes improve user experience by ensuring only relevant schemas are visible and providing better control over schema management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->