### PR TITLE
Mail channel filter and stop

### DIFF
--- a/kairon/events/server.py
+++ b/kairon/events/server.py
@@ -150,3 +150,9 @@ def dispatch_scheduled_event(event_id: Text = Path(description="Event id")):
 def request_epoch(bot: Text = Path(description="Bot id")):
     EventUtility.schedule_channel_mail_reading(bot)
     return {"data": None, "message": "Mail scheduler epoch request!"}
+
+
+@app.get('/api/mail/stop/{bot}', response_model=Response)
+def stop_mail_reading(bot: Text = Path(description="Bot id")):
+    EventUtility.stop_channel_mail_reading(bot)
+    return {"data": None, "message": "Mail scheduler stopped!"}

--- a/kairon/events/utility.py
+++ b/kairon/events/utility.py
@@ -71,4 +71,4 @@ class EventUtility:
                 mail_processor.update_event_id(None)
                 KScheduler().delete_job(event_id)
         except Exception as e:
-            raise logger.error(f"Failed to stop mail reading for bot {bot}. Error: {str(e)}")
+            raise AppException(f"Failed to stop mail reading for bot {bot}. Error: {str(e)}")

--- a/kairon/events/utility.py
+++ b/kairon/events/utility.py
@@ -5,8 +5,7 @@ from uuid6 import uuid7
 from kairon.events.executors.factory import ExecutorFactory
 from kairon.events.scheduler.kscheduler import KScheduler
 from kairon.exceptions import AppException
-from kairon.shared.chat.data_objects import Channels
-from kairon.shared.constants import EventClass, ChannelTypes
+from kairon.shared.constants import EventClass
 from kairon.shared.data.constant import TASK_TYPE
 from loguru import logger
 
@@ -60,3 +59,16 @@ class EventUtility:
                                      EventClass.mail_channel_read_mails, {"bot": bot, "user": mail_processor.bot_settings.user})
         except Exception as e:
             raise AppException(f"Failed to schedule mail reading for bot {bot}. Error: {str(e)}")
+
+    @staticmethod
+    def stop_channel_mail_reading(bot: str):
+        from kairon.shared.channels.mail.processor import MailProcessor
+
+        try:
+            mail_processor = MailProcessor(bot)
+            event_id = mail_processor.state.event_id
+            if event_id:
+                mail_processor.update_event_id(None)
+                KScheduler().delete_job(event_id)
+        except Exception as e:
+            raise logger.error(f"Failed to stop mail reading for bot {bot}. Error: {str(e)}")

--- a/kairon/shared/channels/mail/processor.py
+++ b/kairon/shared/channels/mail/processor.py
@@ -6,6 +6,8 @@ from loguru import logger
 from pydantic.schema import timedelta
 from pydantic.validators import datetime
 from imap_tools import MailBox, AND, OR, NOT
+
+from kairon import Utility
 from kairon.exceptions import AppException
 from kairon.shared.account.data_objects import Bot
 from kairon.shared.channels.mail.constants import MailConstants
@@ -37,15 +39,6 @@ class MailProcessor:
         self.state.event_id = event_id
         self.state.save()
 
-
-    @staticmethod
-    def does_mail_channel_exist(bot:str):
-        """
-        Check if mail channel exists
-        """
-        if Channels.objects(bot=bot, connector_type=ChannelTypes.MAIL.value).first():
-            return True
-        return False
 
     @staticmethod
     def get_mail_channel_state_data(bot:str):
@@ -290,14 +283,6 @@ class MailProcessor:
         # Combine all criteria with AND
         return AND(*criteria)
 
-    @staticmethod
-    def comma_sep_string_to_list(comma_sep_string: str) -> List[str]:
-        """
-        Convert comma separated string to list
-        """
-        if not comma_sep_string:
-            return []
-        return [item.strip() for item in comma_sep_string.split(",") if item.strip()]
 
     @staticmethod
     def read_mails(bot: str) -> ([dict], str):
@@ -325,13 +310,13 @@ class MailProcessor:
             mp.login_imap()
             is_logged_in = True
             subject = mp.config.get('subjects', "")
-            subject = MailProcessor.comma_sep_string_to_list(subject)
+            subject = Utility.string_to_list(subject)
             ignore_subject = mp.config.get('ignore_subjects', "")
