### PR TITLE
rasa upgraded

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,14 +2,14 @@
 pytest==8.3.2
 pytest_httpx==0.30.0
 pytest-asyncio==0.24.0
-responses==0.25.3
+responses==0.25.6
 mock==5.1.0
-moto[all]==5.0.14.dev8
+moto[all]==5.0.26
 mongomock==4.1.2
 black==22.12.0
 locust==2.31.5.dev3
 deepdiff==7.0.1
 pytest-cov==5.0.0
 pytest-html==4.1.1
-pytest-aioresponses==0.2.0
+pytest-aioresponses==0.3.0
 aioresponses==0.7.6

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,4 @@
-rasa[full]==3.6.20
+rasa[full]==3.6.21
 mongoengine==0.29.0
 fastapi==0.115.6
 uvicorn[standard]==0.32.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,7 +1,7 @@
 rasa[full]==3.6.21
-mongoengine==0.29.0
+mongoengine==0.29.1
 fastapi==0.115.6
-uvicorn[standard]==0.32.0
+uvicorn[standard]==0.34.0
 smart-config==0.1.3
 fastapi_sso==0.15.0
 fastapi-keycloak==1.0.11
@@ -10,7 +10,7 @@ zenpy==2.0.50
 validators==0.33.0
 secure==0.3.0
 password-strength==0.0.3.post2
-beautifulsoup4==4.13.0b2
+beautifulsoup4==4.13.0b3
 uuid6==2024.7.10
 passlib[bcrypt]==1.7.4
 json2html==1.3.0
@@ -28,7 +28,7 @@ dramatiq==1.17.0
 dramatiq-mongodb==0.8.3
 nlpaug==1.1.11
 keybert==0.8.5
-pyTelegramBotAPI==4.22.1
+pyTelegramBotAPI==4.26.0
 APScheduler==3.9.1.post1
 croniter==2.0.7
 faiss-cpu==1.8.0.post1
@@ -41,7 +41,7 @@ aiohttp-retry==2.8.3
 pqdict==1.4.0
 google-businessmessages==1.0.5
 google-apitools==0.5.32
-orjson==3.10.7
+orjson==3.10.14
 opentelemetry-distro[otlp]==0.48b0
 opentelemetry-sdk-extension-aws==2.0.2
 opentelemetry-propagator-aws-xray==1.0.2
@@ -60,7 +60,6 @@ opentelemetry-instrumentation-grpc==0.48b0
 opentelemetry-instrumentation-asgi==0.48b0
 opentelemetry-instrumentation-requests==0.48b0
 pykwalify==1.8.0
-gunicorn==22.0.0
 litellm==1.39.5
 jsonschema_rs==0.18.1
 mongoengine-jsonschema==0.1.3
@@ -70,3 +69,4 @@ huggingface-hub==0.25.2
 imap-tools==1.7.4
 more-itertools
 python-multipart>=0.0.18
+nltk

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 python -m pip install -r requirements/dev.txt
 python -c "import spacy; spacy.cli.download('en_core_web_md')"
-python -m spacy link en_core_web_md en
 python -c "import nltk;nltk.download('averaged_perceptron_tagger_eng')"
 python -c "import nltk;nltk.download('averaged_perceptron_tagger')"
 python -c "import nltk;nltk.download('punkt')"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dependency Update**
  - Upgraded Rasa package to version 3.6.21
  - Updated mongoengine to version 0.29.1
  - Updated uvicorn to version 0.34.0
  - Updated beautifulsoup4 to version 4.13.0b3
  - Updated pyTelegramBotAPI to version 4.26.0
  - Updated orjson to version 3.10.14
  - Added new dependency: nltk
  - Updated responses to version 0.25.6
  - Upgraded moto[all] to version 5.0.26
  - Updated pytest-aioresponses to version 0.3.0
- **Setup Changes**
  - Removed linking of the SpaCy model `en_core_web_md` to shortcut `en` in the setup process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->