### PR TITLE
mail config duplicate ignore same bot

### DIFF
--- a/kairon/shared/channels/mail/processor.py
+++ b/kairon/shared/channels/mail/processor.py
@@ -56,16 +56,17 @@ class MailProcessor:
             raise AppException(str(e))
 
     @staticmethod
-    def check_email_config_exists(config_dict: dict) -> bool:
+    def check_email_config_exists(bot: str, config_dict: dict) -> bool:
         """
         Check if email configuration already exists
+        :param bot: str - bot id
         :param config_dict: dict - email configuration
         :return status: bool True if configuration exists, False otherwise
         """
         configs = ChatDataProcessor.get_all_channel_configs(ChannelTypes.MAIL, False)
         email_account = config_dict['email_account']
         for config in configs:
-            if config['config']['email_account'] == email_account:
+            if config['bot'] != bot and config['config']['email_account'] == email_account:
                 subjects1 = Utility.string_to_list(config['config'].get('subjects', ''))
                 subjects2 = Utility.string_to_list(config_dict.get('subjects', ''))
                 if (not subjects1) and (not subjects2):

--- a/kairon/shared/chat/processor.py
+++ b/kairon/shared/chat/processor.py
@@ -29,7 +29,7 @@ class ChatDataProcessor:
             configuration['config']['private_key'] = private_key.replace("\\n", "\n")
         if configuration['connector_type'] == ChannelTypes.MAIL.value:
             from kairon.shared.channels.mail.processor import MailProcessor
-            if MailProcessor.check_email_config_exists(configuration['config']):
+            if MailProcessor.check_email_config_exists(bot, configuration['config']):
                 raise AppException("Email configuration already exists for same email address and subject")
         try:
             filter_args = ChatDataProcessor.__attach_metadata_and_get_filter(configuration, bot)

--- a/tests/unit_test/channels/mail_channel_test.py
+++ b/tests/unit_test/channels/mail_channel_test.py
@@ -599,15 +599,16 @@ class TestMailChannel:
     @patch('kairon.shared.chat.processor.ChatDataProcessor.get_all_channel_configs')
     def test_check_email_config_exists_no_existing_config(self,mock_get_all_channel_configs, config_dict):
         mock_get_all_channel_configs.return_value = []
-        result = MailProcessor.check_email_config_exists(config_dict)
+        result = MailProcessor.check_email_config_exists('test', config_dict)
         assert result == False
 
     @patch('kairon.shared.chat.processor.ChatDataProcessor.get_all_channel_configs')
     def test_check_email_config_exists_same_config_exists(self, mock_get_all_channel_configs, config_dict):
         mock_get_all_channel_configs.return_value = [{
+            'bot': 'test',
             'config': config_dict
         }]
-        result = MailProcessor.check_email_config_exists(config_dict)
+        result = MailProcessor.check_email_config_exists('test_bot', config_dict)
         assert result == True
 
     @patch('kairon.shared.chat.processor.ChatDataProcessor.get_all_channel_configs')
@@ -615,9 +616,20 @@ class TestMailChannel:
         existing_config = config_dict.copy()
         existing_config['subjects'] = 'subject3'
         mock_get_all_channel_configs.return_value = [{
+            "bot": 'test_bot',
             'config': existing_config
         }]
-        result = MailProcessor.check_email_config_exists(config_dict)
+        result = MailProcessor.check_email_config_exists('test', config_dict)
+        assert result == False
+
+    @patch('kairon.shared.chat.processor.ChatDataProcessor.get_all_channel_configs')
+    def test_check_email_config_exists_ignore_same_bot(self, mock_get_all_channel_configs, config_dict):
+        existing_config = config_dict.copy()
+        mock_get_all_channel_configs.return_value = [{
+            "bot": 'test_bot',
+            'config': existing_config
+        }]
+        result = MailProcessor.check_email_config_exists('test_bot', config_dict)
         assert result == False
 
     @patch('kairon.shared.chat.processor.ChatDataProcessor.get_all_channel_configs')
@@ -625,7 +637,8 @@ class TestMailChannel:
         existing_config = config_dict.copy()
         existing_config['subjects'] = 'subject1,subject3'
         mock_get_all_channel_configs.return_value = [{
+            'bot': 'test_bot',
             'config': existing_config
         }]
-        result = MailProcessor.check_email_config_exists(config_dict)
+        result = MailProcessor.check_email_config_exists('test', config_dict)
         assert result == True


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced email configuration validation with bot-specific checks

- **Bug Fixes**
	- Improved email configuration existence detection to prevent conflicts between bot configurations
	- Added error logging for mail scheduler stop requests

- **Refactor**
	- Updated method signatures to include bot identifiers in email configuration checks
	- Refined logic for email configuration validation across different bots

- **Tests**
	- Added new test cases to verify bot-specific email configuration handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->