### PR TITLE
removed default static comment reply

### DIFF
--- a/kairon/shared/chat/data_objects.py
+++ b/kairon/shared/chat/data_objects.py
@@ -37,9 +37,6 @@ class Channels(Auditlog):
             })
             Utility.register_telegram_webhook(Utility.decrypt_message(self.config['access_token']), webhook_url)
 
-        if self.connector_type == "instagram" and self.config.get("static_comment_reply") is None:
-            self.config["static_comment_reply"] = Utility.environment["channels"]["instagram"]["static_comment_reply"]
-
 
 @auditlogger.log
 @push_notification.apply

--- a/system.yaml
+++ b/system.yaml
@@ -206,8 +206,6 @@ channels:
     partner_username: ${360_DIALOG_PARTNER_USERNAME}
     partner_password: ${360DIALOG_PARTNER_PASSWORD}
     error_codes: ${ERROR_CODES:[131021,131052]}
-  instagram:
-    static_comment_reply: ${INSTA_STATIC_COMMENT_REPLY:Thanks for reaching us, please check your inbox}
 llm:
   faq: ${LLM_FAQ_TYPE:GPT3_FAQ_EMBED}
   key: ${TEMPLATE_LLM_KEY}

--- a/tests/testing_data/system.yaml
+++ b/tests/testing_data/system.yaml
@@ -201,8 +201,6 @@ channels:
     partner_username: ${360_DIALOG_PARTNER_USERNAME}
     partner_password: ${360DIALOG_PARTNER_PASSWORD}
     error_codes: ${ERROR_CODES:[131021,131052]}
-  instagram:
-    static_comment_reply: ${INSTA_STATIC_COMMENT_REPLY:Thanks for reaching us, please check your inbox}
 
 llm:
   faq: ${LLM_FAQ_TYPE:GPT3_FAQ_EMBED}

--- a/tests/unit_test/chat/chat_test.py
+++ b/tests/unit_test/chat/chat_test.py
@@ -799,7 +799,7 @@ class TestChat:
         with pytest.raises(NotImplementedError):
             await ChannelHandlerBase().handle_message()
 
-    def test_save_channel_config_insta_with_default_comment_reply(self, monkeypatch):
+    def test_save_channel_config_insta_with_no_comment_reply(self, monkeypatch):
         bot = '5e564fbcdcf0d5fad89e3acd'
 
         def _get_integration_token(*args, **kwargs):
@@ -820,7 +820,7 @@ class TestChat:
         insta = ChatDataProcessor.get_channel_config("instagram", bot, False)
 
         static_comment_reply_actual = insta.get("config", {}).get("static_comment_reply")
-        assert "Thanks for reaching us, please check your inbox" == static_comment_reply_actual
+        assert not static_comment_reply_actual
 
     def test_save_channel_config_insta_with_custom_comment_reply(self, monkeypatch):
         bot = '5e564fbcdcf0d5fad89e3acd'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the legacy behavior that automatically assigned a default static comment reply for Instagram, streamlining how Instagram interactions are handled.
  
- **Chores**
  - Cleaned up system and testing configurations by removing the redundant Instagram channel settings.
  
- **Tests**
  - Updated validations to ensure that there is no default comment reply for Instagram, reflecting the revised integration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->