### PR TITLE
Format text converter channels

### DIFF
--- a/kairon/chat/converters/channels/telegram.py
+++ b/kairon/chat/converters/channels/telegram.py
@@ -1,3 +1,5 @@
+import json
+
 from kairon.chat.converters.channels.responseconverter import ElementTransformerOps
 from kairon.shared.constants import ElementTypes
 
@@ -34,6 +36,34 @@ class TelegramResponseConverter(ElementTransformerOps):
         except Exception as ex:
             raise Exception(f" Error in TelegramResponseConverter::link_transformer {str(ex)}")
 
+    def paragraph_transformer(self, message):
+        try:
+            message_template = ElementTransformerOps.getChannelConfig(self.channel, self.message_type)
+            paragraph_template = json.loads(message_template)
+            jsoniterator = ElementTransformerOps.json_generator(message)
+            final_text = ""
+            for item in jsoniterator:
+                if item.get("type") == "paragraph":
+                    children = ElementTransformerOps.json_generator(item.get("children", []))
+                    for child in children:
+                        text = child.get("text", "")
+                        leading_spaces = len(text) - len(text.lstrip())
+                        trailing_spaces = len(text) - len(text.rstrip())
+                        text = text.strip()
+                        if child.get("bold"):
+                            text = f"<b>{text}</b>"
+                        if child.get("italic"):
+                            text = f"<i>{text}</i>"
+                        if child.get("strikethrough"):
+                            text = f"<s>{text}</s>"
+                        final_text += f"{' ' * leading_spaces}{text}{' ' * trailing_spaces}"
+                    final_text += "\n"
+
+            paragraph_template["text"] = final_text
+            return paragraph_template
+        except Exception as ex:
+            raise Exception(f"Error in TelegramResponseConverter::paragraph_transformer {str(ex)}")
+
     def button_transformer(self, message):
         try:
             jsoniterator = ElementTransformerOps.json_generator(message)
@@ -65,5 +95,7 @@ class TelegramResponseConverter(ElementTransformerOps):
                 return super().video_transformer(message)
             elif self.message_type == ElementTypes.BUTTON.value:
                 return self.button_transformer(message)
+            elif self.message_type == ElementTypes.FORMAT_TEXT.value:
+                return self.paragraph_transformer(message)
         except Exception as ex:
             raise Exception(f"Error in TelegramResponseConverter::messageConverter {str(ex)}")

--- a/kairon/chat/handlers/channels/telegram.py
+++ b/kairon/chat/handlers/channels/telegram.py
@@ -156,7 +156,7 @@ class TelegramOutput(TeleBot, OutputChannel):
                     del response["photo"]
                     api_call = getattr(self, send_functions[("photo",)])
                     api_call(recipient_id, *response_list, **response)
-                elif ops_type in ["link", "video"]:
+                elif ops_type in ["link", "video", "formatText"]:
                     response_list.append(response.get("text"))
                     del response["text"]
                     api_call = getattr(self, send_functions[("text",)])

--- a/kairon/chat/handlers/channels/whatsapp.py
+++ b/kairon/chat/handlers/channels/whatsapp.py
@@ -233,7 +233,7 @@ class WhatsappBot(OutputChannel):
         message = json_message.get("data")
         messagetype = json_message.get("type")
         content_type = {"link": "text", "video": "video", "image": "image", "button": "interactive",
-                        "dropdown": "interactive", "audio": "audio"}
+                        "dropdown": "interactive", "audio": "audio", "formatText": "text"}
         if messagetype is not None and messagetype in type_list:
             messaging_type = content_type.get(messagetype)
             from kairon.chat.converters.channels.response_factory import ConverterFactory

--- a/kairon/shared/constants.py
+++ b/kairon/shared/constants.py
@@ -126,6 +126,7 @@ class ElementTypes(str, Enum):
     BUTTON = "button"
     DROPDOWN = "dropdown"
     QUICK_REPLY = "quick_reply"
+    FORMAT_TEXT = "formatText"
 
 
 class WhatsappBSPTypes(str, Enum):

--- a/metadata/message_template.yml
+++ b/metadata/message_template.yml
@@ -1,4 +1,4 @@
-type_list: ["image","link","video","button","quick_reply","dropdown","audio"]
+type_list: ["image","link","video","button","quick_reply","dropdown","audio", "formatText"]
 slack:
   image: '{
 	"blocks": [
@@ -88,6 +88,7 @@ messenger:
   video: '{"text":"<data>"}'
   button: '{"text":"<data>"}'
   body_message: "Please select from quick buttons:"
+  formatText: '{"text":"<data>"}'
 
 whatsapp:
   image: '{
@@ -112,6 +113,10 @@ whatsapp:
   "action":"<action>"
   }'
   body_message: "Please select from quick buttons:"
+  formatText: '{
+    "preview_url": true,
+    "body":"<data>"
+  }'
 
   dropdown: '{
       "type": "list",
@@ -128,6 +133,13 @@ telegram:
   "reply_to_message_id":0}'
   video: '{"text":"<data>"}'
   body_message: 'Please select from quick buttons:'
+  formatText: '{
+    "text":"<data>",
+    "parse_mode":"HTML",
+    "disable_web_page_preview":false,
+    "disable_notification":false,
+    "reply_to_message_id":0
+  }'
 
 msteams:
   body_message: "Please select from quick buttons:"


### PR DESCRIPTION
whatsapp, telegram, messenger & instagram

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for formatted text messages across Messenger, Telegram, and WhatsApp.
	- Introduced a new message type, `formatText`, in the messaging template for various platforms.

- **Bug Fixes**
	- Enhanced error handling in message processing methods for better reliability.

- **Tests**
	- Expanded test coverage for the new paragraph transformation functionality in the response converters for WhatsApp, Telegram, and Messenger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->