-            ignore_subject = MailProcessor.comma_sep_string_to_list(ignore_subject)
+            ignore_subject = Utility.string_to_list(ignore_subject)
             from_addresses = mp.config.get('from_emails', "")
-            from_addresses = MailProcessor.comma_sep_string_to_list(from_addresses)
+            from_addresses = Utility.string_to_list(from_addresses)
             ignore_from = mp.config.get('ignore_from_emails', "")
-            ignore_from = MailProcessor.comma_sep_string_to_list(ignore_from)
+            ignore_from = Utility.string_to_list(ignore_from)
             read_status = mp.config.get('seen_status', 'all')
             criteria = mp.generate_criteria(subject, ignore_subject, from_addresses, ignore_from, read_status)
             for msg in mp.mailbox.fetch(criteria, mark_seen=False):

--- a/kairon/shared/channels/mail/processor.py
+++ b/kairon/shared/channels/mail/processor.py
@@ -1,6 +1,5 @@
 import asyncio
 import time
-from typing import List
 
 from loguru import logger
 from pydantic.schema import timedelta
@@ -12,7 +11,6 @@ from kairon.exceptions import AppException
 from kairon.shared.account.data_objects import Bot
 from kairon.shared.channels.mail.constants import MailConstants
 from kairon.shared.channels.mail.data_objects import MailResponseLog, MailStatus, MailChannelStateData
-from kairon.shared.chat.data_objects import Channels
 from kairon.shared.chat.processor import ChatDataProcessor
 from kairon.shared.constants import ChannelTypes
 from kairon.shared.data.data_objects import BotSettings

--- a/kairon/shared/channels/mail/scheduler.py
+++ b/kairon/shared/channels/mail/scheduler.py
@@ -1,6 +1,4 @@
 from urllib.parse import urljoin
-
-
 from kairon import Utility
 from kairon.exceptions import AppException
 from kairon.shared.channels.mail.processor import MailProcessor
@@ -27,6 +25,23 @@ class MailScheduler:
         )
         if not resp['success']:
             raise AppException("Failed to request email channel epoch")
+
+    @staticmethod
+    def request_stop(bot: str):
+        event_server_url = Utility.get_event_server_url()
+        if MailProcessor.does_mail_channel_exist(bot):
+            resp = Utility.execute_http_request(
+                "GET",
+                urljoin(
+                    event_server_url,
+                    f"/api/mail/stop/{bot}",
+                ),
+                err_msg="Failed to request epoch",
+            )
+            if not resp['success']:
+                raise AppException("Failed to stop email channel reading")
+        else:
+            raise AppException("Mail channel does not exist")
 
 
 

--- a/kairon/shared/channels/mail/scheduler.py
+++ b/kairon/shared/channels/mail/scheduler.py
@@ -2,6 +2,8 @@ from urllib.parse import urljoin
 from kairon import Utility
 from kairon.exceptions import AppException
 from kairon.shared.channels.mail.processor import MailProcessor
+from kairon.shared.chat.data_objects import Channels
+from kairon.shared.constants import ChannelTypes
 
 
 class MailScheduler:
@@ -29,7 +31,7 @@ class MailScheduler:
     @staticmethod
     def request_stop(bot: str):
         event_server_url = Utility.get_event_server_url()
