### PR TITLE
updated url for chat access

### DIFF
--- a/kairon/chat/routers/web_client.py
+++ b/kairon/chat/routers/web_client.py
@@ -134,22 +134,8 @@ async def execute_flow(
         "message": "Rule executed successfully!"
     }
 
-@router.post('/media/upload', response_model=Response)
-async def media_upload(
-        sender_id: str = Form(...),
-        files: list[UploadFile] = File(...),
-        bot: Text = Path(description="Bot id"),
-        current_user: User = Security(Authentication.get_current_user_and_bot, scopes=CHAT_ACCESS)
-):
-    results = await UserMedia.upload_media_contents(bot, sender_id, files)
-    return {
-        "data": results,
-        "message": 'media uploaded successfully'
-    }
 
-
-
-@router.get('/media/download/{media_id}', response_class=StreamingResponse)
+@router.get('/chat/media/download/{media_id}', response_class=StreamingResponse)
 async def media_download(
         bot: Text = Path(description="Bot id"),
         media_id: Text = Path(description="Id of the document"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The media download endpoint is now available at a new URL: `/chat/media/download/{media_id}`.

- **Removed**
	- The media upload feature and its endpoint have been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->