### PR TITLE
fix for email chat formatting for formatText

### DIFF
--- a/kairon/shared/actions/utils.py
+++ b/kairon/shared/actions/utils.py
@@ -807,7 +807,14 @@ class ActionUtility:
         if data.get('type') == "image":
             reply = f'<span><img src="{data.get("src")}" alt="{data.get("alt")}" width="150" height="150"/><br/><p>{data.get("alt")}</p></span>'
         elif data.get('type') == "paragraph":
-            reply = f'<p>{reply}</p>'
+            reply = ""
+            for child in data['children']:
+                if child.get("bold"):
+                    reply += f"<b>{child.get('text', '')}</b>"
+                if child.get("italic"):
+                    reply += f"<i>{child.get('text', '')}</i>"
+                if child.get("strikethrough"):
+                    reply += f"<s>{child.get('text', '')}</s>"
         elif data.get('type') == "link":
             reply = f'<a target="_blank" href="{data.get("href")}">{reply}</a>'
         elif data.get('type') == "video":

--- a/kairon/shared/actions/utils.py
+++ b/kairon/shared/actions/utils.py
@@ -809,12 +809,14 @@ class ActionUtility:
         elif data.get('type') == "paragraph":
             reply = ""
             for child in data['children']:
+                text = child.get('text', '')
                 if child.get("bold"):
-                    reply += f"<b>{child.get('text', '')}</b>"
+                    text = f"<b>{text}</b>"
                 if child.get("italic"):
-                    reply += f"<i>{child.get('text', '')}</i>"
+                    text = f"<i>{text}</i>"
                 if child.get("strikethrough"):
-                    reply += f"<s>{child.get('text', '')}</s>"
+                    text =  f"<s>{text}</s>"
+                reply += text
         elif data.get('type') == "link":
             reply = f'<a target="_blank" href="{data.get("href")}">{reply}</a>'
         elif data.get('type') == "video":

--- a/tests/unit_test/action/action_test.py
+++ b/tests/unit_test/action/action_test.py
@@ -4060,3 +4060,43 @@ class TestActions:
                                              'feedback, analyzing customer data, and much more.'},
             {'role': 'user', 'content': 'I am interested in Kairon and want to know what features it offers'}
         ]
+
+
+
+def test_format_custom_bot_reply_indirect():
+    # Test text
+    data = {"text": "This is a test message."}
+    result = ActionUtility._ActionUtility__format_custom_bot_reply(data)
+    assert result == "This is a test message."
+
+    # Test image
+    data = {"type": "image", "src": "image_url", "alt": "image_alt", "children": []}
+    result = ActionUtility._ActionUtility__format_custom_bot_reply(data)
+    expected = '<span><img src="image_url" alt="image_alt" width="150" height="150"/><br/><p>image_alt</p></span>'
+    assert result == expected
+
+    # Test paragraph with formatting
+    data = {
+        "type": "paragraph",
+        "children": [
+            {"text": "Bold text", "bold": True},
+            {"text": "Italic text ", "italic": True},
+            {"text": "Strike text ", "strikethrough": True},
+            {"text": " and normal text."}
+        ]
+    }
+    result = ActionUtility._ActionUtility__format_custom_bot_reply(data)
+    expected = "<b>Bold text</b><i>Italic text </i><s>Strike text </s> and normal text."
+    assert result == expected
+
+    # Test link
+    data = {"type": "link", "href": "http://example.com", "children": [{"text": "Example"}]}
+    result = ActionUtility._ActionUtility__format_custom_bot_reply(data)
+    expected = '<a target="_blank" href="http://example.com">Example</a>'
+    assert result == expected
+
+    # Test video
+    data = {"type": "video", "url": "http://example.com/video", "children": []}
+    result = ActionUtility._ActionUtility__format_custom_bot_reply(data)
+    expected = '<a target="_blank" href="http://example.com/video">http://example.com/video</a>'
+    assert result == expected


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced bot reply formatting with support for mixed text styles (bold, italic, strikethrough) within a single paragraph.

- **Improvements**
	- Increased flexibility in text formatting for bot responses, allowing more dynamic and rich text representation.

- **Tests**
	- Added comprehensive tests for the bot reply formatting, covering various data formats including text, images, paragraphs, links, and videos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->