-        if MailProcessor.does_mail_channel_exist(bot):
+        if Utility.is_exist(Channels, raise_error=False, bot=bot, connector_type=ChannelTypes.MAIL.value):
             resp = Utility.execute_http_request(
                 "GET",
                 urljoin(

--- a/kairon/shared/chat/processor.py
+++ b/kairon/shared/chat/processor.py
@@ -70,6 +70,12 @@ class ChatDataProcessor:
         :return: None
         """
         kwargs.update({"bot": bot})
+        if kwargs.get("connector_type") != ChannelTypes.SLACK.value:
+            try:
+                from kairon.shared.channels.mail.scheduler import MailScheduler
+                MailScheduler.request_stop(bot)
+            except Exception as e:
+                logger.error(f"Error while stopping mail scheduler for bot {bot}. Error: {str(e)}")
         Utility.hard_delete_document([Channels], **kwargs)
 
     @staticmethod

--- a/kairon/shared/chat/processor.py
+++ b/kairon/shared/chat/processor.py
@@ -70,12 +70,11 @@ class ChatDataProcessor:
         :return: None
         """
         kwargs.update({"bot": bot})
-        if kwargs.get("connector_type") != ChannelTypes.SLACK.value:
-            try:
-                from kairon.shared.channels.mail.scheduler import MailScheduler
-                MailScheduler.request_stop(bot)
-            except Exception as e:
-                logger.error(f"Error while stopping mail scheduler for bot {bot}. Error: {str(e)}")
+        try:
+            from kairon.shared.channels.mail.scheduler import MailScheduler
+            MailScheduler.request_stop(bot)
+        except Exception as e:
+            logger.error(f"Error while stopping mail scheduler for bot {bot}. Error: {str(e)}")
         Utility.hard_delete_document([Channels], **kwargs)
 
     @staticmethod

--- a/kairon/shared/utils.py
+++ b/kairon/shared/utils.py
@@ -2223,6 +2223,15 @@ class Utility:
             document["user"] = user
             document.delete()
 
+    @staticmethod
+    def string_to_list(comma_sep_string: str, delimilter: str = ",") -> List[str]:
+        """
+        Convert comma separated string to list
+        """
+        if not comma_sep_string:
+            return []
+        return [item.strip() for item in comma_sep_string.split(delimilter) if item.strip()]
+
 
 class StoryValidator:
     @staticmethod
@@ -2756,3 +2765,4 @@ class MailUtility:
         body = body.replace("BOT_NAME", bot_name)
         subject = f"Notification: {user_name} has left the {bot_name} bot"
         return body, subject
+

--- a/metadata/integrations.yml
+++ b/metadata/integrations.yml
@@ -85,6 +85,11 @@ channels:
     optional_fields:
       - interval
       - intent
+      - subjects
+      - ignore_subjects
+      - from_emails
+      - ignore_from_emails
+      - seen_status
 
 actions:
   pipedrive:

--- a/tests/unit_test/channels/mail_channel_test.py
+++ b/tests/unit_test/channels/mail_channel_test.py
@@ -588,39 +588,4 @@ class TestMailChannel:
         Channels.objects(connector_type=ChannelTypes.MAIL.value).delete()
 
 
-    def test_comma_sep_string_to_list(self):
-        # Test input with empty elements
-        assert MailProcessor.comma_sep_string_to_list("apple, , banana, , orange") == ["apple", "banana", "orange"]
-
-        # Test input with only commas
-        assert MailProcessor.comma_sep_string_to_list(",,,") == []
-
-        # Test input with no commas (single element)
-        assert MailProcessor.comma_sep_string_to_list("apple") == ["apple"]
-
-        # Test input with empty string
-        assert MailProcessor.comma_sep_string_to_list("") == []
-
-        # Test input with None
-        assert MailProcessor.comma_sep_string_to_list(None) == []
-
-        # Test input with special characters
-        assert MailProcessor.comma_sep_string_to_list("apple,@banana, #orange$") == ["apple", "@banana", "#orange$"]
-
-        # Test input with numeric values
-        assert MailProcessor.comma_sep_string_to_list("1, 2, 3, 4") == ["1", "2", "3", "4"]
-
-        # Test input with spaces
-        assert MailProcessor.comma_sep_string_to_list("apple, banana, orange") == ["apple", "banana", "orange"]
-
-
-    @patch('kairon.shared.channels.mail.processor.Channels')
-    def test_mail_channel_exist(self, mock_channels):
-        mock_channels.objects.return_value.first.return_value = True
-        assert MailProcessor.does_mail_channel_exist("test_bot") is True
-
-    @patch('kairon.shared.channels.mail.processor.Channels')
-    def test_mail_channel_not_exist(self, mock_channels):
-        mock_channels.objects.return_value.first.return_value = False
-        assert MailProcessor.does_mail_channel_exist("test_bot") is False
 

--- a/tests/unit_test/channels/mail_scheduler_test.py
+++ b/tests/unit_test/channels/mail_scheduler_test.py
@@ -125,8 +125,7 @@ def test_stop_channel_mail_reading(mock_mongo, mock_mail_processor, mock_kschedu
     EventUtility.stop_channel_mail_reading(bot)
     mock_delete_job.assert_called_once()
 
-
-@patch('kairon.shared.channels.mail.processor.MailProcessor.does_mail_channel_exist')
+@patch('kairon.shared.utils.Utility.is_exist')
 @patch('kairon.shared.channels.mail.scheduler.Utility.get_event_server_url')
 @patch('kairon.shared.channels.mail.scheduler.Utility.execute_http_request')
 def test_request_stop_success(mock_execute_http_request, mock_get_event_server_url, mock_imp):
@@ -140,10 +139,10 @@ def test_request_stop_success(mock_execute_http_request, mock_get_event_server_u
         pytest.fail("request_epoch() raised AppException unexpectedly!")
 
 
-@patch('kairon.shared.channels.mail.processor.MailProcessor.does_mail_channel_exist')
+@patch('kairon.shared.utils.Utility.is_exist')
 @patch('kairon.shared.channels.mail.scheduler.Utility.get_event_server_url')
 @patch('kairon.shared.channels.mail.scheduler.Utility.execute_http_request')
-def test_request_stop__response_not_success(mock_execute_http_request, mock_get_event_server_url, mock_imp):
+def test_request_stop_response_not_success(mock_execute_http_request, mock_get_event_server_url, mock_imp):
     mock_get_event_server_url.return_value = "http://localhost"
     mock_execute_http_request.return_value = {'success': False}
     mock_imp.return_value = True
@@ -151,7 +150,7 @@ def test_request_stop__response_not_success(mock_execute_http_request, mock_get_
     with pytest.raises(AppException):
         MailScheduler.request_stop(bot)
 
-@patch('kairon.shared.channels.mail.processor.MailProcessor.does_mail_channel_exist')
+@patch('kairon.shared.utils.Utility.is_exist')
 @patch('kairon.shared.channels.mail.scheduler.Utility.get_event_server_url')
 @patch('kairon.shared.channels.mail.scheduler.Utility.execute_http_request')
 def test_request_stop_no_channel_exist_exception(mock_execute_http_request, mock_get_event_server_url, mock_imp):

--- a/tests/unit_test/channels/mail_scheduler_test.py
+++ b/tests/unit_test/channels/mail_scheduler_test.py
@@ -139,18 +139,6 @@ def test_request_stop_success(mock_execute_http_request, mock_get_event_server_u
     except AppException:
         pytest.fail("request_epoch() raised AppException unexpectedly!")
 
-@patch('kairon.shared.channels.mail.processor.MailProcessor.does_mail_channel_exist')
-@patch('kairon.shared.channels.mail.scheduler.Utility.get_event_server_url')
-@patch('kairon.shared.channels.mail.scheduler.Utility.execute_http_request')
-def test_request_stop_success(mock_execute_http_request, mock_get_event_server_url, mock_imp):
-    mock_get_event_server_url.return_value = "http://localhost"
-    mock_execute_http_request.return_value = {'success': True}
-    mock_imp.return_value = True
-    bot = "test_bot"
-    try:
-        MailScheduler.request_stop(bot)
-    except AppException:
-        pytest.fail("request_epoch() raised AppException unexpectedly!")
 
 @patch('kairon.shared.channels.mail.processor.MailProcessor.does_mail_channel_exist')
 @patch('kairon.shared.channels.mail.scheduler.Utility.get_event_server_url')

--- a/tests/unit_test/channels/mail_scheduler_test.py
+++ b/tests/unit_test/channels/mail_scheduler_test.py
@@ -108,3 +108,69 @@ def test_schedule_channel_mail_reading_exception(mock_mongo_client, mock_mail_pr
         EventUtility.schedule_channel_mail_reading(bot)
     assert str(excinfo.value) == f"Failed to schedule mail reading for bot {bot}. Error: Test Exception"
 
+@patch('kairon.events.utility.KScheduler.delete_job')
+@patch('kairon.events.utility.KScheduler.__init__', return_value=None)
+@patch('kairon.shared.channels.mail.processor.MailProcessor')
+@patch('pymongo.MongoClient', autospec=True)
+def test_stop_channel_mail_reading(mock_mongo, mock_mail_processor, mock_kscheduler, mock_delete_job):
+    from kairon.events.utility import EventUtility
+
+    bot = "test_bot"
+    mock_mail_processor_instance = mock_mail_processor.return_value
+    mock_mail_processor_instance.config = {"interval": 1}
+    mock_mail_processor_instance.state.event_id = 'existing_event_id'
+    mock_mail_processor_instance.bot_settings.user = "test_user"
+
+#     # Test case when event_id is None
+    EventUtility.stop_channel_mail_reading(bot)
+    mock_delete_job.assert_called_once()
+
+
+@patch('kairon.shared.channels.mail.processor.MailProcessor.does_mail_channel_exist')
+@patch('kairon.shared.channels.mail.scheduler.Utility.get_event_server_url')
+@patch('kairon.shared.channels.mail.scheduler.Utility.execute_http_request')
+def test_request_stop_success(mock_execute_http_request, mock_get_event_server_url, mock_imp):
+    mock_get_event_server_url.return_value = "http://localhost"
+    mock_execute_http_request.return_value = {'success': True}
+    mock_imp.return_value = True
+    bot = "test_bot"
+    try:
+        MailScheduler.request_stop(bot)
+    except AppException:
+        pytest.fail("request_epoch() raised AppException unexpectedly!")
+
+@patch('kairon.shared.channels.mail.processor.MailProcessor.does_mail_channel_exist')
+@patch('kairon.shared.channels.mail.scheduler.Utility.get_event_server_url')
+@patch('kairon.shared.channels.mail.scheduler.Utility.execute_http_request')
+def test_request_stop_success(mock_execute_http_request, mock_get_event_server_url, mock_imp):
+    mock_get_event_server_url.return_value = "http://localhost"
+    mock_execute_http_request.return_value = {'success': True}
+    mock_imp.return_value = True
+    bot = "test_bot"
+    try:
+        MailScheduler.request_stop(bot)
+    except AppException:
+        pytest.fail("request_epoch() raised AppException unexpectedly!")
+
+@patch('kairon.shared.channels.mail.processor.MailProcessor.does_mail_channel_exist')
+@patch('kairon.shared.channels.mail.scheduler.Utility.get_event_server_url')
+@patch('kairon.shared.channels.mail.scheduler.Utility.execute_http_request')
+def test_request_stop__response_not_success(mock_execute_http_request, mock_get_event_server_url, mock_imp):
+    mock_get_event_server_url.return_value = "http://localhost"
+    mock_execute_http_request.return_value = {'success': False}
+    mock_imp.return_value = True
+    bot = "test_bot"
+    with pytest.raises(AppException):
+        MailScheduler.request_stop(bot)
+
+@patch('kairon.shared.channels.mail.processor.MailProcessor.does_mail_channel_exist')
+@patch('kairon.shared.channels.mail.scheduler.Utility.get_event_server_url')
+@patch('kairon.shared.channels.mail.scheduler.Utility.execute_http_request')
+def test_request_stop_no_channel_exist_exception(mock_execute_http_request, mock_get_event_server_url, mock_imp):
+    mock_get_event_server_url.return_value = "http://localhost"
+    mock_execute_http_request.return_value = {'success': True}
+    mock_imp.return_value = False
+    bot = "test_bot"
+    with pytest.raises(AppException):
+        MailScheduler.request_stop(bot)
+

--- a/tests/unit_test/utility_test.py
+++ b/tests/unit_test/utility_test.py
@@ -3306,3 +3306,30 @@ class TestUtility:
         validate_and_send_mail_mock.assert_called_once_with(
             email, expected_subject, expected_body
         )
+
+
+    def test_comma_sep_string_to_list(self):
+        # Test input with empty elements
+        assert Utility.string_to_list("apple, , banana, , orange") == ["apple", "banana", "orange"]
+
+        # Test input with only commas
+        assert Utility.string_to_list(",,,") == []
+
+        # Test input with no commas (single element)
+        assert Utility.string_to_list("apple") == ["apple"]
+
+        # Test input with empty string
+        assert Utility.string_to_list("") == []
+
+        # Test input with None
+        assert Utility.string_to_list(None) == []
+
+        # Test input with special characters
+        assert Utility.string_to_list("apple,@banana, #orange$") == ["apple", "@banana", "#orange$"]
+
+        # Test input with numeric values
+        assert Utility.string_to_list("1, 2, 3, 4") == ["1", "2", "3", "4"]
+
+        # Test input with spaces
+        assert Utility.string_to_list("apple, banana, orange") == ["apple", "banana", "orange"]
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new endpoint for stopping mail reading associated with a bot.
	- Added optional fields to the mail integration for enhanced configurability.
	- Implemented a method for generating customizable email fetching criteria.

- **Bug Fixes**
	- Improved error handling in the mail scheduler stop functionality.

- **Tests**
	- Added new tests for mail reading and stopping functionality, enhancing test coverage.
	- Introduced tests for the new string-to-list utility method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->