### PR TITLE
api to trigger mail read event

### DIFF
--- a/kairon/api/app/routers/bot/bot.py
+++ b/kairon/api/app/routers/bot/bot.py
@@ -19,6 +19,7 @@ from kairon.api.models import (
     TextDataLowerCase, SlotMappingRequest, EventConfig, MultiFlowStoryRequest, BotSettingsRequest
 )
 from kairon.events.definitions.data_importer import TrainingDataImporterEvent
+from kairon.events.definitions.mail_channel import MailReadEvent
 from kairon.events.definitions.model_testing import ModelTestingEvent
 from kairon.events.definitions.model_training import ModelTrainingEvent
 from kairon.exceptions import AppException
@@ -1670,3 +1671,16 @@ async def get_mail_channel_logs(start_idx: int = 0, page_size: int = 10,
     """
     data = MailProcessor.get_log(current_user.get_bot(), start_idx, page_size)
     return Response(data=data)
+
+
+@router.get("/mail_channel/read_mailbox", response_model=Response)
+async def trigger_mail_channel_read(
+        current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
+):
+    """
+    Trains the chatbot
+    """
+    event = MailReadEvent(current_user.get_bot(), current_user.get_user())
+    event.validate()
+    event.enqueue()
+    return Response(message="mail channel read triggered")

--- a/kairon/api/app/routers/bot/bot.py
+++ b/kairon/api/app/routers/bot/bot.py
@@ -1678,7 +1678,7 @@ async def trigger_mail_channel_read(
         current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
 ):
     """
-    Trains the chatbot
+    Triggers asynchronous reading of emails from the configured mailbox.
     """
     event = MailReadEvent(current_user.get_bot(), current_user.get_user())
     event.validate()

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -15342,6 +15342,24 @@ def test_add_story_to_different_bot():
     assert actual["error_code"] == 0
 
 
+@patch('kairon.api.app.routers.bot.bot.MailReadEvent.__init__', return_value=None)
+@patch('kairon.api.app.routers.bot.bot.MailReadEvent.validate')
+@patch('kairon.api.app.routers.bot.bot.MailReadEvent.enqueue')
+def test_trigger_mail_channel_read(mock_enque, mock_validate, mock_init):
+    response = client.get(
+        f"/api/bot/{pytest.bot}/mail_channel/read_mailbox",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    mock_validate.assert_called_once()
+    mock_enque.assert_called_once()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["message"] == "mail channel read triggered"
+
+
+
 @responses.activate
 def test_train_on_different_bot(monkeypatch):
     def _mock_training_limit(*arge, **kwargs):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an API endpoint that triggers mailbox reading operations, ensuring proper permission checks and providing a success confirmation.

- **Tests**
  - Added integration tests that verify the endpoint’s functionality by checking that event validation and triggering occur as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->