### PR TITLE
Executor logs fix

### DIFF
--- a/kairon/shared/cloud/utils.py
+++ b/kairon/shared/cloud/utils.py
@@ -59,7 +59,7 @@ class CloudUtility:
             s3.delete_object(Bucket=bucket, Key=file)
 
     @staticmethod
-    def trigger_lambda(event_class: EventClass, env_data: Any, task_type: TASK_TYPE = TASK_TYPE.ACTION.value,
+    def trigger_lambda(event_class: EventClass, env_data: Any, task_type: TASK_TYPE,
                        from_executor: bool = False):
         """
         Triggers lambda based on the event class.
@@ -108,7 +108,8 @@ class CloudUtility:
         bot_id = CloudUtility.get_bot_id_from_env_data(event_class, data,
                                                        from_executor=kwargs.get("from_executor", False),
                                                        task_type=task_type)
-
+        if event_class == EventClass.scheduler_evaluator.value and not task_type:
+            task_type = TASK_TYPE.CALLBACK.value
         try:
             log = ExecutorLogs.objects(executor_log_id=executor_log_id, task_type=task_type, event_class=event_class,
                                        status=EVENT_STATUS.INITIATED.value).get()

--- a/kairon/shared/cloud/utils.py
+++ b/kairon/shared/cloud/utils.py
@@ -59,7 +59,7 @@ class CloudUtility:
             s3.delete_object(Bucket=bucket, Key=file)
 
     @staticmethod
-    def trigger_lambda(event_class: EventClass, env_data: Any, task_type: TASK_TYPE,
+    def trigger_lambda(event_class: EventClass, env_data: Any, task_type: TASK_TYPE = TASK_TYPE.CALLBACK.value,
                        from_executor: bool = False):
         """
         Triggers lambda based on the event class.

--- a/kairon/shared/cloud/utils.py
+++ b/kairon/shared/cloud/utils.py
@@ -59,7 +59,7 @@ class CloudUtility:
             s3.delete_object(Bucket=bucket, Key=file)
 
     @staticmethod
-    def trigger_lambda(event_class: EventClass, env_data: Any, task_type: TASK_TYPE = TASK_TYPE.CALLBACK.value,
+    def trigger_lambda(event_class: EventClass, env_data: Any, task_type: TASK_TYPE,
                        from_executor: bool = False):
         """
         Triggers lambda based on the event class.

--- a/kairon/shared/events/data_objects.py
+++ b/kairon/shared/events/data_objects.py
@@ -5,7 +5,7 @@ from kairon.shared.data.constant import TASK_TYPE
 
 
 class ExecutorLogs(DynamicDocument):
-    task_type = StringField(choices=[task_type.value for task_type in TASK_TYPE])
+    task_type = StringField(default=TASK_TYPE.CALLBACK.value, choices=[task_type.value for task_type in TASK_TYPE])
     event_class = StringField()
     data = DynamicField()
     status = StringField(required=True)

--- a/kairon/shared/events/data_objects.py
+++ b/kairon/shared/events/data_objects.py
@@ -5,7 +5,7 @@ from kairon.shared.data.constant import TASK_TYPE
 
 
 class ExecutorLogs(DynamicDocument):
-    task_type = StringField(default=TASK_TYPE.CALLBACK.value, choices=[task_type.value for task_type in TASK_TYPE])
+    task_type = StringField(choices=[task_type.value for task_type in TASK_TYPE])
     event_class = StringField()
     data = DynamicField()
     status = StringField(required=True)

--- a/tests/unit_test/cloud_utils_test.py
+++ b/tests/unit_test/cloud_utils_test.py
@@ -278,7 +278,8 @@ class TestCloudUtils:
                 assert resp == response
 
         from kairon.shared.events.data_objects import ExecutorLogs
-        logs = ExecutorLogs.objects(event_class=EventClass.scheduler_evaluator.value)
+        logs = ExecutorLogs.objects(event_class=EventClass.scheduler_evaluator.value,
+                                    task_type=TASK_TYPE.CALLBACK.value)
         log = logs[0].to_mongo().to_dict()
         print(log)
         assert log['task_type'] == TASK_TYPE.CALLBACK.value


### PR DESCRIPTION
Added code for executor logs for scheduler_evaluator event_class when task_type is Callback and added and fixed test cases for the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The `trigger_lambda` method now requires an explicit `task_type` parameter, improving clarity in task management.
	- Default value for `task_type` in `ExecutorLogs` is now set to `TASK_TYPE.CALLBACK.value`.

- **Bug Fixes**
	- Enhanced logic for determining `task_type` based on `event_class`, ensuring accurate task logging.

- **Tests**
	- Improved test coverage for Lambda invocation functionality and updated existing tests to align with new method signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->