### PR TITLE
fix to delete multiple entries from the prompt management

### DIFF
--- a/kairon/api/app/routers/bot/data.py
+++ b/kairon/api/app/routers/bot/data.py
@@ -15,6 +15,7 @@ from kairon.shared.cognition.processor import CognitionDataProcessor
 from kairon.shared.concurrency.actors.factory import ActorFactory
 from kairon.shared.constants import ActorType
 from kairon.shared.constants import DESIGNER_ACCESS
+from kairon.shared.data.data_models import DeleteCognitionRequest
 from kairon.shared.data.processor import MongoProcessor
 from kairon.shared.models import User
 from kairon.shared.utils import Utility
@@ -169,6 +170,16 @@ async def delete_cognition_data(
         "message": "Record deleted!"
     }
 
+@router.post("/cognition/delete_multiple", response_model=Response)
+async def delete_multiple_cognition_data(
+    request: DeleteCognitionRequest,
+    current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
+):
+    """
+    Deletes multiple cognition content entries of the bot in bulk
+    """
+    cognition_processor.delete_multiple_cognition_data(request.row_ids, current_user.get_bot(), current_user.get_user())
+    return {"message": "Records deleted!"}
 
 @router.get("/cognition", response_model=Response)
 async def list_cognition_data(

--- a/kairon/api/app/routers/bot/data.py
+++ b/kairon/api/app/routers/bot/data.py
@@ -15,7 +15,7 @@ from kairon.shared.cognition.processor import CognitionDataProcessor
 from kairon.shared.concurrency.actors.factory import ActorFactory
 from kairon.shared.constants import ActorType
 from kairon.shared.constants import DESIGNER_ACCESS
-from kairon.shared.data.data_models import DeleteCognitionRequest
+from kairon.shared.data.data_models import  BulkDeleteRequest
 from kairon.shared.data.processor import MongoProcessor
 from kairon.shared.models import User
 from kairon.shared.utils import Utility
@@ -172,7 +172,7 @@ async def delete_cognition_data(
 
 @router.post("/cognition/delete_multiple", response_model=Response)
 async def delete_multiple_cognition_data(
-    request: DeleteCognitionRequest,
+    request: BulkDeleteRequest,
     current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
 ):
     """

--- a/kairon/shared/cognition/processor.py
+++ b/kairon/shared/cognition/processor.py
@@ -363,6 +363,15 @@ class CognitionDataProcessor:
         except DoesNotExist:
             raise AppException("Payload does not exists!")
 
+    def delete_multiple_cognition_data(self, row_ids: List[str], bot: Text, user: str = None):
+        """
+        Deletes multiple cognition entries in bulk.
+        """
+        if not row_ids:
+            raise AppException("row_ids list cannot be empty!")
+        query = {"id__in": row_ids}
+        Utility.hard_delete_document([CognitionData], bot=bot,user=user, **query)
+
     def delete_all_cognition_data_by_collection(self, collection_name: Text, bot: Text):
         """
         Deletes all documents from the specified collection for a given bot.

--- a/kairon/shared/data/data_models.py
+++ b/kairon/shared/data/data_models.py
@@ -1228,6 +1228,16 @@ class CognitiveDataRequest(BaseModel):
             raise ValueError("data cannot be empty")
         return values
 
+class DeleteCognitionRequest(BaseModel):
+    row_ids: List[str]
+
+    @root_validator
+    def check(cls, values):
+        row_ids = values.get("row_ids")
+        if not row_ids or not isinstance(row_ids, list) or any(not row_id.strip() for row_id in row_ids):
+            raise ValueError("row_ids must be a non-empty list of valid strings")
+
+        return values
 
 class RazorpayActionRequest(BaseModel):
     name: constr(to_lower=True, strip_whitespace=True)

--- a/kairon/shared/data/data_models.py
+++ b/kairon/shared/data/data_models.py
@@ -1228,7 +1228,7 @@ class CognitiveDataRequest(BaseModel):
             raise ValueError("data cannot be empty")
         return values
 
-class DeleteCognitionRequest(BaseModel):
+class BulkDeleteRequest(BaseModel):
     row_ids: List[str]
 
     @root_validator

--- a/tests/unit_test/data_processor/data_processor_test.py
+++ b/tests/unit_test/data_processor/data_processor_test.py
@@ -18105,6 +18105,38 @@ class TestMongoProcessor:
         bot = 'testing'
         assert list(processor.list_cognition_data(bot)) == []
 
+    def test_delete_multiple_payload_content(self):
+        processor = CognitionDataProcessor()
+        bot = 'test'
+        user = 'testUser'
+        collection = "multiple_delete_clear"
+
+        metadata = {
+            "metadata": None,
+            "collection_name": collection,
+            "bot": bot,
+            "user": user
+        }
+        processor.save_cognition_schema(metadata, user, bot)
+        contents = [
+            "A bot is a software application designed to automate tasks.",
+            "Bots can perform tasks like answering questions or analyzing data.",
+            "Some bots control physical machines, craeate leads or play games."
+        ]
+        content_ids = []
+        for content in contents:
+            payload = {
+                "data": content,
+                "content_type": "text",
+                "collection": collection
+            }
+
+            content_id = processor.save_cognition_data(payload, user, bot)
+            content_ids.append(content_id)
+
+        processor.delete_multiple_cognition_data(content_ids, bot, user)
+        remaining_docs = CognitionData.objects(id__in=content_ids)
+        assert remaining_docs.count() == 0
 
 class TestAgentProcessor:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - **Bulk Data Deletion:** A new feature enables the removal of multiple cognition data entries simultaneously through a dedicated endpoint, improving operational efficiency in data management.
  - **Enhanced Validations:** The new functionality includes robust checks to ensure that deletion requests contain valid and non-empty lists, reducing errors during the deletion process.

- **Tests**
  - Added integration and unit tests to validate the new bulk deletion functionality and ensure proper error handling for invalid requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->