### PR TITLE
Built an end-to-end catalog ingestion flow from Petpooja(POS) to Meta

### DIFF
--- a/email.yaml
+++ b/email.yaml
@@ -25,4 +25,5 @@ email:
         book_a_demo_subject: ${EMAIL_TEMPLATES_BOOK_A_DEMO_SUBJECT:"kAIron Demo Requested"}
         member_left_bot_subject: ${EMAIL_TEMPLATES_USER_LEFT_BOT_SUBJECT:"User has left the BOT_NAME bot"}
         member_left_bot_mail_body: ${EMAIL_TEMPLATES_USER_LEFT_BOT_BODY:"User USER_NAME has left the BOT_NAME bot."}
+        catalog_sync_status_subject: ${EMAIL_TEMPLATES_CATALOG_SYNC_UPDATE:"Catalog Sync Update"}
 

--- a/kairon/api/app/main.py
+++ b/kairon/api/app/main.py
@@ -24,7 +24,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from kairon.api.app.routers import auth, augment, history, user, account, idp, system
 from kairon.api.app.routers.bot import action, bot, agents, secrets, multilingual, metric, data, \
-    channels, custom_widgets
+    channels, custom_widgets, integrations
 from kairon.api.models import Response
 from kairon.exceptions import AppException
 from kairon.shared.account.processor import AccountProcessor
@@ -276,3 +276,4 @@ app.include_router(idp.router, prefix="/api/idp", tags=["SSO", "IDP"])
 app.include_router(system.router, prefix="/api/system", tags=["Application"])
 app.include_router(data.router, prefix="/api/bot/{bot}/data", tags=["File Upload/Download"])
 app.include_router(custom_widgets.router, prefix="/api/bot/{bot}/widgets", tags=["Custom analytical widgets"])
+app.include_router(integrations.router, prefix="/api/bot/integration", tags=["Data Integrations"])

--- a/kairon/api/app/routers/bot/data.py
+++ b/kairon/api/app/routers/bot/data.py
@@ -1,7 +1,7 @@
 import os
-from typing import List, Text
+from typing import List
 
-from fastapi import UploadFile, File, Security, APIRouter, Query, HTTPException, Path
+from fastapi import UploadFile, File, Security, APIRouter, Query, HTTPException
 from starlette.requests import Request
 from starlette.responses import FileResponse
 

--- a/kairon/api/app/routers/bot/data.py
+++ b/kairon/api/app/routers/bot/data.py
@@ -1,7 +1,7 @@
 import os
-from typing import List
+from typing import List, Text
 
-from fastapi import UploadFile, File, Security, APIRouter, Query, HTTPException
+from fastapi import UploadFile, File, Security, APIRouter, Query, HTTPException, Path
 from starlette.requests import Request
 from starlette.responses import FileResponse
 
@@ -13,8 +13,9 @@ from kairon.shared.auth import Authentication
 from kairon.shared.cognition.data_objects import CognitionSchema
 from kairon.shared.cognition.processor import CognitionDataProcessor
 from kairon.shared.concurrency.actors.factory import ActorFactory
-from kairon.shared.constants import ActorType
+from kairon.shared.constants import ActorType, CatalogSyncClass
 from kairon.shared.constants import DESIGNER_ACCESS
+from kairon.shared.data.data_models import POSIntegrationRequest
 from kairon.shared.data.data_models import  BulkDeleteRequest
 from kairon.shared.data.processor import MongoProcessor
 from kairon.shared.models import User
@@ -360,7 +361,7 @@ async def download_error_csv(
 async def knowledge_vault_sync(
     primary_key_col: str,
     collection_name: str,
-    event_type: str,
+    sync_type: str,
     data: List[dict],
     current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
 ):
@@ -369,7 +370,7 @@ async def knowledge_vault_sync(
     """
     data = [{key.lower(): value for key, value in row.items()} for row in data]
 
-    error_summary = cognition_processor.validate_data(primary_key_col.lower(), collection_name.lower(), event_type.lower(), data, current_user.get_bot())
+    error_summary = cognition_processor.validate_data(primary_key_col.lower(), collection_name.lower(), sync_type.lower(), data, current_user.get_bot())
 
     if error_summary:
         return Response(
@@ -379,7 +380,7 @@ async def knowledge_vault_sync(
             error_code=400
         )
 
-    await cognition_processor.upsert_data(primary_key_col.lower(), collection_name.lower(), event_type.lower(), data,
+    await cognition_processor.upsert_data(primary_key_col.lower(), collection_name.lower(), sync_type.lower(), data,
                                     current_user.get_bot(), current_user.get_user())
 
     return Response(
@@ -387,3 +388,26 @@ async def knowledge_vault_sync(
         message="Processing completed successfully",
         data=None
     )
+
+
+@router.post("/integrations/add", response_model=Response)
+async def add_pos_integration_config(
+    request_data: POSIntegrationRequest,
+    sync_type: str,
+    current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
+):
+    """
+    Add data integration config
+    """
+    CognitionDataProcessor.load_catalog_provider_mappings()
+
+    if request_data.provider not in CatalogSyncClass.__members__.values():
+        raise AppException("Invalid Provider")
+
+    CognitionDataProcessor.add_bot_sync_config(request_data, current_user.get_bot(), current_user.get_user())
+
+    integration_endpoint = cognition_processor.save_pos_integration_config(
+        request_data.dict(), current_user.get_bot(), current_user.get_user(), sync_type
+    )
+
+    return Response(message='POS Integration Complete', data=integration_endpoint)

--- a/kairon/api/app/routers/bot/integrations.py
+++ b/kairon/api/app/routers/bot/integrations.py
@@ -60,7 +60,7 @@ async def rerun_sync(
     execution_id: str = Path(description="Execution id"),
 ):
     """
-    Handles incoming data from catalog_sync (e.g., Petpooja) for processing, validation, and eventual storage.
+    Handles incoming data from catalog_sync and rerunning (e.g., Petpooja) for processing, validation, and eventual storage.
     """
     sync_log_entry = CatalogSyncLogs.objects(execution_id=execution_id).first()
     if not sync_log_entry:

--- a/kairon/api/app/routers/bot/integrations.py
+++ b/kairon/api/app/routers/bot/integrations.py
@@ -1,0 +1,85 @@
+from typing import  Text
+
+from fastapi import Security, APIRouter, Path
+from starlette.requests import Request
+
+from kairon.api.models import Response
+from kairon.events.definitions.catalog_sync import CatalogSync
+from kairon.exceptions import AppException
+from kairon.shared.auth import Authentication
+from kairon.shared.catalog_sync.data_objects import CatalogSyncLogs
+from kairon.shared.cognition.processor import CognitionDataProcessor
+from kairon.shared.constants import CatalogProvider
+from kairon.shared.constants import DESIGNER_ACCESS
+from kairon.shared.models import User
+from kairon.shared.utils import MailUtility
+
+router = APIRouter()
+cognition_processor = CognitionDataProcessor()
+
+@router.post("/{provider}/{sync_type}/{bot}/{token}", response_model=Response)
+async def sync_data(
+    request: Request,
+    provider: CatalogProvider = Path(description="Catalog provider name",
+                                 examples=[CatalogProvider.PETPOOJA.value]),
+    bot: Text = Path(description="Bot id"),
+    sync_type: Text = Path(description="Sync Type"),
+    current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
+    token: str = Path(description="JWT token for authentication"),
+):
+    """
+    Handles incoming data from catalog_sync (e.g., Petpooja) for processing, validation, and eventual storage.
+    """
+
+    request_body = await request.json()
+
+    event = CatalogSync(
+        bot=bot,
+        user=current_user.get_user(),
+        provider=provider,
+        sync_type=sync_type,
+        token=token
+    )
+
+    is_event_data = await event.validate(request_body=request_body)
+    if is_event_data is True:
+        event.enqueue()
+        return {"message": "Sync in progress! Check logs."}
+    else:
+        raise AppException(is_event_data)
+
+
+
+@router.post("/{provider}/{sync_type}/{bot}/{token}/{execution_id}", response_model=Response)
+async def rerun_sync(
+    provider: CatalogProvider = Path(description="Catalog provider name",
+                                 examples=[CatalogProvider.PETPOOJA.value]),
+    bot: Text = Path(description="Bot id"),
+    sync_type: Text = Path(description="Sync Type"),
+    current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
+    token: str = Path(description="JWT token for authentication"),
+    execution_id: str = Path(description="Execution id"),
+):
+    """
+    Handles incoming data from catalog_sync (e.g., Petpooja) for processing, validation, and eventual storage.
+    """
+    sync_log_entry = CatalogSyncLogs.objects(execution_id=execution_id).first()
+    if not sync_log_entry:
+        raise AppException(f"Sync log with execution ID {execution_id} not found.")
+
+    request_body = sync_log_entry.raw_payload
+
+    event = CatalogSync(
+        bot=bot,
+        user=current_user.get_user(),
+        provider=provider,
+        sync_type=sync_type,
+        token=token
+    )
+
+    is_event_data = await event.validate(request_body=request_body)
+    if is_event_data is True:
+        event.enqueue()
+        return {"message": "Sync in progress! Check logs."}
+    else:
+        raise AppException(is_event_data)

--- a/kairon/api/app/routers/bot/integrations.py
+++ b/kairon/api/app/routers/bot/integrations.py
@@ -12,7 +12,6 @@ from kairon.shared.cognition.processor import CognitionDataProcessor
 from kairon.shared.constants import CatalogProvider
 from kairon.shared.constants import DESIGNER_ACCESS
 from kairon.shared.models import User
-from kairon.shared.utils import MailUtility
 
 router = APIRouter()
 cognition_processor = CognitionDataProcessor()

--- a/kairon/catalog_sync/definitions/base.py
+++ b/kairon/catalog_sync/definitions/base.py
@@ -1,0 +1,18 @@
+from abc import abstractmethod
+
+
+class CatalogSyncBase:
+
+    """Base class to create events"""
+
+    @abstractmethod
+    def validate(self):
+        raise NotImplementedError("Provider not implemented")
+
+    @abstractmethod
+    def preprocess(self):
+        raise NotImplementedError("Provider not implemented")
+
+    @abstractmethod
+    def execute(self, **kwargs):
+        raise NotImplementedError("Provider not implemented")

--- a/kairon/catalog_sync/definitions/factory.py
+++ b/kairon/catalog_sync/definitions/factory.py
@@ -1,0 +1,29 @@
+from kairon.events.definitions.petpooja_sync import PetpoojaSync
+from kairon.exceptions import AppException
+from kairon.shared.constants import CatalogSyncClass
+
+
+class CatalogSyncFactory:
+
+    __provider_implementations = {
+        CatalogSyncClass.petpooja: PetpoojaSync,
+    }
+
+    @staticmethod
+    def get_instance(provider: str):
+        """
+        Factory to retrieve catalog provider implementation for execution.
+        :param provider: catalog provider name (e.g., "petpooja")
+        :return: Corresponding Sync class
+        """
+        try:
+            provider_enum = CatalogSyncClass(provider.lower())
+        except ValueError:
+            valid_syncs = [sync.value for sync in CatalogSyncClass]
+            raise AppException(f"'{provider}' is not a valid catalog sync provider. Accepted types: {valid_syncs}")
+
+        sync_class = CatalogSyncFactory.__provider_implementations.get(provider_enum)
+        if not sync_class:
+            raise AppException(f"No implementation found for provider '{provider}'.")
+
+        return sync_class

--- a/kairon/events/definitions/catalog_sync.py
+++ b/kairon/events/definitions/catalog_sync.py
@@ -1,0 +1,73 @@
+from typing import Text
+from kairon import Utility
+from loguru import logger
+
+from kairon.catalog_sync.definitions.factory import CatalogSyncFactory
+from kairon.events.definitions.base import EventsBase
+from kairon.shared.account.processor import AccountProcessor
+from kairon.shared.constants import EventClass
+from kairon.shared.data.constant import SyncType, SYNC_STATUS
+from kairon.shared.catalog_sync.catalog_sync_log_processor import CatalogSyncLogProcessor
+
+
+class CatalogSync(EventsBase):
+    """
+    Validates and processes data from catalog (e.g., Petpooja) before importing it
+    to knowledge vault and meta
+    """
+
+    def __init__(self, bot: Text, user: Text, provider: Text, **kwargs):
+        """
+        Initialise event.
+        """
+        sync_class = CatalogSyncFactory.get_instance(provider)
+        self.catalog_sync = sync_class(
+            bot=bot,
+            user=user,
+            provider=provider,
+            sync_type=kwargs.get("sync_type", SyncType.item_toggle),
+            token=kwargs.get("token", "")
+        )
+        self.catalog_sync.data = []
+
+    async def validate(self, **kwargs):
+        """
+        Validates if an event is already running for that particular bot and
+        checks if the event trigger limit has been exceeded.
+        Then, preprocesses the received request
+        """
+        request = kwargs.get("request_body")
+        self.catalog_sync.data = request
+        is_event_data = await self.catalog_sync.validate(request_body = request)
+        return is_event_data
+
+    def enqueue(self, **kwargs):
+        """
+        Send event to event server
+        """
+        try:
+            payload = {
+                'bot': self.catalog_sync.bot,
+                'user': self.catalog_sync.user,
+                'provider': self.catalog_sync.provider,
+                'sync_type': self.catalog_sync.sync_type,
+                'token': self.catalog_sync.token,
+                'data': self.catalog_sync.data
+            }
+            CatalogSyncLogProcessor.add_log(self.catalog_sync.bot, self.catalog_sync.user, self.catalog_sync.provider, self.catalog_sync.sync_type, sync_status=SYNC_STATUS.ENQUEUED.value)
+            Utility.request_event_server(EventClass.catalog_integration, payload)
+        except Exception as e:
+            CatalogSyncLogProcessor.delete_enqueued_event_log(self.catalog_sync.bot)
+            raise e
+
+    async def execute(self, **kwargs):
+        """
+        Execute the document content import event.
+        """
+        AccountProcessor.load_system_properties()
+        self.catalog_sync.data = kwargs.get("data", [])
+        try:
+            initiate_import, stale_primary_keys= await self.catalog_sync.preprocess(request_body=self.catalog_sync.data)
+            await self.catalog_sync.execute(data=self.catalog_sync.data, initiate_import = initiate_import,stale_primary_keys = stale_primary_keys)
+        except Exception as e:
+            logger.error(str(e))

--- a/kairon/events/definitions/factory.py
+++ b/kairon/events/definitions/factory.py
@@ -1,4 +1,5 @@
 from kairon.events.definitions.agentic_flow import AgenticFlowEvent
+from kairon.events.definitions.catalog_sync import CatalogSync
 from kairon.events.definitions.content_importer import DocContentImporterEvent
 from kairon.events.definitions.data_importer import TrainingDataImporterEvent
 from kairon.events.definitions.faq_importer import FaqDataImporterEvent
@@ -24,7 +25,8 @@ class EventFactory:
         EventClass.message_broadcast: MessageBroadcastEvent,
         EventClass.content_importer: DocContentImporterEvent,
         EventClass.mail_channel_read_mails: MailReadEvent,
-        EventClass.agentic_flow: AgenticFlowEvent
+        EventClass.agentic_flow: AgenticFlowEvent,
+        EventClass.catalog_integration: CatalogSync
     }
 
     @staticmethod

--- a/kairon/events/definitions/petpooja_sync.py
+++ b/kairon/events/definitions/petpooja_sync.py
@@ -1,0 +1,197 @@
+from typing import Text
+
+from dotenv import set_key
+
+from kairon import Utility
+from loguru import logger
+
+from kairon.catalog_sync.definitions.base import CatalogSyncBase
+from kairon.exceptions import AppException
+from kairon.meta.processor import MetaProcessor
+from kairon.shared.cognition.processor import CognitionDataProcessor
+from kairon.shared.constants import EventClass
+from kairon.shared.data.constant import SyncType, SYNC_STATUS
+from kairon.shared.data.data_objects import POSIntegrations, BotSyncConfig
+from kairon.shared.catalog_sync.catalog_sync_log_processor import CatalogSyncLogProcessor
+from kairon.shared.utils import MailUtility
+
+
+class PetpoojaSync(CatalogSyncBase):
+    """
+    Validates and processes data from catalog (e.g., Petpooja) before importing it
+    to knowledge vault and meta
+    """
+
+    def __init__(self, bot: Text, user: Text, provider: Text, **kwargs):
+        """
+        Initialise event.
+        """
+        self.bot = bot
+        self.user = user
+        self.provider = provider
+        self.token = kwargs.get("token", "")
+        self.sync_type = kwargs.get("sync_type", SyncType.item_toggle)
+        self.data = []
+
+    async def validate(self, **kwargs):
+        """
+        Validates if an event is already running for that particular bot and
+        checks if the event trigger limit has been exceeded.
+        Then, preprocesses the received request
+        """
+        try:
+            request = kwargs.get("request_body")
+            CatalogSyncLogProcessor.is_sync_in_progress(self.bot)
+            CatalogSyncLogProcessor.is_limit_exceeded(self.bot)
+            CatalogSyncLogProcessor.add_log(self.bot, self.user, self.provider, self.sync_type,
+                                            sync_status=SYNC_STATUS.INITIATED.value, raw_payload=request)
+
+            CatalogSyncLogProcessor.is_sync_type_allowed(self.bot, self.sync_type)
+            if not CatalogSyncLogProcessor.is_catalog_collection_exists(self.bot) and CatalogSyncLogProcessor.is_ai_enabled(self.bot):
+                CatalogSyncLogProcessor.create_catalog_collection(bot=self.bot, user=self.user)
+            CatalogSyncLogProcessor.add_log(self.bot, self.user, sync_status=SYNC_STATUS.VALIDATING_REQUEST)
+            if self.sync_type == SyncType.push_menu:
+                CatalogSyncLogProcessor.validate_item_ids(request)
+                CatalogSyncLogProcessor.validate_item_fields(self.bot, request, self.provider)
+                CatalogSyncLogProcessor.validate_image_configurations(self.bot, self.user)
+            else:
+                CatalogSyncLogProcessor.validate_item_toggle_request(request)
+            return True
+        except Exception as e:
+            execution_id = CatalogSyncLogProcessor.get_execution_id_for_bot(self.bot)
+            await MailUtility.format_and_send_mail(
+                    mail_type="catalog_sync_status", email="himanshu.gupta@nimblework.com", bot = self.bot, executionID = execution_id,
+                    sync_status=SYNC_STATUS.VALIDATING_FAILED, message = str(e), first_name = "HG"
+                )
+            CatalogSyncLogProcessor.add_log(self.bot, self.user, sync_status=SYNC_STATUS.FAILED.value,
+                                            exception=str(e),
+                                            status="Failure")
+            return str(e)
+
+    async def preprocess(self, **kwargs):
+        """
+        Transform and preprocess incoming payload data into `self.data`
+        for catalog sync and meta sync.
+        """
+        sync_status = SYNC_STATUS.VALIDATING_REQUEST_SUCCESS
+        try:
+            cognition_processor = CognitionDataProcessor()
+            sync_status=SYNC_STATUS.PREPROCESSING
+            CatalogSyncLogProcessor.add_log(self.bot, self.user, sync_status=sync_status)
+            request = kwargs.get("request_body")
+            if self.sync_type == SyncType.push_menu:
+                self.data = cognition_processor.preprocess_push_menu_data(self.bot, request, self.provider)
+            else:
+                self.data = cognition_processor.preprocess_item_toggle_data(self.bot, request, self.provider)
+            sync_status = SYNC_STATUS.PREPROCESSING_COMPLETED
+            CatalogSyncLogProcessor.add_log(self.bot, self.user, sync_status=sync_status, processed_payload= self.data)
+            stale_primary_keys = CognitionDataProcessor.save_ai_data(self.data, self.bot, self.user, self.sync_type)
+            initiate_import = True
+            if CatalogSyncLogProcessor.is_ai_enabled(self.bot):
+                restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(self.bot)
+                catalog_name = f"{restaurant_name}_{branch_name}_catalog"
+                sync_status = SYNC_STATUS.VALIDATING_KNOWLEDGE_VAULT_DATA
+                CatalogSyncLogProcessor.add_log(self.bot, self.user, sync_status=sync_status)
+                error_summary = cognition_processor.validate_data("id", catalog_name,
+                                                                  self.sync_type.lower(), self.data.get("kv", []), self.bot)
+                if error_summary:
+                    initiate_import = False
+                    sync_status = SYNC_STATUS.SAVE.value
+                    CatalogSyncLogProcessor.add_log(self.bot, self.user, validation_errors=error_summary,
+                                                    sync_status=sync_status, status="Failure")
+            return initiate_import, stale_primary_keys
+        except Exception as e:
+            execution_id = CatalogSyncLogProcessor.get_execution_id_for_bot(self.bot)
+            await MailUtility.format_and_send_mail(
+                mail_type="catalog_sync_status", email="himanshu.gupta@nimblework.com", bot=self.bot,
+                executionID=execution_id,
+                sync_status=sync_status, message=str(e), first_name="HG"
+            )
+            CatalogSyncLogProcessor.add_log(self.bot, self.user, sync_status=SYNC_STATUS.FAILED.value,
+                                            exception=str(e),
+                                            status="Failure")
+            return None
+
+
+    async def execute(self, **kwargs):
+        """
+        Execute the document content import event.
+        """
+        self.data = kwargs.get("data", {})
+        cognition_processor = CognitionDataProcessor()
+        initiate_import = kwargs.get("initiate_import", False)
+        stale_primary_keys = kwargs.get("stale_primary_keys")
+        status = "Failure"
+        sync_status = SYNC_STATUS.PREPROCESSING_COMPLETED
+        try:
+            knowledge_vault_data = self.data.get("kv", [])
+            restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(self.bot)
+            catalog_name = f"{restaurant_name}_{branch_name}_catalog"
+
+            if not CatalogSyncLogProcessor.is_ai_enabled(self.bot) and not CatalogSyncLogProcessor.is_meta_enabled(self.bot):
+                CatalogSyncLogProcessor.add_log(self.bot, self.user,
+                                                exception="Sync to knowledge vault and Meta is not allowed for this bot. Contact Support!!",
+                                                status="Success")
+                raise Exception("Sync to knowledge vault and Meta is not allowed for this bot. Contact Support!!")
+
+            if initiate_import and CatalogSyncLogProcessor.is_ai_enabled(self.bot):
+                result = await cognition_processor.upsert_data("id", catalog_name,
+                                                                   self.sync_type.lower(), knowledge_vault_data,
+                                                                   self.bot, self.user)
+                stale_primary_keys = result.get("stale_ids")
+            else:
+                sync_status = SYNC_STATUS.COMPLETED.value
+                CatalogSyncLogProcessor.add_log(self.bot, self.user,
+                                                exception="Sync to knowledge vault is not allowed for this bot. Contact Support!!",
+                                                status="Success")
+
+            if not CatalogSyncLogProcessor.is_meta_enabled(self.bot):
+                sync_status = SYNC_STATUS.COMPLETED.value
+                CatalogSyncLogProcessor.add_log(self.bot, self.user,
+                                                exception="Sync to Meta is not allowed for this bot. Contact Support!!",
+                                                status="Success")
+
+            integrations_doc = POSIntegrations.objects(bot=self.bot, provider=self.provider,
+                                                    sync_type=self.sync_type).first()
+            if integrations_doc and 'meta_config' in integrations_doc:
+                sync_status=SYNC_STATUS.SAVE_META.value
+                CatalogSyncLogProcessor.add_log(self.bot, self.user, sync_status=sync_status)
+                meta_processor = MetaProcessor(integrations_doc.meta_config.get('access_token'),
+                                               integrations_doc.meta_config.get('catalog_id'))
+
+                meta_payload = self.data.get("meta", [])
+                if self.sync_type == SyncType.push_menu:
+                    meta_processor.preprocess_data(self.bot, meta_payload, "CREATE", self.provider)
+                    await meta_processor.push_meta_catalog()
+                    if stale_primary_keys:
+                        delete_payload = meta_processor.preprocess_delete_data(stale_primary_keys)
+                        await meta_processor.delete_meta_catalog(delete_payload)
+                    status = "Success"
+                else:
+                    meta_processor.preprocess_data(self.bot, meta_payload, "UPDATE", self.provider)
+                    await meta_processor.update_meta_catalog()
+                    status = "Success"
+            execution_id = CatalogSyncLogProcessor.get_execution_id_for_bot(self.bot)
+            sync_status=SYNC_STATUS.COMPLETED.value
+            await MailUtility.format_and_send_mail(
+                mail_type="catalog_sync_status", email="himanshu.gupta@nimblework.com", bot=self.bot,
+                executionID=execution_id,
+                sync_status=sync_status, message="Catalog has been synced successfully", first_name="HG"
+            )
+            CatalogSyncLogProcessor.add_log(self.bot, self.user, sync_status=sync_status, status=status)
+        except Exception as e:
+            print(str(e))
+            execution_id = CatalogSyncLogProcessor.get_execution_id_for_bot(self.bot)
+            await MailUtility.format_and_send_mail(
+                mail_type="catalog_sync_status", email="himanshu.gupta@nimblework.com", bot=self.bot,
+                executionID=execution_id,
+                sync_status=sync_status, message=str(e), first_name="HG"
+            )
+            if not CatalogSyncLogProcessor.is_meta_enabled(self.bot) and not CatalogSyncLogProcessor.is_ai_enabled(self.bot):
+                CatalogSyncLogProcessor.add_log(self.bot, self.user,
+                                                sync_status=SYNC_STATUS.COMPLETED.value)
+            else:
+                CatalogSyncLogProcessor.add_log(self.bot, self.user,
+                                                    exception=str(e),
+                                                    status="Failure",
+                                                    sync_status=sync_status)

--- a/kairon/events/definitions/petpooja_sync.py
+++ b/kairon/events/definitions/petpooja_sync.py
@@ -1,17 +1,10 @@
 from typing import Text
 
-from dotenv import set_key
-
-from kairon import Utility
-from loguru import logger
-
 from kairon.catalog_sync.definitions.base import CatalogSyncBase
-from kairon.exceptions import AppException
 from kairon.meta.processor import MetaProcessor
 from kairon.shared.cognition.processor import CognitionDataProcessor
-from kairon.shared.constants import EventClass
 from kairon.shared.data.constant import SyncType, SYNC_STATUS
-from kairon.shared.data.data_objects import POSIntegrations, BotSyncConfig
+from kairon.shared.data.data_objects import POSIntegrations
 from kairon.shared.catalog_sync.catalog_sync_log_processor import CatalogSyncLogProcessor
 from kairon.shared.utils import MailUtility
 

--- a/kairon/meta/processor.py
+++ b/kairon/meta/processor.py
@@ -1,0 +1,122 @@
+import asyncio
+import json
+from typing import Text, List
+from urllib.parse import urljoin
+from loguru import logger
+import requests
+from kairon import Utility
+from kairon.shared.catalog_sync.data_objects import CatalogProviderMapping
+from kairon.shared.rest_client import AioRestClient
+from urllib.parse import quote
+
+
+class MetaProcessor:
+
+    def __init__(self, access_token: Text, catalog_id:Text):
+        self.catalog_id = catalog_id
+        self.access_token = access_token
+        self.headers = {}
+        self.processed_data = []
+
+    def preprocess_data(self,bot: Text, data: List[dict], method: Text, provider: str):
+        doc = CatalogProviderMapping.objects(provider=provider).first()
+        if not doc:
+            raise Exception(f"Metadata mappings not found for provider={provider}")
+
+        meta_fields = list(doc.meta_mappings.keys())
+
+        for item in data:
+            transformed_item = {"retailer_id": item["id"]}
+
+            if method == "UPDATE":
+                transformed_item["data"] = {}
+                for field in meta_fields:
+                    if field in item:
+                        value = int(item[field]) if field == "price" else item[field]
+                        transformed_item["data"][field] = value
+
+            else:
+                transformed_item["data"] = {"currency": "INR"}
+                for field in meta_fields:
+                    if field in item:
+                        value = int(item[field]) if field == "price" else item[field]
+                        transformed_item["data"][field] = value
+
+            transformed_item["method"] = method
+            transformed_item["item_type"] = "PRODUCT_ITEM"
+            self.processed_data.append(transformed_item)
+
+        return self.processed_data
+
+    def preprocess_delete_data(self, remaining_ids: List):
+        """
+        Creates a payload for deleting stale records from the catalog.
+        Args:
+            remaining_ids: List of primary keys that need to be deleted.
+        Returns:
+            Dict: Payload containing the list of delete operations.
+        """
+        return [{"retailer_id": id, "method": "DELETE"} for id in remaining_ids]
+
+    async def push_meta_catalog(self):
+        """
+        Sync the data to meta when event type is 'push_menu'
+        """
+        try:
+            req = quote(json.dumps(self.processed_data))
+            base_url = f"https://graph.facebook.com/v21.0/{self.catalog_id}/batch"
+            url = f"{base_url}?item_type=PRODUCT_ITEM&requests={req}"
+
+            data = {
+                "access_token": self.access_token,
+            }
+
+            response = await asyncio.to_thread(requests.post, url, headers={}, data=data)
+            response.raise_for_status()
+            print("Response JSON:", response.json())
+            print("Successfully synced product items to Meta catalog(Push Menu)")
+        except Exception as e:
+            logger.exception(f"Error syncing product items to Meta catalog for push menu: {str(e)}")
+            raise e
+
+    async def update_meta_catalog(self):
+        """
+        Sync the data to meta when event type is 'push_menu'
+        """
+        try:
+            req = quote(json.dumps(self.processed_data))
+            base_url = f"https://graph.facebook.com/v21.0/{self.catalog_id}/batch"
+            url = f"{base_url}?item_type=PRODUCT_ITEM&requests={req}"
+
+            data = {
+                "access_token": self.access_token,
+            }
+
+            response = await asyncio.to_thread(requests.post, url, headers={}, data=data)
+            response.raise_for_status()
+            print("Response JSON:", response.json())
+            print("Successfully synced product items to Meta catalog(Item Toggle)")
+        except Exception as e:
+            logger.exception(f"Error syncing product items to Meta catalog for item toggle: {str(e)}")
+            raise e
+
+
+    async def delete_meta_catalog(self, delete_payload: list):
+        """
+        Sync the data to meta when event type is 'push_menu'
+        """
+        try:
+            req = quote(json.dumps(delete_payload))
+            base_url = "https://graph.facebook.com/v21.0/1880697869060042/batch"
+            url = f"{base_url}?requests={req}"
+
+            data = {
+                "access_token": self.access_token,
+            }
+            response = await asyncio.to_thread(requests.post, url, headers={}, data=data)
+            response.raise_for_status()
+            print("Response JSON:", response.json())
+            print("Successfully deleted data from meta.")
+        except Exception as e:
+            print(f"Error deleting data from meta: {e}")
+            raise e

--- a/kairon/meta/processor.py
+++ b/kairon/meta/processor.py
@@ -104,7 +104,7 @@ class MetaProcessor:
         """
         try:
             req = quote(json.dumps(delete_payload))
-            base_url = "https://graph.facebook.com/v21.0/1880697869060042/batch"
+            base_url = f"https://graph.facebook.com/v21.0/{self.catalog_id}/batch"
             url = f"{base_url}?requests={req}"
 
             data = {
@@ -115,5 +115,5 @@ class MetaProcessor:
             print("Response JSON:", response.json())
             print("Successfully deleted data from meta.")
         except Exception as e:
-            print(f"Error deleting data from meta: {e}")
+            logger.exception(f"Error deleting data from meta: {str(e)}")
             raise e

--- a/kairon/meta/processor.py
+++ b/kairon/meta/processor.py
@@ -1,12 +1,9 @@
 import asyncio
 import json
 from typing import Text, List
-from urllib.parse import urljoin
 from loguru import logger
 import requests
-from kairon import Utility
 from kairon.shared.catalog_sync.data_objects import CatalogProviderMapping
-from kairon.shared.rest_client import AioRestClient
 from urllib.parse import quote
 
 

--- a/kairon/shared/account/data_objects.py
+++ b/kairon/shared/account/data_objects.py
@@ -155,6 +155,7 @@ class MailTemplates(EmbeddedDocument):
     add_trusted_device = StringField()
     button_template = StringField()
     leave_bot_owner_notification = StringField()
+    catalog_sync_status = StringField()
 
 
 class SystemProperties(Document):

--- a/kairon/shared/account/processor.py
+++ b/kairon/shared/account/processor.py
@@ -959,6 +959,7 @@ class AccountProcessor:
                 ).read(),
                 button_template=open("template/emails/button.html", "r").read(),
                 leave_bot_owner_notification=open("template/emails/leaveBotOwnerNotification.html", "r").read(),
+                catalog_sync_status=open("template/emails/catalog_sync_status.html", "r").read(),
             )
             system_properties = (
                 SystemProperties(mail_templates=mail_templates)
@@ -1013,6 +1014,8 @@ class AccountProcessor:
         ]["button_template"]
         Utility.email_conf["email"]["templates"]["leave_bot_owner_notification"] = system_properties["mail_templates"][
             "leave_bot_owner_notification"]
+        Utility.email_conf["email"]["templates"]["catalog_sync_status"] = system_properties["mail_templates"][
+            "catalog_sync_status"]
 
     @staticmethod
     async def confirm_email(token: str):

--- a/kairon/shared/catalog_sync/catalog_sync_log_processor.py
+++ b/kairon/shared/catalog_sync/catalog_sync_log_processor.py
@@ -1,0 +1,320 @@
+import json
+from datetime import datetime
+from typing import List
+
+from bson import ObjectId
+from loguru import logger
+from mongoengine import Q, DoesNotExist
+
+from kairon.shared.cognition.data_objects import CognitionSchema, ColumnMetadata, CollectionData
+from kairon.shared.cognition.processor import CognitionDataProcessor
+from kairon.shared.content_importer.data_objects import ContentValidationLogs
+from kairon.shared.data.constant import SYNC_STATUS, SyncType
+from kairon.shared.data.data_models import CognitionSchemaRequest
+from kairon.shared.data.data_objects import BotSettings, BotSyncConfig
+from kairon.shared.data.processor import MongoProcessor
+from kairon.shared.catalog_sync.data_objects import CatalogSyncLogs, CatalogProviderMapping
+from kairon.shared.models import CognitionMetadataType
+
+
+class CatalogSyncLogProcessor:
+    """
+    Log processor for content importer event.
+    """
+
+    @staticmethod
+    def add_log(bot: str, user: str, provider: str = None, sync_type: str = None, validation_errors: dict = None,
+                raw_payload: dict = None, processed_payload: dict = None, exception: str = None, status: str = None,
+                sync_status: str = SYNC_STATUS.INITIATED.value):
+        """
+        Adds or updates log for content importer event.
+        @param bot: bot id.
+        @param user: kairon username.
+        @param provider: provider (e.g. Petpooja, Shopify etc.)
+        @param sync_type: sync type
+        @param validation_errors: Dictionary containing any validation errors encountered
+        @param exception: Exception occurred during event.
+        @param status: Validation success or failure.
+        @param sync_status: Event success or failed due to any error during validation or import.
+        @return:
+        """
+        try:
+            doc = CatalogSyncLogs.objects(bot=bot).filter(
+                Q(sync_status__ne=SYNC_STATUS.COMPLETED.value) &
+                Q(sync_status__ne=SYNC_STATUS.FAILED.value)).get()
+        except DoesNotExist:
+            doc = CatalogSyncLogs(
+                bot=bot,
+                user=user,
+                execution_id=str(ObjectId()),
+                provider=provider,
+                raw_payload = raw_payload,
+                sync_type = sync_type,
+                start_timestamp=datetime.utcnow()
+            )
+        doc.sync_status = sync_status
+        if processed_payload:
+            doc.processed_payload = processed_payload
+        if exception:
+            doc.exception = exception
+        if status:
+            doc.status = status
+        if validation_errors:
+            doc.validation_errors = validation_errors
+        if sync_status in {SYNC_STATUS.FAILED.value, SYNC_STATUS.COMPLETED.value}:
+            doc.end_timestamp = datetime.utcnow()
+        doc.save()
+
+    @staticmethod
+    def is_sync_in_progress(bot: str, raise_exception=True):
+        """
+        Checks if event is in progress.
+        @param bot: bot id
+        @param raise_exception: Raise exception if event is in progress.
+        @return: boolean flag.
+        """
+        in_progress = False
+        try:
+            CatalogSyncLogs.objects(bot=bot).filter(
+                Q(sync_status__ne=SYNC_STATUS.COMPLETED.value) &
+                Q(sync_status__ne=SYNC_STATUS.FAILED.value) &
+                Q(sync_status__ne=SYNC_STATUS.ABORTED.value)).get()
+
+            if raise_exception:
+                raise Exception("Sync already in progress! Check logs.")
+            in_progress = True
+        except DoesNotExist as e:
+            logger.error(e)
+        return in_progress
+
+    @staticmethod
+    def is_limit_exceeded(bot: str, raise_exception=True):
+        """
+        Checks if daily event triggering limit exceeded.
+        @param bot: bot id.
+        @param raise_exception: Raise exception if limit is reached.
+        @return: boolean flag
+        """
+        today = datetime.today()
+
+        today_start = today.replace(hour=0, minute=0, second=0)
+        doc_count = CatalogSyncLogs.objects(
+            bot=bot, start_timestamp__gte=today_start
+        ).count()
+        if doc_count >= BotSettings.objects(bot=bot).get().catalog_sync_limit_per_day:
+            if raise_exception:
+                raise Exception("Daily limit exceeded.")
+            else:
+                return True
+        else:
+            return False
+
+    @staticmethod
+    def get_logs(bot: str, start_idx: int = 0, page_size: int = 10):
+        """
+        Get all logs for content importer event.
+        @param bot: bot id.
+        @param start_idx: start index
+        @param page_size: page size
+        @return: list of logs.
+        """
+        for log in CatalogSyncLogs.objects(bot=bot).order_by("-start_timestamp").skip(start_idx).limit(page_size):
+            log = log.to_mongo().to_dict()
+            log.pop('_id')
+            log.pop('bot')
+            log.pop('user')
+            yield log
+
+    @staticmethod
+    def delete_enqueued_event_log(bot: str):
+        """
+        Deletes latest log if it is present in enqueued state.
+        """
+        latest_log = CatalogSyncLogs.objects(bot=bot).order_by('-id').first()
+        if latest_log and latest_log.sync_status == SYNC_STATUS.ENQUEUED.value:
+            latest_log.delete()
+
+    @staticmethod
+    def is_catalog_collection_exists(bot: str) -> bool:
+        """
+        Checks if the 'catalogue_table' exists in CognitionSchema for the given bot.
+        """
+        restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(bot)
+        catalog_name = f"{restaurant_name}_{branch_name}_catalog"
+        return CognitionSchema.objects(bot=bot, collection_name=catalog_name).first() is not None
+
+    @staticmethod
+    def  create_catalog_collection(bot: str, user: str):
+        """
+        Creates a 'catalogue_table' collection in CognitionSchema for the given bot with predefined metadata fields.
+        """
+        # Define column names and their data types
+        cognition_processor = CognitionDataProcessor()
+        column_definitions = [
+            ("id", CognitionMetadataType.str.value),
+            ("title", CognitionMetadataType.str.value),
+            ("description", CognitionMetadataType.str.value),
+            ("price", CognitionMetadataType.float.value),
+            ("facebook_product_category", CognitionMetadataType.str.value),
+            ("availability", CognitionMetadataType.str.value),
+        ]
+
+        bot_settings = BotSettings.objects(bot=bot).first()
+        if bot_settings:
+            bot_settings.cognition_columns_per_collection_limit = 10
+            bot_settings.llm_settings['enable_faq'] = True
+            bot_settings.save()
+
+        metadata= [
+            {
+                "column_name": col,
+                "data_type": data_type,
+                "enable_search": True,
+                "create_embeddings": True
+            }
+            for col, data_type in column_definitions
+        ]
+        restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(bot)
+        catalog_name = f"{restaurant_name}_{branch_name}_catalog"
+        catalog_schema = CognitionSchemaRequest(
+            collection_name=catalog_name,
+            metadata=metadata
+        )
+
+        metadata_id = cognition_processor.save_cognition_schema(
+            catalog_schema.dict(),
+            user, bot)
+
+        return metadata_id
+
+    @staticmethod
+    def validate_item_ids(json_data):
+        """
+        Validates that all items have an 'itemid' and extracts a list of valid category IDs.
+        Raises an exception if any item is missing 'itemid'.
+        Returns a set of valid category IDs.
+        """
+        for item in json_data.get("items", []):
+            if "itemid" not in item:
+                raise Exception(f"Missing 'itemid' in item: {item}")
+
+    @staticmethod
+    def validate_item_toggle_request(json_data: dict) -> None:
+        """
+        Validates that `inStock` exists and is a boolean,
+        and `itemID` exists in the payload.
+        Raises:
+            ValueError: If any validation fails.
+        """
+        body = json_data.get("body", {})
+
+        if "inStock" not in body:
+            raise Exception("Missing required field: 'inStock'")
+        if not isinstance(body["inStock"], bool):
+            raise Exception("'inStock' must be a boolean (true or false)")
+
+        if "itemID" not in body:
+            raise Exception("Missing required field: 'itemID'")
+
+    @staticmethod
+    def validate_item_fields(bot, json_data, provider):
+        """
+        Validates that each item has the required source fields as defined in the metadata file.
+        Ensures 'item_categoryid' is within valid categories.
+        Only runs if event_type is 'push_menu'.
+        """
+        doc = CatalogProviderMapping.objects(provider=provider).first()
+        if not doc:
+            raise Exception(f"Metadata mappings not found and provider={provider}")
+
+        provider_mappings = {
+            "meta": doc.meta_mappings,
+            "kv": doc.kv_mappings
+        }
+
+        valid_category_ids = {cat["categoryid"] for cat in json_data.get("categories", [])}
+
+        required_fields = set()
+        for system_fields in provider_mappings.values():
+            for config in system_fields.values():
+                source_field = config.get("source")
+                if source_field:
+                    required_fields.add(source_field)
+
+        for item in json_data.get("items", []):
+            missing_fields = [field for field in required_fields if field not in item]
+            if missing_fields:
+                raise Exception(f"Missing fields {missing_fields} in item: {item}")
+
+            if "item_categoryid" in item and item["item_categoryid"] not in valid_category_ids:
+                raise Exception(f"Invalid 'item_categoryid' {item['item_categoryid']} in item: {item}")
+
+    @staticmethod
+    def is_sync_type_allowed(bot: str, sync_type: str):
+        config = BotSyncConfig.objects(branch_bot=bot).first()
+        if not config:
+            raise Exception("No bot sync config found for bot")
+
+        if sync_type == SyncType.push_menu and not config.process_push_menu:
+            raise Exception("Push menu processing is disabled for this bot")
+
+        if sync_type == SyncType.item_toggle and not config.process_item_toggle:
+            raise Exception("Item toggle is disabled for this bot")
+
+
+    @staticmethod
+    def is_ai_enabled(bot: str):
+        config = BotSyncConfig.objects(branch_bot=bot).first()
+        if not config:
+            raise Exception("No bot sync config found for bot")
+        return config.ai_enabled
+
+    @staticmethod
+    def is_meta_enabled(bot: str):
+        config = BotSyncConfig.objects(branch_bot=bot).first()
+        if not config:
+            raise Exception("No bot sync config found for bot")
+        return config.meta_enabled
+
+    @staticmethod
+    def validate_image_configurations(bot: str, user: str):
+        restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(bot)
+        catalog_images_collection = f"{restaurant_name}_{branch_name}_catalog_images"
+
+        if not CollectionData.objects(bot=bot, collection_name=catalog_images_collection).first():
+            global_fallback_data = {
+                "image_type": "global",
+                "image_url":"",
+                "image_base64":""
+            }
+            CollectionData(
+                collection_name=catalog_images_collection,
+                data=global_fallback_data,
+                user=user,
+                bot=bot,
+                status=True,
+                timestamp=datetime.utcnow()
+            ).save()
+
+        document = CollectionData.objects(
+            collection_name=catalog_images_collection,
+            bot=bot,
+            data__image_type="global"
+        ).first()
+
+        if not document:
+            raise Exception(
+                f"Global fallback image document not found in `{catalog_images_collection}`")
+
+        if not document.data.get("image_url"):
+            raise Exception(
+                f"Global fallback image URL not found")
+
+    @staticmethod
+    def get_execution_id_for_bot(bot: str):
+        doc = CatalogSyncLogs.objects(bot=bot).filter(
+            Q(sync_status__ne=SYNC_STATUS.COMPLETED.value) &
+            Q(sync_status__ne=SYNC_STATUS.FAILED.value)
+        ).order_by('-start_timestamp').first()
+
+        return doc.execution_id if doc else None

--- a/kairon/shared/catalog_sync/catalog_sync_log_processor.py
+++ b/kairon/shared/catalog_sync/catalog_sync_log_processor.py
@@ -1,18 +1,14 @@
-import json
 from datetime import datetime
-from typing import List
 
 from bson import ObjectId
 from loguru import logger
 from mongoengine import Q, DoesNotExist
 
-from kairon.shared.cognition.data_objects import CognitionSchema, ColumnMetadata, CollectionData
+from kairon.shared.cognition.data_objects import CognitionSchema, CollectionData
 from kairon.shared.cognition.processor import CognitionDataProcessor
-from kairon.shared.content_importer.data_objects import ContentValidationLogs
 from kairon.shared.data.constant import SYNC_STATUS, SyncType
 from kairon.shared.data.data_models import CognitionSchemaRequest
 from kairon.shared.data.data_objects import BotSettings, BotSyncConfig
-from kairon.shared.data.processor import MongoProcessor
 from kairon.shared.catalog_sync.data_objects import CatalogSyncLogs, CatalogProviderMapping
 from kairon.shared.models import CognitionMetadataType
 
@@ -307,8 +303,7 @@ class CatalogSyncLogProcessor:
                 f"Global fallback image document not found in `{catalog_images_collection}`")
 
         if not document.data.get("image_url"):
-            raise Exception(
-                f"Global fallback image URL not found")
+            raise Exception("Global fallback image URL not found")
 
     @staticmethod
     def get_execution_id_for_bot(bot: str):

--- a/kairon/shared/catalog_sync/data_objects.py
+++ b/kairon/shared/catalog_sync/data_objects.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+from mongoengine import StringField, BooleanField, DateTimeField, DynamicDocument, DictField, ListField
+from kairon.shared.data.signals import push_notification, auditlogger
+
+
+@auditlogger.log
+@push_notification.apply
+class CatalogSyncLogs(DynamicDocument):
+    execution_id = StringField(required=True, unique=True)
+    raw_payload = DictField(required=True)
+    processed_payload = DictField(default=None)
+    validation_errors = DictField(default={})
+    exception = StringField(default="")
+    bot = StringField(required=True)
+    user = StringField(required=True)
+    provider = StringField(required=True)
+    sync_type = StringField(required=True)
+    start_timestamp = DateTimeField(default=datetime.utcnow)
+    end_timestamp = DateTimeField(default=None)
+    status = StringField(default=None)
+    sync_status = StringField(default="COMPLETED")
+
+    meta = {"indexes": [{"fields": ["bot", "event_id", ("bot", "event_status", "-start_timestamp")]}]}
+
+
+@auditlogger.log
+@push_notification.apply
+class CatalogProviderMapping(DynamicDocument):
+    """
+    Stores field mappings (meta and kv) for each bot and provider combination.
+    """
+    provider = StringField(required=True)
+    meta_mappings = DictField(default=dict)
+    kv_mappings = DictField(default=dict)

--- a/kairon/shared/catalog_sync/data_objects.py
+++ b/kairon/shared/catalog_sync/data_objects.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from mongoengine import StringField, BooleanField, DateTimeField, DynamicDocument, DictField, ListField
+from mongoengine import StringField, DateTimeField, DynamicDocument, DictField
 from kairon.shared.data.signals import push_notification, auditlogger
 
 

--- a/kairon/shared/cognition/processor.py
+++ b/kairon/shared/cognition/processor.py
@@ -677,33 +677,6 @@ class CognitionDataProcessor:
     #             await self.sync_with_qdrant(llm_processor, qdrant_collection, bot, new_document, user, primary_key_col)
     #
     #     return {"message": "Upsert complete!"}
-
-    async def sync_with_qdrant(self, llm_processor, collection_name, bot, document, user, primary_key_col):
-        """
-        Syncs a document with Qdrant vector database by generating embeddings and upserting them.
-
-        Args:
-            llm_processor (LLMProcessor): Instance of LLMProcessor for embedding and Qdrant operations.
-            collection_name (str): Name of the Qdrant collection.
-            bot (str): Bot identifier.
-            document (CognitionData): Document to sync with Qdrant.
-            user (Text): User performing the operation.
-
-        Raises:
-            AppException: If Qdrant upsert operation fails.
-        """
-        try:
-            metadata = self.find_matching_metadata(bot, document['data'], document.get('collection'))
-            search_payload, embedding_payload = Utility.retrieve_search_payload_and_embedding_payload(
-                document['data'], metadata)
-            embeddings = await llm_processor.get_embedding(embedding_payload, user, invocation='knowledge_vault_sync')
-            points = [{'id': document['vector_id'], 'vector': embeddings, 'payload': search_payload}]
-            await llm_processor.__collection_upsert__(collection_name, {'points': points},
-                                                      err_msg="Unable to train FAQ! Contact support")
-            logger.info(f"Row with {primary_key_col}: {document['data'].get(primary_key_col)} upserted in Qdrant.")
-        except Exception as e:
-            raise AppException(f"Failed to sync document with Qdrant: {str(e)}")
-
     def _validate_sync_type(self, sync_type: str):
         if sync_type not in VaultSyncType.__members__.keys():
             raise AppException("Sync type does not exist")

--- a/kairon/shared/constants.py
+++ b/kairon/shared/constants.py
@@ -83,6 +83,10 @@ class EventClass(str, Enum):
     content_importer = "content_importer"
     mail_channel_read_mails = "email_channel_read_mails"
     agentic_flow = "agentic_flow"
+    catalog_integration = "catalog_integration"
+
+class CatalogSyncClass(str, Enum):
+    petpooja = "petpooja"
 
 
 class EventRequestType(str, Enum):
@@ -119,6 +123,9 @@ class ChannelTypes(str, Enum):
     BUSINESS_MESSAGES = "business_messages"
     LINE = "line"
     MAIL = "mail"
+
+class CatalogProvider(str, Enum):
+    PETPOOJA = "petpooja"
 
 class ElementTypes(str, Enum):
     LINK = "link"

--- a/kairon/shared/data/constant.py
+++ b/kairon/shared/data/constant.py
@@ -111,6 +111,24 @@ class EVENT_STATUS(str, Enum):
     ABORTED = "Aborted"
 
 
+class SYNC_STATUS(str, Enum):
+    INITIATED = "Initiated"
+    VALIDATING_REQUEST = "Validating request"
+    VALIDATING_REQUEST_SUCCESS = "Validating request successful"
+    VALIDATING_FAILED = "Validation Failed"
+    VALIDATING_KNOWLEDGE_VAULT_DATA = "Validating Knowledge vault processed data"
+    PREPROCESSING = "Preprocessing in progress"
+    PREPROCESSING_FAILED = "Preprocessing Failed"
+    PREPROCESSING_COMPLETED = "Preprocessing Completed"
+    SAVE = "Importing data to kairon"
+    SAVE_META = "Importing data to Meta"
+    SYNC_FAILED = "Sync Failed"
+    ENQUEUED = "Enqueued"
+    COMPLETED = "Completed"
+    FAILED = "Failed"
+    ABORTED = "Aborted"
+
+
 class ONBOARDING_STATUS(str, Enum):
     NOT_COMPLETED = "Not Completed"
     SKIPPED = "Skipped"
@@ -185,6 +203,7 @@ class TOKEN_TYPE(str, Enum):
     DYNAMIC = "dynamic"
     CHANNEL = "channel"
     REFRESH = "refresh"
+    DATA_INTEGRATION = "data_integration"
 
 
 class ModelTestType(str, Enum):
@@ -261,6 +280,9 @@ class FeatureMappings(str, Enum):
     ONLY_SSO_LOGIN = "only_sso_login"
     CREATE_USER = "create_user"
 
+class SyncType(str, Enum):
+    push_menu = "push_menu"
+    item_toggle = "item_toggle"
 
 ORG_SETTINGS_MESSAGES = {
     "create_user": "User creation is blocked by your OrgAdmin from SSO",

--- a/kairon/shared/data/data_models.py
+++ b/kairon/shared/data/data_models.py
@@ -1390,3 +1390,12 @@ class FlowTagChangeRequest(BaseModel):
     name: constr(to_lower=True, strip_whitespace=True)
     tag: str
     type: str
+
+class MetaConfig(BaseModel):
+    access_token: str
+    catalog_id: str
+
+class POSIntegrationRequest(BaseModel):
+    provider: str
+    config: dict
+    meta_config: Optional[MetaConfig]

--- a/kairon/shared/data/data_objects.py
+++ b/kairon/shared/data/data_objects.py
@@ -930,6 +930,7 @@ class BotSettings(Auditlog):
     cognition_columns_per_collection_limit = IntField(default=5)
     integrations_per_user_limit = IntField(default=3)
     live_agent_enabled = BooleanField(default=False)
+    catalog_sync_limit_per_day = IntField(default=5)
 
     meta = {"indexes": [{"fields": ["bot", ("bot", "status")]}]}
 
@@ -1086,3 +1087,33 @@ class UserMediaData(Auditlog):
 
 
     meta = {"indexes": [{"fields": ["bot", ("bot", "sender_id"), "media_id"]}]}
+
+
+@auditlogger.log
+@push_notification.apply
+class POSIntegrations(Auditlog):
+    bot = StringField(required=True)
+    provider = StringField(required=True)
+    config = DictField(required=True)
+    sync_type = StringField(required=True, default=None)
+    user = StringField(required=True)
+    timestamp = DateTimeField(default=datetime.utcnow)
+    meta_config = DictField()
+
+    meta = {"indexes": [{"fields": ["bot", "provider"]}]}
+
+
+@auditlogger.log
+@push_notification.apply
+class BotSyncConfig(Auditlog):
+    process_push_menu = BooleanField(default=False)
+    process_item_toggle = BooleanField(default=False)
+    parent_bot = StringField(required=True)
+    restaurant_name = StringField(required=True)
+    provider = StringField(required=True)
+    branch_name = StringField(required=True)
+    branch_bot = StringField(required=True)
+    ai_enabled = BooleanField(default=False)
+    meta_enabled = BooleanField(default=False)
+    user = StringField(required=True)
+    timestamp = DateTimeField(default=datetime.utcnow)

--- a/kairon/shared/data/utils.py
+++ b/kairon/shared/data/utils.py
@@ -398,6 +398,23 @@ class DataUtility:
         return channel_endpoint
 
     @staticmethod
+    def get_integration_endpoint(integration_config: dict):
+        from kairon.shared.auth import Authentication
+
+        token, _ = Authentication.generate_integration_token(
+            integration_config['bot'], integration_config['user'], role=ACCESS_ROLES.DESIGNER.value,
+            access_limit=[
+                f"/api/bot/integration/{integration_config['provider']}/{integration_config['sync_type']}/{integration_config['bot']}/.+"],
+            token_type=TOKEN_TYPE.DATA_INTEGRATION.value
+        )
+
+        integration_endpoint = urljoin(
+            Utility.environment['model']['agent']['url'],
+            f"/api/bot/integration/{integration_config['provider']}/{integration_config['sync_type']}/{integration_config['bot']}/{token}"
+        )
+        return integration_endpoint
+
+    @staticmethod
     def save_channel_metadata(**kwargs):
         token = kwargs["token"]
         channel_config = kwargs.get("config")

--- a/kairon/shared/llm/processor.py
+++ b/kairon/shared/llm/processor.py
@@ -330,6 +330,23 @@ class LLMProcessor(LLMBase):
             timeout=5)
         return response
 
+    async def __delete_collection_points__(self, collection_name: Text, point_ids: List, err_msg: Text,
+                                           raise_err=True):
+        client = AioRestClient()
+        response = await client.request(http_url=urljoin(self.db_url, f"/collections/{collection_name}/points/delete"),
+                                        request_method="POST",
+                                        headers=self.headers,
+                                        request_body={"points": point_ids},
+                                        return_json=True,
+                                        timeout=5)
+        print(response)
+
+        if not response.get('result'):
+            if "status" in response:
+                logging.exception(response['status'].get('error'))
+                if raise_err:
+                    raise AppException(err_msg)
+
     async def __collection_hybrid_query__(self, collection_name: Text, embeddings: Dict, limit: int, score_threshold: float):
         client = AioRestClient()
         request_body = {

--- a/kairon/shared/models.py
+++ b/kairon/shared/models.py
@@ -117,9 +117,9 @@ class CognitionMetadataType(str, Enum):
     int = "int"
     float = "float"
 
-class VaultSyncEventType(str, Enum):
+class VaultSyncType(str, Enum):
     push_menu = ["column_length_mismatch", "invalid_columns", "pydantic_validation"]
-    field_update = ["invalid_columns", "document_non_existence", "pydantic_validation"]
+    item_toggle = ["invalid_columns", "document_non_existence", "pydantic_validation"]
 
 class GlobalSlotsEntryType(str, Enum):
     agentic_flow = "agentic_flow"

--- a/kairon/shared/utils.py
+++ b/kairon/shared/utils.py
@@ -2529,6 +2529,7 @@ class MailUtility:
             "add_trusted_device": MailUtility.__handle_add_trusted_device,
             "book_a_demo": MailUtility.__handle_book_a_demo,
             "member_left_bot": MailUtility.__handle_member_left_bot,
+            "catalog_sync_status": MailUtility.__handle_catalog_sync_status
         }
         base_url = kwargs.get("base_url")
         if not base_url:
@@ -2663,6 +2664,22 @@ class MailUtility:
         body = Utility.email_conf["email"]["templates"]["verification_confirmation"]
         body = body.replace("FIRST_NAME", first_name.capitalize())
         subject = Utility.email_conf["email"]["templates"]["confirmed_subject"]
+        return body, subject
+
+    @staticmethod
+    def __handle_catalog_sync_status(**kwargs):
+        bot = kwargs.get("bot")
+        executionID = kwargs.get("executionID")
+        sync_status = kwargs.get("sync_status")
+        message = kwargs.get("message")
+
+        body = Utility.email_conf["email"]["templates"]["catalog_sync_status"]
+
+        body = body.replace("BOT_ID", bot)
+        body = body.replace("EXECUTION_ID", executionID)
+        body = body.replace("SYNC_STATUS", sync_status)
+        body = body.replace("MESSAGE", message)
+        subject = Utility.email_conf["email"]["templates"]["catalog_sync_status_subject"]
         return body, subject
 
     @staticmethod

--- a/metadata/catalog_provider_mappings.json
+++ b/metadata/catalog_provider_mappings.json
@@ -27,7 +27,7 @@
       },
       "brand": {
         "source": null,
-        "default": "Sattva"
+        "default": "Test Restaurant"
       },
       "condition": {
         "source": null,

--- a/metadata/catalog_provider_mappings.json
+++ b/metadata/catalog_provider_mappings.json
@@ -1,0 +1,60 @@
+{
+  "petpooja": {
+    "meta": {
+      "name": {
+        "source": "itemname",
+        "default": "No title"
+      },
+      "description": {
+        "source": "itemdescription",
+        "default": "No description available"
+      },
+      "price": {
+        "source": "price",
+        "default": 0.0
+      },
+      "availability": {
+        "source": "in_stock",
+        "default": "out of stock"
+      },
+      "image_url": {
+        "source": "item_image_url",
+        "default": "https://www.kairon.com/default-image.jpg"
+      },
+      "url": {
+        "source": null,
+        "default": "https://www.kairon.com/"
+      },
+      "brand": {
+        "source": null,
+        "default": "Sattva"
+      },
+      "condition": {
+        "source": null,
+        "default": "new"
+      }
+    },
+    "kv": {
+      "title": {
+        "source": "itemname",
+        "default": "No title"
+      },
+      "description": {
+        "source": "itemdescription",
+        "default": "No description available"
+      },
+      "price": {
+        "source": "price",
+        "default": 0.0
+      },
+      "facebook_product_category": {
+        "source": "item_categoryid",
+        "default": "Food and drink > General"
+      },
+      "availability": {
+        "source": "in_stock",
+        "default": "out of stock"
+      }
+    }
+  }
+}

--- a/template/emails/catalog_sync_status.html
+++ b/template/emails/catalog_sync_status.html
@@ -1,0 +1,278 @@
+<!-- REQUIRED PARAMS: Bot ID, Execution ID, Sync Status, Message -->
+<!-- Sub: Catalog Sync Status Update -->
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title></title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <style type="text/css">
+        @media screen {
+            @font-face {
+                font-family: 'Inter';
+                font-style: normal;
+                font-weight: 400;
+                font-display: swap;
+                src: url(https://fonts.gstatic.com/s/inter/v3/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa1ZL7.woff2) format('woff2');
+                unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+                    U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+            }
+
+            @font-face {
+                font-family: 'Inter';
+                font-style: normal;
+                font-weight: 700;
+                font-display: swap;
+                src: url(https://fonts.gstatic.com/s/inter/v3/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa1ZL7.woff2) format('woff2');
+                unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+                    U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+            }
+        }
+
+        /* CLIENT-SPECIFIC STYLES */
+        body,
+        table,
+        td,
+        a {
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+        }
+
+        table,
+        td {
+            mso-table-lspace: 0pt;
+            mso-table-rspace: 0pt;
+        }
+
+        img {
+            -ms-interpolation-mode: bicubic;
+        }
+
+        /* RESET STYLES */
+        img {
+            border: 0;
+            height: auto;
+            line-height: 100%;
+            outline: none;
+            text-decoration: none;
+        }
+
+        table {
+            border-collapse: collapse !important;
+        }
+
+        body {
+            height: 100% !important;
+            margin: 0 !important;
+            padding: 0 !important;
+            width: 100% !important;
+        }
+
+        /* iOS BLUE LINKS */
+        a[x-apple-data-detectors] {
+            color: inherit !important;
+            text-decoration: none !important;
+            font-size: inherit !important;
+            font-family: inherit !important;
+            font-weight: inherit !important;
+            line-height: inherit !important;
+        }
+
+        /* MOBILE STYLES */
+        @media screen and (max-width: 600px) {
+            h1 {
+                font-size: 18px !important;
+                line-height: 18px !important;
+            }
+
+            #mailheadimage {
+                width: 100%;
+            }
+        }
+
+        /* ANDROID CENTER FIX */
+        div[style*='margin: 16px 0;'] {
+            margin: 0 !important;
+        }
+    </style>
+</head>
+
+<body style="background-color: #f5f5f5; margin: 0 !important; padding: 0 !important">
+    <!-- HIDDEN PREHEADER TEXT -->
+    <div style="
+        display: none;
+        font-size: 1px;
+        color: #fefefe;
+        line-height: 1px;
+        font-family: 'Inter', Helvetica, Arial, sans-serif;
+        max-height: 0px;
+        max-width: 0px;
+        opacity: 0;
+        overflow: hidden;
+      ">
+        We're thrilled to have you on kAIron! Get ready to dive into your first bot.
+    </div>
+    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+        <!-- LOGO -->
+        <tr>
+            <td bgcolor="#f5f5f5" align="center" style="padding: 0 10px">
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px">
+                    <tr>
+                        <td style="padding: 36px 0 10px">
+                            <img src="BASE_URL/assets/logo/kAIron.png" alt="Kairon" width="106px" />
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        <!-- MAIN CARD -->
+        <tr>
+            <td bgcolor="#f5f5f5" align="center" style="padding: 0 10px">
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px">
+                    <tr>
+                        <td bgcolor="#ffffff" align="center" style="padding: 0 60px 30px 60px">
+                            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px">
+                                <tr>
+                                    <td align="center" style="padding: 20px 0">
+                                        <img id="mailheadimage"
+                                            src="BASE_URL/assets/emails/email-verification.png"
+                                            alt="Verify Email" width="288" height="180" />
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td align="center" style="font-family: Inter, Arial, sans-serif">
+                                        <h1 style="font-size: 24px; font-weight: 600; margin: 0">
+                                            Catalog Sync Status Update
+                                        </h1>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="
+                        font-family: Inter, Arial, sans-serif;
+                        font-size: 15px;
+                        padding: 16px 0;
+                      ">
+                                        <p>Hi,</p>
+                                        <p>
+                                            Bot ID: <strong style="color: #2F45C5;">BOT_ID</strong><br/>
+                                            Execution ID: <strong style="color: #2F45C5;">EXECUTION_ID</strong><br/><br/>
+                                            Sync Status: <strong style="color: #2F45C5;">SYNC_STATUS</strong><br/><br/>
+                                            Message: <strong style="color: #2F45C5;">MESSAGE</strong><br/><br/>
+                                        </p>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="
+                        font-family: Inter, Arial, sans-serif;
+                        font-size: 15px;
+                        padding: 16px 0;
+                      ">
+                                        <p style="margin-bottom: 0">Thanks,</p>
+                                        <p style="margin-top: 0">The team behind kAIron!​</p>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        <!-- FOOTER -->
+        <tr>
+            <td bgcolor="#f5f5f5" align="center" style="
+            padding: 5px 10px;
+            font-size: 12px;
+            color: #404040;
+            font-family: Inter, Arial, sans-serif;
+          ">
+                This email was sent to
+                <span style="text-decoration: none; color: #2f45c5">USER_EMAIL</span>
+            </td>
+        </tr>
+        <tr>
+            <td bgcolor="#f5f5f5" align="center" style="padding: 0 10px">
+                <table cellpadding="0" cellspacing="0" width="100%">
+                    <tr>
+                        <td align="center" style="padding: 36px 0 10px">
+                            <img src="BASE_URL/assets/emails/nimble-logo.png" alt="Digite"
+                                width="106px" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td align="center">
+                            <table cellpadding="0" cellspacing="0" align="center">
+                                <tr>
+                                    <td align="center">
+                                        <table style="display: inline-block">
+                                            <tr>
+                                                <td style="padding: 5px 10px">
+                                                    <a href="https://www.facebook.com/digite" target="_blank">
+                                                        <img src="BASE_URL/assets/emails/facebook.png"
+                                                            alt="Facebook" width="24" height="24" style="
+                                  display: block;
+                                  width: 20px !important;
+                                  height: 20px !important;
+                                " class="CToWUd" /></a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                        <table style="display: inline-block">
+                                            <tr>
+                                                <td style="padding: 5px 10px">
+                                                    <a href="https://twitter.com/digiteinc" target="_blank">
+                                                        <img src="BASE_URL/assets/emails/twitter.png"
+                                                            alt="Twitter" width="24" height="24" style="
+                                  display: block;
+                                  width: 20px !important;
+                                  height: 20px !important;
+                                " class="CToWUd" /></a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                        <table style="display: inline-block">
+                                            <tr>
+                                                <td style="padding: 5px 10px">
+                                                    <a href="https://linkedin.com/company/digite" target="_blank"><img
+                                                            src="BASE_URL/assets/emails/linkedin.png"
+                                                            alt="LinkedIn" width="24" height="24" style="
+                                  display: block;
+                                  width: 20px !important;
+                                  height: 20px !important;
+                                " class="CToWUd" /></a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                        <table style="display: inline-block">
+                                            <tr>
+                                                <td style="padding: 5px 10px">
+                                                    <a href="https://www.youtube.com/user/digiteswift" target="_blank">
+                                                        <img src="BASE_URL/assets/emails/youtube.png"
+                                                            alt="YouTube" width="24" height="24" style="
+                                  display: block;
+                                  width: 20px !important;
+                                  height: 20px !important;
+                                " class="CToWUd" />
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td align="center"
+                            style="padding: 0 0 50px; font-family: Inter, Arial, sans-serif; font-size: 12px">
+                            <p>Digité, Inc. 21060 Homestead Rd, Suite 220 Cupertino, CA, 95014, US</p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+
+</html>

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -8,7 +8,7 @@ import time
 from datetime import datetime, timedelta
 from io import BytesIO
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 from urllib.parse import urljoin
 from zipfile import ZipFile
 import litellm
@@ -2024,7 +2024,7 @@ def test_knowledge_vault_sync_push_menu(mock_embedding, mock_collection_exists, 
 
     expected_calls = [
         {
-            "model": "text-embedding-3-small",
+            "model": "text-embedding-3-large",
             "input": ['{"id":1,"item":"Juice","price":2.5,"quantity":10}', '{"id":2,"item":"Apples","price":1.2,"quantity":20}'],
             "metadata": {'user': 'integration@demo.ai', 'bot': pytest.bot, 'invocation': 'knowledge_vault_sync'},
             "api_key": "common_openai_key",
@@ -2155,7 +2155,7 @@ def test_knowledge_vault_sync_item_toggle(mock_embedding, mock_collection_exists
 
     expected_calls = [
         {
-            "model": "text-embedding-3-small",
+            "model": "text-embedding-3-large",
             "input": ['{"id":1,"item":"Juice","price":80.5,"quantity":56}', '{"id":2,"item":"Milk","price":27.0,"quantity":12}'],
             "metadata": {'user': 'integration@demo.ai', 'bot': pytest.bot, 'invocation': 'knowledge_vault_sync'},
             "api_key": "common_openai_key",
@@ -3327,14 +3327,16 @@ def test_add_pos_integration_config_invalid_sync_type():
 @mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
 @mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
 @mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
 @mock.patch.object(MetaProcessor, "push_meta_catalog", autospec=True)
 @mock.patch.object(MetaProcessor, "delete_meta_catalog", autospec=True)
 @mock.patch.object(litellm, "aembedding", autospec=True)
 def test_catalog_sync_push_menu_success(mock_embedding, mock_collection_exists, mock_create_collection,
-                                        mock_collection_upsert, mock_delete_meta_catalog, mock_push_meta_catalog):
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_delete_meta_catalog, mock_push_meta_catalog):
     mock_collection_exists.return_value = False
     mock_create_collection.return_value = None
     mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
     mock_push_meta_catalog.return_value = None
     mock_delete_meta_catalog.return_value = None
 
@@ -3491,14 +3493,17 @@ def test_catalog_sync_push_menu_success(mock_embedding, mock_collection_exists, 
 @mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
 @mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
 @mock.patch.object(LLMProcessor, "__delete_collection_points__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
 @mock.patch.object(MetaProcessor, "push_meta_catalog", autospec=True)
 @mock.patch.object(MetaProcessor, "delete_meta_catalog", autospec=True)
 @mock.patch.object(litellm, "aembedding", autospec=True)
 def test_catalog_sync_push_menu_success_with_delete_data(mock_embedding, mock_collection_exists, mock_create_collection,
-                                        mock_collection_upsert, mock_delete_collection_points, mock_delete_meta_catalog, mock_push_meta_catalog):
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_delete_collection_points,
+                                                         mock_delete_meta_catalog, mock_push_meta_catalog):
     mock_collection_exists.return_value = False
     mock_create_collection.return_value = None
     mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
     mock_push_meta_catalog.return_value = None
     mock_delete_meta_catalog.return_value = None
     mock_delete_collection_points.return_value = None
@@ -3618,13 +3623,15 @@ def test_catalog_sync_push_menu_success_with_delete_data(mock_embedding, mock_co
 @mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
 @mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
 @mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
 @mock.patch.object(MetaProcessor, "update_meta_catalog", autospec=True)
 @mock.patch.object(litellm, "aembedding", autospec=True)
 def test_catalog_sync_item_toggle_success(mock_embedding, mock_collection_exists, mock_create_collection,
-                                        mock_collection_upsert, mock_update_meta_catalog):
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_update_meta_catalog):
     mock_collection_exists.return_value = False
     mock_create_collection.return_value = None
     mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
     mock_update_meta_catalog.return_value = None
 
     embedding = list(np.random.random(LLMProcessor.__embedding__))
@@ -3741,7 +3748,8 @@ def test_catalog_sync_item_toggle_success(mock_embedding, mock_collection_exists
 
     CatalogProviderMapping.objects(provider="petpooja").delete()
     BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
-    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="invalid_sync").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="item_toggle").delete()
     LLMSecret.objects.delete()
     CollectionData.objects(collection_name=catalog_data_collection).delete()
     CollectionData.objects(collection_name=catalog_images_collection).delete()
@@ -3754,14 +3762,16 @@ def test_catalog_sync_item_toggle_success(mock_embedding, mock_collection_exists
 @mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
 @mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
 @mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
 @mock.patch.object(MetaProcessor, "push_meta_catalog", autospec=True)
 @mock.patch.object(MetaProcessor, "delete_meta_catalog", autospec=True)
 @mock.patch.object(litellm, "aembedding", autospec=True)
 def test_catalog_sync_push_menu_process_push_menu_disabled(mock_embedding, mock_collection_exists, mock_create_collection,
-                                        mock_collection_upsert, mock_delete_meta_catalog, mock_push_meta_catalog):
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_delete_meta_catalog, mock_push_meta_catalog):
     mock_collection_exists.return_value = False
     mock_create_collection.return_value = None
     mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
     mock_push_meta_catalog.return_value = None
     mock_delete_meta_catalog.return_value = None
 
@@ -3869,7 +3879,7 @@ def test_catalog_sync_push_menu_process_push_menu_disabled(mock_embedding, mock_
 
     CatalogProviderMapping.objects(provider="petpooja").delete()
     BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
-    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="invalid_sync").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").delete()
     LLMSecret.objects.delete()
     CollectionData.objects(collection_name=catalog_data_collection).delete()
     # CollectionData.objects(collection_name=catalog_images_collection).delete()
@@ -3883,13 +3893,15 @@ def test_catalog_sync_push_menu_process_push_menu_disabled(mock_embedding, mock_
 @mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
 @mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
 @mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
 @mock.patch.object(MetaProcessor, "update_meta_catalog", autospec=True)
 @mock.patch.object(litellm, "aembedding", autospec=True)
 def test_catalog_sync_item_toggle_process_item_toggle_disabled(mock_embedding, mock_collection_exists, mock_create_collection,
-                                        mock_collection_upsert, update_meta_catalog):
+                                        mock_collection_upsert, mock_format_and_send_mail, update_meta_catalog):
     mock_collection_exists.return_value = False
     mock_create_collection.return_value = None
     mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
     update_meta_catalog.return_value = None
 
     embedding = list(np.random.random(LLMProcessor.__embedding__))
@@ -3947,7 +3959,7 @@ def test_catalog_sync_item_toggle_process_item_toggle_disabled(mock_embedding, m
     assert bot_sync_config.branch_name == "branch1"
     assert bot_sync_config.parent_bot == pytest.bot
 
-    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").first()
+    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="item_toggle").first()
     assert pos_integration is not None
     assert pos_integration.config["restaurant_id"] == "98765"
     assert pos_integration.meta_config["access_token"] == "dummy_access_token"
@@ -3996,7 +4008,7 @@ def test_catalog_sync_item_toggle_process_item_toggle_disabled(mock_embedding, m
 
     CatalogProviderMapping.objects(provider="petpooja").delete()
     BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
-    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="invalid_sync").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="item_toggle").delete()
     LLMSecret.objects.delete()
     CollectionData.objects(collection_name=catalog_data_collection).delete()
     # CollectionData.objects(collection_name=catalog_images_collection).delete()
@@ -4010,14 +4022,16 @@ def test_catalog_sync_item_toggle_process_item_toggle_disabled(mock_embedding, m
 @mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
 @mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
 @mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
 @mock.patch.object(MetaProcessor, "push_meta_catalog", autospec=True)
 @mock.patch.object(MetaProcessor, "delete_meta_catalog", autospec=True)
 @mock.patch.object(litellm, "aembedding", autospec=True)
 def test_catalog_sync_push_menu_ai_disabled_meta_disabled(mock_embedding, mock_collection_exists, mock_create_collection,
-                                        mock_collection_upsert, mock_delete_meta_catalog, mock_push_meta_catalog):
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_delete_meta_catalog, mock_push_meta_catalog):
     mock_collection_exists.return_value = False
     mock_create_collection.return_value = None
     mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
     mock_push_meta_catalog.return_value = None
     mock_delete_meta_catalog.return_value = None
 
@@ -4148,6 +4162,8 @@ def test_catalog_sync_push_menu_ai_disabled_meta_disabled(mock_embedding, mock_c
         {"id": doc.data["id"], "price": doc.data["price"]}
         for doc in catalog_data_docs
     ]
+    for i in catalog_data_docs:
+        print(i.to_mongo().to_dict())
 
     expected_items = [
         {"id": "10539634", "price": 8700.0},
@@ -4162,10 +4178,161 @@ def test_catalog_sync_push_menu_ai_disabled_meta_disabled(mock_embedding, mock_c
 
     CatalogProviderMapping.objects(provider="petpooja").delete()
     BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
-    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="invalid_sync").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").delete()
+    LLMSecret.objects.delete()
+    # CollectionData.objects(collection_name=catalog_data_collection).delete()
+    CollectionData.objects(collection_name=catalog_images_collection).delete()
+    CatalogSyncLogs.objects.delete()
+    CognitionData.objects(bot=pytest.bot).delete()
+    CognitionSchema.objects(bot=pytest.bot).delete()
+
+
+
+@pytest.mark.asyncio
+@responses.activate
+@mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
+@mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
+@mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
+@mock.patch.object(MetaProcessor, "update_meta_catalog", autospec=True)
+@mock.patch.object(litellm, "aembedding", autospec=True)
+def test_catalog_sync_item_toggle_ai_disabled_meta_disabled(mock_embedding, mock_collection_exists, mock_create_collection,
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_update_meta_catalog):
+    mock_collection_exists.return_value = False
+    mock_create_collection.return_value = None
+    mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
+    mock_update_meta_catalog.return_value = None
+
+    embedding = list(np.random.random(LLMProcessor.__embedding__))
+    mock_embedding.return_value = litellm.EmbeddingResponse(
+        **{'data': [{'embedding': embedding}, {'embedding': embedding}, {'embedding': embedding}]})
+
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        },
+    ]
+
+    for secret in secrets:
+        LLMSecret(**secret).save()
+
+    payload = {
+      "provider": "petpooja",
+      "config": {
+        "restaurant_name": "restaurant1",
+        "branch_name": "branch1",
+        "restaurant_id": "98765"
+       },
+       "meta_config": {
+        "access_token":"dummy_access_token",
+        "catalog_id":"12345"
+       }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=item_toggle",
+        json = payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "POS Integration Complete"
+    assert actual["error_code"] == 0
+    assert actual["success"]
+    assert "integration/petpooja/item_toggle" in actual["data"]
+    assert str(pytest.bot) in actual["data"]
+    sync_url = actual["data"]
+    token = sync_url.split(str(pytest.bot) + "/")[1]
+
+    provider_mapping = CatalogProviderMapping.objects(provider="petpooja").first()
+    assert provider_mapping is not None
+    assert provider_mapping.meta_mappings is not None
+    assert provider_mapping.kv_mappings is not None
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    assert bot_sync_config is not None
+    assert bot_sync_config.restaurant_name == "restaurant1"
+    assert bot_sync_config.branch_name == "branch1"
+    assert bot_sync_config.parent_bot == pytest.bot
+
+    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="item_toggle").first()
+    assert pos_integration is not None
+    assert pos_integration.config["restaurant_id"] == "98765"
+    assert pos_integration.meta_config["access_token"] == "dummy_access_token"
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    bot_sync_config.process_item_toggle = True
+    bot_sync_config.save()
+
+    event_url = urljoin(
+        Utility.environment["events"]["server_url"],
+        f"/api/events/execute/{EventClass.catalog_integration}",
+    )
+    responses.add(
+        "POST",
+        event_url,
+        json={"success": True, "message": "Event triggered successfully!"},
+    )
+
+    item_toggle_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload.json")
+
+    with item_toggle_payload_path.open("r", encoding="utf-8") as f:
+        item_toggle_payload = json.load(f)
+
+    response = client.post(
+        url=sync_url,
+        json=item_toggle_payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "Sync in progress! Check logs."
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["success"]
+
+    complete_end_to_end_event_execution(
+        pytest.bot, "integration@demo.ai", EventClass.catalog_integration, sync_type="item_toggle", token=token,
+        provider="petpooja", data=item_toggle_payload
+    )
+
+    latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
+    print(latest_log.to_mongo().to_dict())
+    assert latest_log is not None
+    assert latest_log.execution_id
+    assert latest_log.sync_status == "Completed"
+    assert latest_log.status == "Success"
+    assert hasattr(latest_log, "exception")
+    assert latest_log.exception == "Sync to knowledge vault and Meta is not allowed for this bot. Contact Support!!"
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_data_collection = f"{restaurant_name}_{branch_name}_catalog_data"
+    catalog_data_docs = CollectionData.objects(collection_name=catalog_data_collection, bot=pytest.bot)
+    catalog_item_summaries = [
+        {"id": doc.data["id"], "availability": doc.data["availability"]}
+        for doc in catalog_data_docs
+    ]
+
+    expected_items = [
+        {"id": "10539634", "availability": "in stock"},
+        {"id": "10539699", "availability": "in stock"},
+        {"id": "10539580", "availability": "out of stock"},
+    ]
+
+    assert all(item in catalog_item_summaries for item in expected_items)
+
+    cognition_data_docs = CognitionData.objects(bot=str(pytest.bot))
+    assert cognition_data_docs.count() == 0
+
+    CatalogProviderMapping.objects(provider="petpooja").delete()
+    BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="item_toggle").delete()
     LLMSecret.objects.delete()
     CollectionData.objects(collection_name=catalog_data_collection).delete()
-    CollectionData.objects(collection_name=catalog_images_collection).delete()
+    # CollectionData.objects(collection_name=catalog_images_collection).delete()
     CatalogSyncLogs.objects.delete()
     CognitionData.objects(bot=pytest.bot).delete()
     CognitionSchema.objects(bot=pytest.bot).delete()
@@ -4176,14 +4343,16 @@ def test_catalog_sync_push_menu_ai_disabled_meta_disabled(mock_embedding, mock_c
 @mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
 @mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
 @mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
 @mock.patch.object(MetaProcessor, "push_meta_catalog", autospec=True)
 @mock.patch.object(MetaProcessor, "delete_meta_catalog", autospec=True)
 @mock.patch.object(litellm, "aembedding", autospec=True)
 def test_catalog_sync_push_menu_ai_enabled_meta_disabled(mock_embedding, mock_collection_exists, mock_create_collection,
-                                        mock_collection_upsert, mock_delete_meta_catalog, mock_push_meta_catalog):
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_delete_meta_catalog, mock_push_meta_catalog):
     mock_collection_exists.return_value = False
     mock_create_collection.return_value = None
     mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
     mock_push_meta_catalog.return_value = None
     mock_delete_meta_catalog.return_value = None
 
@@ -4335,13 +4504,170 @@ def test_catalog_sync_push_menu_ai_enabled_meta_disabled(mock_embedding, mock_co
 
     CatalogProviderMapping.objects(provider="petpooja").delete()
     BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
-    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="invalid_sync").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").delete()
+    LLMSecret.objects.delete()
+    # CollectionData.objects(collection_name=catalog_data_collection).delete()
+    CollectionData.objects(collection_name=catalog_images_collection).delete()
+    CatalogSyncLogs.objects.delete()
+    # CognitionData.objects(bot=pytest.bot).delete()
+    # CognitionSchema.objects(bot=pytest.bot).delete()
+
+@pytest.mark.asyncio
+@responses.activate
+@mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
+@mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
+@mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
+@mock.patch.object(MetaProcessor, "update_meta_catalog", autospec=True)
+@mock.patch.object(litellm, "aembedding", autospec=True)
+def test_catalog_sync_item_toggle_ai_enabled_meta_disabled(mock_embedding, mock_collection_exists, mock_create_collection,
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_update_meta_catalog):
+    mock_collection_exists.return_value = False
+    mock_create_collection.return_value = None
+    mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
+    mock_update_meta_catalog.return_value = None
+
+    embedding = list(np.random.random(LLMProcessor.__embedding__))
+    mock_embedding.return_value = litellm.EmbeddingResponse(
+        **{'data': [{'embedding': embedding}, {'embedding': embedding}, {'embedding': embedding}]})
+
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        },
+    ]
+
+    for secret in secrets:
+        LLMSecret(**secret).save()
+
+    payload = {
+      "provider": "petpooja",
+      "config": {
+        "restaurant_name": "restaurant1",
+        "branch_name": "branch1",
+        "restaurant_id": "98765"
+       },
+       "meta_config": {
+        "access_token":"dummy_access_token",
+        "catalog_id":"12345"
+       }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=item_toggle",
+        json = payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "POS Integration Complete"
+    assert actual["error_code"] == 0
+    assert actual["success"]
+    assert "integration/petpooja/item_toggle" in actual["data"]
+    assert str(pytest.bot) in actual["data"]
+    sync_url = actual["data"]
+    token = sync_url.split(str(pytest.bot) + "/")[1]
+
+    provider_mapping = CatalogProviderMapping.objects(provider="petpooja").first()
+    assert provider_mapping is not None
+    assert provider_mapping.meta_mappings is not None
+    assert provider_mapping.kv_mappings is not None
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    assert bot_sync_config is not None
+    assert bot_sync_config.restaurant_name == "restaurant1"
+    assert bot_sync_config.branch_name == "branch1"
+    assert bot_sync_config.parent_bot == pytest.bot
+
+    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="item_toggle").first()
+    assert pos_integration is not None
+    assert pos_integration.config["restaurant_id"] == "98765"
+    assert pos_integration.meta_config["access_token"] == "dummy_access_token"
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    bot_sync_config.process_item_toggle = True
+    bot_sync_config.ai_enabled = True
+    bot_sync_config.save()
+
+    event_url = urljoin(
+        Utility.environment["events"]["server_url"],
+        f"/api/events/execute/{EventClass.catalog_integration}",
+    )
+    responses.add(
+        "POST",
+        event_url,
+        json={"success": True, "message": "Event triggered successfully!"},
+    )
+
+    item_toggle_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload.json")
+
+    with item_toggle_payload_path.open("r", encoding="utf-8") as f:
+        item_toggle_payload = json.load(f)
+
+    response = client.post(
+        url=sync_url,
+        json=item_toggle_payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "Sync in progress! Check logs."
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["success"]
+
+    complete_end_to_end_event_execution(
+        pytest.bot, "integration@demo.ai", EventClass.catalog_integration, sync_type="item_toggle", token=token,
+        provider="petpooja", data=item_toggle_payload
+    )
+
+    latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
+    print(latest_log.to_mongo().to_dict())
+    assert latest_log is not None
+    assert latest_log.execution_id
+    assert latest_log.sync_status == "Completed"
+    assert latest_log.status == "Success"
+    assert hasattr(latest_log, "exception")
+    assert latest_log.exception == "Sync to Meta is not allowed for this bot. Contact Support!!"
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_data_collection = f"{restaurant_name}_{branch_name}_catalog_data"
+    catalog_data_docs = CollectionData.objects(collection_name=catalog_data_collection, bot=pytest.bot)
+    catalog_item_summaries = [
+        {"id": doc.data["id"], "availability": doc.data["availability"]}
+        for doc in catalog_data_docs
+    ]
+
+    expected_items = [
+        {"id": "10539634", "availability": "in stock"},
+        {"id": "10539699", "availability": "in stock"},
+        {"id": "10539580", "availability": "out of stock"},
+    ]
+
+    assert all(item in catalog_item_summaries for item in expected_items)
+
+    cognition_data_docs = CognitionData.objects(bot=str(pytest.bot))
+    assert cognition_data_docs.count() == 3
+
+    cognition_map = {doc.data["id"]: doc.data["availability"] for doc in cognition_data_docs if
+                     "id" in doc.data and "availability" in doc.data}
+    for item in expected_items:
+        assert item["id"] in cognition_map
+        assert cognition_map[item["id"]] == item["availability"]
+
+    CatalogProviderMapping.objects(provider="petpooja").delete()
+    BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="item_toggle").delete()
     LLMSecret.objects.delete()
     CollectionData.objects(collection_name=catalog_data_collection).delete()
-    CollectionData.objects(collection_name=catalog_images_collection).delete()
+    # CollectionData.objects(collection_name=catalog_images_collection).delete()
     CatalogSyncLogs.objects.delete()
     CognitionData.objects(bot=pytest.bot).delete()
     CognitionSchema.objects(bot=pytest.bot).delete()
+
 
 
 @pytest.mark.asyncio
@@ -4349,14 +4675,16 @@ def test_catalog_sync_push_menu_ai_enabled_meta_disabled(mock_embedding, mock_co
 @mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
 @mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
 @mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
 @mock.patch.object(MetaProcessor, "push_meta_catalog", autospec=True)
 @mock.patch.object(MetaProcessor, "delete_meta_catalog", autospec=True)
 @mock.patch.object(litellm, "aembedding", autospec=True)
 def test_catalog_sync_push_menu_ai_disabled_meta_enabled(mock_embedding, mock_collection_exists, mock_create_collection,
-                                        mock_collection_upsert, mock_delete_meta_catalog, mock_push_meta_catalog):
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_delete_meta_catalog, mock_push_meta_catalog):
     mock_collection_exists.return_value = False
     mock_create_collection.return_value = None
     mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
     mock_push_meta_catalog.return_value = None
     mock_delete_meta_catalog.return_value = None
 
@@ -4502,13 +4830,13 @@ def test_catalog_sync_push_menu_ai_disabled_meta_enabled(mock_embedding, mock_co
 
     CatalogProviderMapping.objects(provider="petpooja").delete()
     BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
-    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="invalid_sync").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").delete()
     LLMSecret.objects.delete()
-    CollectionData.objects(collection_name=catalog_data_collection).delete()
+    # CollectionData.objects(collection_name=catalog_data_collection).delete()
     CollectionData.objects(collection_name=catalog_images_collection).delete()
     CatalogSyncLogs.objects.delete()
-    CognitionData.objects(bot=pytest.bot).delete()
-    CognitionSchema.objects(bot=pytest.bot).delete()
+    # CognitionData.objects(bot=pytest.bot).delete()
+    # CognitionSchema.objects(bot=pytest.bot).delete()
 
 
 @pytest.mark.asyncio
@@ -4516,14 +4844,166 @@ def test_catalog_sync_push_menu_ai_disabled_meta_enabled(mock_embedding, mock_co
 @mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
 @mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
 @mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
+@mock.patch.object(MetaProcessor, "update_meta_catalog", autospec=True)
+@mock.patch.object(litellm, "aembedding", autospec=True)
+def test_catalog_sync_item_toggle_ai_disabled_meta_enabled(mock_embedding, mock_collection_exists, mock_create_collection,
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_update_meta_catalog):
+    mock_collection_exists.return_value = False
+    mock_create_collection.return_value = None
+    mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
+    mock_update_meta_catalog.return_value = None
+
+    embedding = list(np.random.random(LLMProcessor.__embedding__))
+    mock_embedding.return_value = litellm.EmbeddingResponse(
+        **{'data': [{'embedding': embedding}, {'embedding': embedding}, {'embedding': embedding}]})
+
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        },
+    ]
+
+    for secret in secrets:
+        LLMSecret(**secret).save()
+
+    payload = {
+      "provider": "petpooja",
+      "config": {
+        "restaurant_name": "restaurant1",
+        "branch_name": "branch1",
+        "restaurant_id": "98765"
+       },
+       "meta_config": {
+        "access_token":"dummy_access_token",
+        "catalog_id":"12345"
+       }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=item_toggle",
+        json = payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "POS Integration Complete"
+    assert actual["error_code"] == 0
+    assert actual["success"]
+    assert "integration/petpooja/item_toggle" in actual["data"]
+    assert str(pytest.bot) in actual["data"]
+    sync_url = actual["data"]
+    token = sync_url.split(str(pytest.bot) + "/")[1]
+
+    provider_mapping = CatalogProviderMapping.objects(provider="petpooja").first()
+    assert provider_mapping is not None
+    assert provider_mapping.meta_mappings is not None
+    assert provider_mapping.kv_mappings is not None
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    assert bot_sync_config is not None
+    assert bot_sync_config.restaurant_name == "restaurant1"
+    assert bot_sync_config.branch_name == "branch1"
+    assert bot_sync_config.parent_bot == pytest.bot
+
+    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="item_toggle").first()
+    assert pos_integration is not None
+    assert pos_integration.config["restaurant_id"] == "98765"
+    assert pos_integration.meta_config["access_token"] == "dummy_access_token"
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    bot_sync_config.process_item_toggle = True
+    bot_sync_config.meta_enabled = True
+    bot_sync_config.save()
+
+    event_url = urljoin(
+        Utility.environment["events"]["server_url"],
+        f"/api/events/execute/{EventClass.catalog_integration}",
+    )
+    responses.add(
+        "POST",
+        event_url,
+        json={"success": True, "message": "Event triggered successfully!"},
+    )
+
+    item_toggle_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload.json")
+
+    with item_toggle_payload_path.open("r", encoding="utf-8") as f:
+        item_toggle_payload = json.load(f)
+
+    response = client.post(
+        url=sync_url,
+        json=item_toggle_payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "Sync in progress! Check logs."
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["success"]
+
+    complete_end_to_end_event_execution(
+        pytest.bot, "integration@demo.ai", EventClass.catalog_integration, sync_type="item_toggle", token=token,
+        provider="petpooja", data=item_toggle_payload
+    )
+
+    latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
+    print(latest_log.to_mongo().to_dict())
+    assert latest_log is not None
+    assert latest_log.execution_id
+    assert latest_log.sync_status == "Completed"
+    assert latest_log.status == "Success"
+    assert hasattr(latest_log, "exception")
+    assert latest_log.exception == "Sync to knowledge vault is not allowed for this bot. Contact Support!!"
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_data_collection = f"{restaurant_name}_{branch_name}_catalog_data"
+    catalog_data_docs = CollectionData.objects(collection_name=catalog_data_collection, bot=pytest.bot)
+    catalog_item_summaries = [
+        {"id": doc.data["id"], "availability": doc.data["availability"]}
+        for doc in catalog_data_docs
+    ]
+
+    expected_items = [
+        {"id": "10539634", "availability": "in stock"},
+        {"id": "10539699", "availability": "in stock"},
+        {"id": "10539580", "availability": "out of stock"},
+    ]
+
+    assert all(item in catalog_item_summaries for item in expected_items)
+
+    cognition_data_docs = CognitionData.objects(bot=str(pytest.bot))
+    assert cognition_data_docs.count() == 0
+
+    CatalogProviderMapping.objects(provider="petpooja").delete()
+    BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="item_toggle").delete()
+    LLMSecret.objects.delete()
+    CollectionData.objects(collection_name=catalog_data_collection).delete()
+    # CollectionData.objects(collection_name=catalog_images_collection).delete()
+    CatalogSyncLogs.objects.delete()
+    CognitionData.objects(bot=pytest.bot).delete()
+    CognitionSchema.objects(bot=pytest.bot).delete()
+
+@pytest.mark.asyncio
+@responses.activate
+@mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
+@mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
+@mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
 @mock.patch.object(MetaProcessor, "push_meta_catalog", autospec=True)
 @mock.patch.object(MetaProcessor, "delete_meta_catalog", autospec=True)
 @mock.patch.object(litellm, "aembedding", autospec=True)
 def test_catalog_sync_push_menu_global_image_not_found(mock_embedding, mock_collection_exists, mock_create_collection,
-                                        mock_collection_upsert, mock_delete_meta_catalog, mock_push_meta_catalog):
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_delete_meta_catalog, mock_push_meta_catalog):
     mock_collection_exists.return_value = False
     mock_create_collection.return_value = None
     mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
     mock_push_meta_catalog.return_value = None
     mock_delete_meta_catalog.return_value = None
 
@@ -4652,14 +5132,16 @@ def test_catalog_sync_push_menu_global_image_not_found(mock_embedding, mock_coll
 @mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
 @mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
 @mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
 @mock.patch.object(MetaProcessor, "push_meta_catalog", autospec=True)
 @mock.patch.object(MetaProcessor, "delete_meta_catalog", autospec=True)
 @mock.patch.object(litellm, "aembedding", autospec=True)
 def test_catalog_sync_push_menu_global_local_images_success(mock_embedding, mock_collection_exists, mock_create_collection,
-                                        mock_collection_upsert, mock_delete_meta_catalog, mock_push_meta_catalog):
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_delete_meta_catalog, mock_push_meta_catalog):
     mock_collection_exists.return_value = False
     mock_create_collection.return_value = None
     mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
     mock_push_meta_catalog.return_value = None
     mock_delete_meta_catalog.return_value = None
 
@@ -4850,14 +5332,16 @@ def test_catalog_sync_push_menu_global_local_images_success(mock_embedding, mock
 @mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
 @mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
 @mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
 @mock.patch.object(MetaProcessor, "push_meta_catalog", autospec=True)
 @mock.patch.object(MetaProcessor, "delete_meta_catalog", autospec=True)
 @mock.patch.object(litellm, "aembedding", autospec=True)
 def test_catalog_rerun_sync_push_menu_success(mock_embedding, mock_collection_exists, mock_create_collection,
-                                        mock_collection_upsert, mock_delete_meta_catalog, mock_push_meta_catalog):
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_delete_meta_catalog, mock_push_meta_catalog):
     mock_collection_exists.return_value = False
     mock_create_collection.return_value = None
     mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
     mock_push_meta_catalog.return_value = None
     mock_delete_meta_catalog.return_value = None
 
@@ -27952,7 +28436,6 @@ def test_get_bot_settings():
     assert actual["message"] is None
     actual["data"].pop("bot")
     actual["data"].pop("user")
-    actual["data"].pop("timestamp")
     actual["data"].pop("status")
     assert actual['data'] == {'is_billed': False, 'chat_token_expiry': 30,
                               'data_generation_limit_per_day': 3,
@@ -27974,7 +28457,8 @@ def test_get_bot_settings():
                               'cognition_columns_per_collection_limit': 5,
                               'content_importer_limit_per_day': 5,
                               'integrations_per_user_limit': 3,
-                              'retry_broadcasting_limit': 3}
+                              'retry_broadcasting_limit': 3,
+                              'catalog_sync_limit_per_day': 5}
 
 
 @patch("kairon.shared.utils.Utility.request_event_server", autospec=True)
@@ -28081,7 +28565,8 @@ def test_update_analytics_settings():
                               'content_importer_limit_per_day': 5,
                               'cognition_columns_per_collection_limit': 5,
                               'integrations_per_user_limit': 3,
-                              'retry_broadcasting_limit': 3}
+                              'retry_broadcasting_limit': 3,
+                              'catalog_sync_limit_per_day': 5}
 
 
 def test_delete_channels_config():

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -8734,6 +8734,9 @@ def test_metadata_upload_api(monkeypatch):
 
 
 def test_metadata_upload_api_column_limit_exceeded():
+    bot_settings = BotSettings.objects(bot=pytest.bot).get()
+    bot_settings.cognition_columns_per_collection_limit = 5
+    bot_settings.save()
     response = client.post(
         url=f"/api/bot/{pytest.bot}/data/cognition/schema",
         json={
@@ -28436,6 +28439,7 @@ def test_get_bot_settings():
     assert actual["message"] is None
     actual["data"].pop("bot")
     actual["data"].pop("user")
+    actual["data"].pop("timestamp")
     actual["data"].pop("status")
     assert actual['data'] == {'is_billed': False, 'chat_token_expiry': 30,
                               'data_generation_limit_per_day': 3,

--- a/tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload.json
+++ b/tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload.json
@@ -1,0 +1,14 @@
+{
+    "type": "POST",
+    "body": {
+        "restID": "njrbv7mu",
+        "inStock": false,
+        "itemID": [
+            "10539580"
+        ],
+        "type": "item",
+        "autoTurnOnTime": "custom",
+        "customTurnOnTime": "2025-03-26 12:45:00"
+    },
+    "params": {}
+}

--- a/tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload_invalid_missing_instock.json
+++ b/tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload_invalid_missing_instock.json
@@ -1,0 +1,13 @@
+{
+    "type": "POST",
+    "body": {
+        "restID": "njrbv7mu",
+        "itemID": [
+            "10539580"
+        ],
+        "type": "item",
+        "autoTurnOnTime": "custom",
+        "customTurnOnTime": "2025-03-26 12:45:00"
+    },
+    "params": {}
+}

--- a/tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload_invalid_missing_itemid.json
+++ b/tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload_invalid_missing_itemid.json
@@ -1,0 +1,11 @@
+{
+    "type": "POST",
+    "body": {
+        "restID": "njrbv7mu",
+        "inStock": false,
+        "type": "item",
+        "autoTurnOnTime": "custom",
+        "customTurnOnTime": "2025-03-26 12:45:00"
+    },
+    "params": {}
+}

--- a/tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload_invalid_nonboolean_instock.json
+++ b/tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload_invalid_nonboolean_instock.json
@@ -1,0 +1,14 @@
+{
+    "type": "POST",
+    "body": {
+        "restID": "njrbv7mu",
+        "inStock": "invalid",
+        "itemID": [
+            "10539580"
+        ],
+        "type": "item",
+        "autoTurnOnTime": "custom",
+        "customTurnOnTime": "2025-03-26 12:45:00"
+    },
+    "params": {}
+}

--- a/tests/testing_data/catalog_sync/catalog_sync_push_menu_payload.json
+++ b/tests/testing_data/catalog_sync/catalog_sync_push_menu_payload.json
@@ -1,0 +1,270 @@
+{
+    "success": "1",
+    "message": "Menu items are successfully listed.",
+    "restaurants": [
+        {
+            "restaurantid": "4639",
+            "active": "1",
+            "details": {
+                "menusharingcode": "nu0wisf4",
+                "currency_html": "&#8377;",
+                "country": "India",
+                "country_id": "97",
+                "images": [],
+                "restaurantname": "Indisubb Foods Private Limited",
+                "address": "Ahmedabad",
+                "contact": "1234567890",
+                "latitude": "1",
+                "longitude": "1",
+                "landmark": "",
+                "city": "Ahmedabad",
+                "city_id": "1321851",
+                "state": "Gujarat",
+                "state_id": "1612",
+                "minimumorderamount": "0",
+                "minimumdeliverytime": "30 Minutes",
+                "deliverycharge": "0",
+                "deliveryhoursfrom1": "",
+                "deliveryhoursto1": "",
+                "deliveryhoursfrom2": "",
+                "deliveryhoursto2": "",
+                "calculatetaxonpacking": 0,
+                "calculatetaxondelivery": 0,
+                "dc_taxes_id": "",
+                "pc_taxes_id": "",
+                "packaging_applicable_on": "NONE",
+                "packaging_charge": "",
+                "packaging_charge_type": ""
+            }
+        }
+    ],
+    "ordertypes": [
+        {
+            "ordertypeid": 1,
+            "ordertype": "Delivery"
+        },
+        {
+            "ordertypeid": 2,
+            "ordertype": "Pick Up"
+        },
+        {
+            "ordertypeid": 3,
+            "ordertype": "Dine In"
+        }
+    ],
+    "categories": [
+        {
+            "categoryid": "77583",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Add Ons",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77581",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Beverages",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77585",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Chicken",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77578",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Chicken Meal",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77584",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Desserts",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77582",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Hot Coffees",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77579",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Seafood Meal",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77580",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Side Orders",
+            "categorytimings": "",
+            "category_image_url": ""
+        }
+    ],
+    "parentcategories": [],
+    "items": [
+        {
+            "itemid": "10539634",
+            "itemallowvariation": "0",
+            "itemrank": "1",
+            "item_categoryid": "77578",
+            "item_ordertype": "1,2,3",
+            "item_packingcharges": "0",
+            "itemallowaddon": "0",
+            "itemaddonbasedon": "0",
+            "item_favorite": "0",
+            "ignore_taxes": "0",
+            "ignore_discounts": "0",
+            "in_stock": "2",
+            "cuisine": [],
+            "variation_groupname": "",
+            "variation": [],
+            "addon": [],
+            "is_recommend": "0",
+            "itemname": "Potter 4",
+            "item_attributeid": "1",
+            "itemdescription": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+            "minimumpreparationtime": "",
+            "price": "8700.00",
+            "active": "1",
+            "item_image_url": "",
+            "item_tax": "2524,2525",
+            "gst_type": "services"
+        },
+        {
+            "itemid": "10539699",
+            "itemallowvariation": "0",
+            "itemrank": "1",
+            "item_categoryid": "77578",
+            "item_ordertype": "1,2,3",
+            "item_packingcharges": "0",
+            "itemallowaddon": "0",
+            "itemaddonbasedon": "0",
+            "item_favorite": "0",
+            "ignore_taxes": "0",
+            "ignore_discounts": "0",
+            "in_stock": "2",
+            "cuisine": [],
+            "variation_groupname": "",
+            "variation": [],
+            "addon": [],
+            "is_recommend": "0",
+            "itemname": "Potter 99",
+            "item_attributeid": "1",
+            "itemdescription": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+            "minimumpreparationtime": "",
+            "price": "3426.00",
+            "active": "1",
+            "item_image_url": "",
+            "item_tax": "2524,2525",
+            "gst_type": "services"
+        },
+        {
+            "itemid": "10539580",
+            "itemallowvariation": "0",
+            "itemrank": "1",
+            "item_categoryid": "77578",
+            "item_ordertype": "1,2,3",
+            "item_packingcharges": "0",
+            "itemallowaddon": "1",
+            "itemaddonbasedon": "0",
+            "item_favorite": "0",
+            "ignore_taxes": "0",
+            "ignore_discounts": "0",
+            "in_stock": "2",
+            "cuisine": [],
+            "variation_groupname": "",
+            "variation": [],
+            "addon": [
+                {
+                    "addon_group_id": "11425",
+                    "addon_item_selection_min": "1",
+                    "addon_item_selection_max": "1"
+                }
+            ],
+            "is_recommend": "0",
+            "itemname": "Potter 5",
+            "item_attributeid": "1",
+            "itemdescription": "chicken fillet  nuggets come with a sauce of your choice (nugget\/garlic sauce). Bite-sized pieces of tender all breast chicken fillets, marinated in our unique & signature blend, breaded and seasoned to perfection, then deep-fried until deliciously tender, crispy with a golden crust",
+            "minimumpreparationtime": "",
+            "price": "3159.00",
+            "active": "1",
+            "item_image_url": "",
+            "item_tax": "2524,2525",
+            "gst_type": "services"
+        }
+    ],
+    "variations": [],
+    "addongroups": [],
+    "attributes": [
+        {
+            "attributeid": "1",
+            "attribute": "veg",
+            "active": "1"
+        },
+        {
+            "attributeid": "2",
+            "attribute": "non-veg",
+            "active": "1"
+        }
+    ],
+    "taxes": [
+        {
+            "taxid": "2524",
+            "taxname": "CGST",
+            "tax": "2.5",
+            "taxtype": "1",
+            "tax_ordertype": "",
+            "active": "1",
+            "tax_coreortotal": "2",
+            "tax_taxtype": "1",
+            "rank": "1",
+            "consider_in_core_amount": "0",
+            "description": ""
+        },
+        {
+            "taxid": "2525",
+            "taxname": "SGST",
+            "tax": "2.5",
+            "taxtype": "1",
+            "tax_ordertype": "",
+            "active": "1",
+            "tax_coreortotal": "2",
+            "tax_taxtype": "1",
+            "rank": "2",
+            "consider_in_core_amount": "0",
+            "description": ""
+        }
+    ],
+    "discounts": [],
+    "serverdatetime": "2024-08-05 16:40:42",
+    "db_version": "1.0",
+    "application_version": "4.0",
+    "http_code": 200,
+    "error": ""
+}

--- a/tests/testing_data/catalog_sync/catalog_sync_push_menu_payload_invalid.json
+++ b/tests/testing_data/catalog_sync/catalog_sync_push_menu_payload_invalid.json
@@ -1,0 +1,269 @@
+{
+    "success": "1",
+    "message": "Menu items are successfully listed.",
+    "restaurants": [
+        {
+            "restaurantid": "4639",
+            "active": "1",
+            "details": {
+                "menusharingcode": "nu0wisf4",
+                "currency_html": "&#8377;",
+                "country": "India",
+                "country_id": "97",
+                "images": [],
+                "restaurantname": "Indisubb Foods Private Limited",
+                "address": "Ahmedabad",
+                "contact": "1234567890",
+                "latitude": "1",
+                "longitude": "1",
+                "landmark": "",
+                "city": "Ahmedabad",
+                "city_id": "1321851",
+                "state": "Gujarat",
+                "state_id": "1612",
+                "minimumorderamount": "0",
+                "minimumdeliverytime": "30 Minutes",
+                "deliverycharge": "0",
+                "deliveryhoursfrom1": "",
+                "deliveryhoursto1": "",
+                "deliveryhoursfrom2": "",
+                "deliveryhoursto2": "",
+                "calculatetaxonpacking": 0,
+                "calculatetaxondelivery": 0,
+                "dc_taxes_id": "",
+                "pc_taxes_id": "",
+                "packaging_applicable_on": "NONE",
+                "packaging_charge": "",
+                "packaging_charge_type": ""
+            }
+        }
+    ],
+    "ordertypes": [
+        {
+            "ordertypeid": 1,
+            "ordertype": "Delivery"
+        },
+        {
+            "ordertypeid": 2,
+            "ordertype": "Pick Up"
+        },
+        {
+            "ordertypeid": 3,
+            "ordertype": "Dine In"
+        }
+    ],
+    "categories": [
+        {
+            "categoryid": "77583",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Add Ons",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77581",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Beverages",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77585",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Chicken",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77578",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Chicken Meal",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77584",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Desserts",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77582",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Hot Coffees",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77579",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Seafood Meal",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77580",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Side Orders",
+            "categorytimings": "",
+            "category_image_url": ""
+        }
+    ],
+    "parentcategories": [],
+    "items": [
+        {
+            "itemid": "10539634",
+            "itemallowvariation": "0",
+            "itemrank": "1",
+            "item_categoryid": "77578",
+            "item_ordertype": "1,2,3",
+            "item_packingcharges": "0",
+            "itemallowaddon": "0",
+            "itemaddonbasedon": "0",
+            "item_favorite": "0",
+            "ignore_taxes": "0",
+            "ignore_discounts": "0",
+            "in_stock": "2",
+            "cuisine": [],
+            "variation_groupname": "",
+            "variation": [],
+            "addon": [],
+            "is_recommend": "0",
+            "itemname": "Potter 4",
+            "item_attributeid": "1",
+            "itemdescription": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+            "minimumpreparationtime": "",
+            "price": "8700.00",
+            "active": "1",
+            "item_image_url": "",
+            "item_tax": "2524,2525",
+            "gst_type": "services"
+        },
+        {
+            "itemallowvariation": "0",
+            "itemrank": "1",
+            "item_categoryid": "77578",
+            "item_ordertype": "1,2,3",
+            "item_packingcharges": "0",
+            "itemallowaddon": "0",
+            "itemaddonbasedon": "0",
+            "item_favorite": "0",
+            "ignore_taxes": "0",
+            "ignore_discounts": "0",
+            "in_stock": "2",
+            "cuisine": [],
+            "variation_groupname": "",
+            "variation": [],
+            "addon": [],
+            "is_recommend": "0",
+            "itemname": "Potter 99",
+            "item_attributeid": "1",
+            "itemdescription": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+            "minimumpreparationtime": "",
+            "price": "3426.00",
+            "active": "1",
+            "item_image_url": "",
+            "item_tax": "2524,2525",
+            "gst_type": "services"
+        },
+        {
+            "itemid": "10539580",
+            "itemallowvariation": "0",
+            "itemrank": "1",
+            "item_categoryid": "77578",
+            "item_ordertype": "1,2,3",
+            "item_packingcharges": "0",
+            "itemallowaddon": "1",
+            "itemaddonbasedon": "0",
+            "item_favorite": "0",
+            "ignore_taxes": "0",
+            "ignore_discounts": "0",
+            "in_stock": "2",
+            "cuisine": [],
+            "variation_groupname": "",
+            "variation": [],
+            "addon": [
+                {
+                    "addon_group_id": "11425",
+                    "addon_item_selection_min": "1",
+                    "addon_item_selection_max": "1"
+                }
+            ],
+            "is_recommend": "0",
+            "itemname": "Potter 5",
+            "item_attributeid": "1",
+            "itemdescription": "chicken fillet  nuggets come with a sauce of your choice (nugget\/garlic sauce). Bite-sized pieces of tender all breast chicken fillets, marinated in our unique & signature blend, breaded and seasoned to perfection, then deep-fried until deliciously tender, crispy with a golden crust",
+            "minimumpreparationtime": "",
+            "price": "3159.00",
+            "active": "1",
+            "item_image_url": "",
+            "item_tax": "2524,2525",
+            "gst_type": "services"
+        }
+    ],
+    "variations": [],
+    "addongroups": [],
+    "attributes": [
+        {
+            "attributeid": "1",
+            "attribute": "veg",
+            "active": "1"
+        },
+        {
+            "attributeid": "2",
+            "attribute": "non-veg",
+            "active": "1"
+        }
+    ],
+    "taxes": [
+        {
+            "taxid": "2524",
+            "taxname": "CGST",
+            "tax": "2.5",
+            "taxtype": "1",
+            "tax_ordertype": "",
+            "active": "1",
+            "tax_coreortotal": "2",
+            "tax_taxtype": "1",
+            "rank": "1",
+            "consider_in_core_amount": "0",
+            "description": ""
+        },
+        {
+            "taxid": "2525",
+            "taxname": "SGST",
+            "tax": "2.5",
+            "taxtype": "1",
+            "tax_ordertype": "",
+            "active": "1",
+            "tax_coreortotal": "2",
+            "tax_taxtype": "1",
+            "rank": "2",
+            "consider_in_core_amount": "0",
+            "description": ""
+        }
+    ],
+    "discounts": [],
+    "serverdatetime": "2024-08-05 16:40:42",
+    "db_version": "1.0",
+    "application_version": "4.0",
+    "http_code": 200,
+    "error": ""
+}

--- a/tests/testing_data/catalog_sync/catalog_sync_push_menu_payload_with_delete_data.json
+++ b/tests/testing_data/catalog_sync/catalog_sync_push_menu_payload_with_delete_data.json
@@ -1,0 +1,242 @@
+{
+    "success": "1",
+    "message": "Menu items are successfully listed.",
+    "restaurants": [
+        {
+            "restaurantid": "4639",
+            "active": "1",
+            "details": {
+                "menusharingcode": "nu0wisf4",
+                "currency_html": "&#8377;",
+                "country": "India",
+                "country_id": "97",
+                "images": [],
+                "restaurantname": "Indisubb Foods Private Limited",
+                "address": "Ahmedabad",
+                "contact": "1234567890",
+                "latitude": "1",
+                "longitude": "1",
+                "landmark": "",
+                "city": "Ahmedabad",
+                "city_id": "1321851",
+                "state": "Gujarat",
+                "state_id": "1612",
+                "minimumorderamount": "0",
+                "minimumdeliverytime": "30 Minutes",
+                "deliverycharge": "0",
+                "deliveryhoursfrom1": "",
+                "deliveryhoursto1": "",
+                "deliveryhoursfrom2": "",
+                "deliveryhoursto2": "",
+                "calculatetaxonpacking": 0,
+                "calculatetaxondelivery": 0,
+                "dc_taxes_id": "",
+                "pc_taxes_id": "",
+                "packaging_applicable_on": "NONE",
+                "packaging_charge": "",
+                "packaging_charge_type": ""
+            }
+        }
+    ],
+    "ordertypes": [
+        {
+            "ordertypeid": 1,
+            "ordertype": "Delivery"
+        },
+        {
+            "ordertypeid": 2,
+            "ordertype": "Pick Up"
+        },
+        {
+            "ordertypeid": 3,
+            "ordertype": "Dine In"
+        }
+    ],
+    "categories": [
+        {
+            "categoryid": "77583",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Add Ons",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77581",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Beverages",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77585",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Chicken",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77578",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Chicken Meal",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77584",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Desserts",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77582",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Hot Coffees",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77579",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Seafood Meal",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77580",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Side Orders",
+            "categorytimings": "",
+            "category_image_url": ""
+        }
+    ],
+    "parentcategories": [],
+    "items": [
+        {
+            "itemid": "10539699",
+            "itemallowvariation": "0",
+            "itemrank": "1",
+            "item_categoryid": "77578",
+            "item_ordertype": "1,2,3",
+            "item_packingcharges": "0",
+            "itemallowaddon": "0",
+            "itemaddonbasedon": "0",
+            "item_favorite": "0",
+            "ignore_taxes": "0",
+            "ignore_discounts": "0",
+            "in_stock": "2",
+            "cuisine": [],
+            "variation_groupname": "",
+            "variation": [],
+            "addon": [],
+            "is_recommend": "0",
+            "itemname": "Potter 99",
+            "item_attributeid": "1",
+            "itemdescription": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+            "minimumpreparationtime": "",
+            "price": "123.00",
+            "active": "1",
+            "item_image_url": "",
+            "item_tax": "2524,2525",
+            "gst_type": "services"
+        },
+        {
+            "itemid": "10539580",
+            "itemallowvariation": "0",
+            "itemrank": "1",
+            "item_categoryid": "77578",
+            "item_ordertype": "1,2,3",
+            "item_packingcharges": "0",
+            "itemallowaddon": "1",
+            "itemaddonbasedon": "0",
+            "item_favorite": "0",
+            "ignore_taxes": "0",
+            "ignore_discounts": "0",
+            "in_stock": "2",
+            "cuisine": [],
+            "variation_groupname": "",
+            "variation": [],
+            "addon": [
+                {
+                    "addon_group_id": "11425",
+                    "addon_item_selection_min": "1",
+                    "addon_item_selection_max": "1"
+                }
+            ],
+            "is_recommend": "0",
+            "itemname": "Potter 5",
+            "item_attributeid": "1",
+            "itemdescription": "chicken fillet  nuggets come with a sauce of your choice (nugget\/garlic sauce). Bite-sized pieces of tender all breast chicken fillets, marinated in our unique & signature blend, breaded and seasoned to perfection, then deep-fried until deliciously tender, crispy with a golden crust",
+            "minimumpreparationtime": "",
+            "price": "3159.00",
+            "active": "1",
+            "item_image_url": "",
+            "item_tax": "2524,2525",
+            "gst_type": "services"
+        }
+    ],
+    "variations": [],
+    "addongroups": [],
+    "attributes": [
+        {
+            "attributeid": "1",
+            "attribute": "veg",
+            "active": "1"
+        },
+        {
+            "attributeid": "2",
+            "attribute": "non-veg",
+            "active": "1"
+        }
+    ],
+    "taxes": [
+        {
+            "taxid": "2524",
+            "taxname": "CGST",
+            "tax": "2.5",
+            "taxtype": "1",
+            "tax_ordertype": "",
+            "active": "1",
+            "tax_coreortotal": "2",
+            "tax_taxtype": "1",
+            "rank": "1",
+            "consider_in_core_amount": "0",
+            "description": ""
+        },
+        {
+            "taxid": "2525",
+            "taxname": "SGST",
+            "tax": "2.5",
+            "taxtype": "1",
+            "tax_ordertype": "",
+            "active": "1",
+            "tax_coreortotal": "2",
+            "tax_taxtype": "1",
+            "rank": "2",
+            "consider_in_core_amount": "0",
+            "description": ""
+        }
+    ],
+    "discounts": [],
+    "serverdatetime": "2024-08-05 16:40:42",
+    "db_version": "1.0",
+    "application_version": "4.0",
+    "http_code": 200,
+    "error": ""
+}

--- a/tests/unit_test/action/action_test.py
+++ b/tests/unit_test/action/action_test.py
@@ -2697,7 +2697,8 @@ class TestActions:
                                 'content_importer_limit_per_day': 5,
                                 'integrations_per_user_limit': 3,
                                 'live_agent_enabled': False,
-                                'retry_broadcasting_limit': 3}
+                                'retry_broadcasting_limit': 3,
+                                'catalog_sync_limit_per_day': 5}
 
     def test_prompt_action_not_exists(self):
         with pytest.raises(ActionFailure, match="Faq feature is disabled for the bot! Please contact support."):
@@ -3939,7 +3940,8 @@ class TestActions:
                                 'cognition_columns_per_collection_limit': 5,
                                 'integrations_per_user_limit': 3,
                                 'live_agent_enabled': False,
-                                'retry_broadcasting_limit': 3}
+                                'retry_broadcasting_limit': 3,
+                                'catalog_sync_limit_per_day': 5}
 
     def test_get_prompt_action_config_2(self):
         bot = "test_bot_action_test"

--- a/tests/unit_test/data_processor/catalog_sync_log_processor_test.py
+++ b/tests/unit_test/data_processor/catalog_sync_log_processor_test.py
@@ -1,0 +1,571 @@
+import json
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+from babel.messages.jslexer import uni_escape_re
+from mongoengine import connect
+
+from kairon import Utility
+from kairon.exceptions import AppException
+from kairon.shared.catalog_sync.catalog_sync_log_processor import CatalogSyncLogProcessor
+from kairon.shared.catalog_sync.data_objects import CatalogSyncLogs
+from kairon.shared.cognition.data_objects import CognitionSchema, CollectionData
+from kairon.shared.cognition.processor import CognitionDataProcessor
+from kairon.shared.data.constant import SYNC_STATUS, SyncType
+from kairon.shared.data.data_objects import BotSettings, BotSyncConfig
+
+
+class TestCatalogSyncLogProcessor:
+
+    @pytest.fixture(scope='session', autouse=True)
+    def init(self):
+        os.environ["system_file"] = "./tests/testing_data/system.yaml"
+        Utility.load_environment()
+        connect(**Utility.mongoengine_connection(Utility.environment['database']["url"]))
+
+
+    def test_add_log(self):
+        bot = 'test'
+        user = 'test'
+        provider = "petpooja"
+        sync_type = "push_menu"
+        CatalogSyncLogProcessor.add_log(bot, user, provider = provider, sync_type = sync_type,raw_payload={"item":"Test raw payload"})
+        log = CatalogSyncLogs.objects(bot=bot).get().to_mongo().to_dict()
+        assert not log.get('exception')
+        assert log['execution_id']
+        assert log['raw_payload']
+        assert log['sync_type']
+        assert log['start_timestamp']
+        assert not log.get('end_timestamp')
+        assert not log.get('processed_payload')
+        assert log['sync_status'] == SYNC_STATUS.INITIATED.value
+
+    def test_add_log_exception(self):
+        bot = 'test'
+        user = 'test'
+        CatalogSyncLogProcessor.add_log(bot, user, sync_status=SYNC_STATUS.FAILED.value,
+                                        exception="Push menu processing is disabled for this bot",
+                                        status="Failure")
+        log = CatalogSyncLogs.objects(bot=bot).get().to_mongo().to_dict()
+        assert log.get('exception') == "Push menu processing is disabled for this bot"
+        assert log['execution_id']
+        assert log['raw_payload']
+        assert log['sync_type']
+        assert log['start_timestamp']
+        assert log.get('end_timestamp')
+        assert log['sync_status'] == SYNC_STATUS.FAILED.value
+
+
+    def test_add_log_validation_errors(self):
+        bot = 'test'
+        user = 'test'
+        provider = "petpooja"
+        sync_type = "push_menu"
+        CatalogSyncLogProcessor.add_log(bot, user, provider = provider, sync_type = sync_type,raw_payload={"item":"Test raw payload"},
+                                        sync_status=SYNC_STATUS.FAILED.value,
+                                        exception="Validation Failed",
+                                        status="Failure",
+                                        validation_errors={
+                                            "Header mismatch": "Expected headers ['order_id', 'order_priority', 'sales', 'profit'] but found ['order_id', 'order_priority', 'revenue', 'sales'].",
+                                            "Missing columns": "{'profit'}.",
+                                            "Extra columns": "{'revenue'}."
+                                        }
+                                        )
+        log = list(CatalogSyncLogProcessor.get_logs(bot))
+        assert log[0].get('exception') == "Validation Failed"
+        assert log[0]['execution_id']
+        assert log[0]['raw_payload']
+        assert log[0]['sync_type']
+        assert log[0]['start_timestamp']
+        assert log[0]["validation_errors"]
+        assert log[0].get('end_timestamp')
+        assert log[0]['sync_status'] == SYNC_STATUS.FAILED.value
+
+    def test_add_log_success(self):
+        bot = 'test'
+        user = 'test'
+        provider = "petpooja"
+        sync_type = "push_menu"
+        CatalogSyncLogProcessor.add_log(bot, user, provider = provider, sync_type = sync_type,raw_payload={"item":"Test raw payload"})
+        CatalogSyncLogProcessor.add_log(bot, user, sync_status=SYNC_STATUS.COMPLETED.value, status="Success")
+        log = list(CatalogSyncLogProcessor.get_logs(bot))
+        assert not log[0].get('exception')
+        assert log[0]['execution_id']
+        assert log[0]['raw_payload']
+        assert log[0]['sync_type']
+        assert log[0]['start_timestamp']
+        assert not log[0]["validation_errors"]
+        assert log[0]["status"] == 'Success'
+        assert log[0]['sync_status'] == SYNC_STATUS.COMPLETED.value
+
+    def test_is_event_in_progress_false(self):
+        bot = 'test'
+        assert not CatalogSyncLogProcessor.is_sync_in_progress(bot)
+
+    def test_is_event_in_progress_true(self):
+        bot = 'test'
+        user = 'test'
+        provider = "petpooja"
+        sync_type = "push_menu"
+        CatalogSyncLogProcessor.add_log(bot, user, provider=provider, sync_type=sync_type,
+                                        raw_payload={"item": "Test raw payload"})
+        assert CatalogSyncLogProcessor.is_sync_in_progress(bot, False)
+
+        with pytest.raises(Exception):
+            CatalogSyncLogProcessor.is_sync_in_progress(bot)
+
+    def test_get_logs(self):
+        bot = 'test'
+        logs = list(CatalogSyncLogProcessor.get_logs(bot))
+        assert len(logs) == 4
+
+    def test_is_limit_exceeded_exception(self, monkeypatch):
+        bot = 'test'
+        try:
+            bot_settings = BotSettings.objects(bot=bot).get()
+            bot_settings.catalog_sync_limit_per_day = 0
+        except:
+            bot_settings = BotSettings(bot=bot, catalog_sync_limit_per_day=0, user="test")
+        bot_settings.save()
+        with pytest.raises(Exception):
+            assert CatalogSyncLogProcessor.is_limit_exceeded(bot)
+
+    def test_is_limit_exceeded(self, monkeypatch):
+        bot = 'test'
+        bot_settings = BotSettings.objects(bot=bot).get()
+        bot_settings.catalog_sync_limit_per_day = 3
+        bot_settings.save()
+        assert CatalogSyncLogProcessor.is_limit_exceeded(bot, False)
+
+    def test_is_limit_exceeded_false(self, monkeypatch):
+        bot = 'test'
+        bot_settings = BotSettings.objects(bot=bot).get()
+        bot_settings.catalog_sync_limit_per_day = 6
+        bot_settings.save()
+        assert not CatalogSyncLogProcessor.is_limit_exceeded(bot)
+
+    def test_catalog_collection_exists_true(self):
+        bot = "test"
+        user = "test"
+
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch A",
+            branch_bot=bot,
+            user=user
+        ).save()
+
+        expected_collection = "test_restaurant_branch_a_catalog"
+
+        CognitionSchema(
+            bot=bot,
+            user=user,
+            collection_name=expected_collection
+        ).save()
+
+        assert CatalogSyncLogProcessor.is_catalog_collection_exists(bot) is True
+
+        BotSyncConfig.objects.delete()
+        CognitionSchema.objects.delete()
+
+    def test_catalog_collection_exists_false(self):
+        bot = "test"
+        user = "test"
+
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch A",
+            branch_bot=bot,
+            user=user
+        ).save()
+
+        assert CatalogSyncLogProcessor.is_catalog_collection_exists(bot) is False
+
+        BotSyncConfig.objects.delete()
+        CognitionSchema.objects.delete()
+
+    def test_create_catalog_collection(self):
+        bot = "test_bot"
+        user = "test_user"
+
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo_provider",
+            branch_name="Test Branch",
+            branch_bot=bot,
+            user=user
+        ).save()
+
+        BotSettings(
+            bot=bot,
+            user=user,
+            cognition_columns_per_collection_limit=5,
+            llm_settings={'enable_faq': True}
+        ).save()
+
+        metadata_id = CatalogSyncLogProcessor.create_catalog_collection(bot, user)
+
+        assert metadata_id is not None
+
+        catalog_name = "test_restaurant_test_branch_catalog"
+        created_schema = CognitionSchema.objects(collection_name=catalog_name).first()
+        assert created_schema is not None
+        assert created_schema.collection_name == catalog_name
+
+        BotSyncConfig.objects.delete()
+        BotSettings.objects.delete()
+        CognitionSchema.objects.delete()
+
+    def test_validate_item_ids(self):
+        push_menu_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_push_menu_payload.json")
+
+        with push_menu_payload_path.open("r", encoding="utf-8") as f:
+            push_menu_payload = json.load(f)
+
+        try:
+            CatalogSyncLogProcessor.validate_item_ids(push_menu_payload)
+            itemid_missing = False
+        except Exception as e:
+            itemid_missing = True
+
+        assert itemid_missing is False
+
+    def test_validate_item_ids_missing_itemid(self):
+        push_menu_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_push_menu_payload_invalid.json")
+
+        with push_menu_payload_path.open("r", encoding="utf-8") as f:
+            push_menu_payload = json.load(f)
+
+        with pytest.raises(Exception):
+            CatalogSyncLogProcessor.validate_item_ids(push_menu_payload)
+
+    def test_validate_item_toggle_request_valid(self):
+        file_path = Path("tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload.json")
+        with file_path.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+
+        CatalogSyncLogProcessor.validate_item_toggle_request(payload)
+
+    def test_validate_item_toggle_request_missing_instock(self):
+        file_path = Path("tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload_invalid_missing_instock.json")
+        with file_path.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+
+        with pytest.raises(Exception, match="Missing required field: 'inStock'"):
+            CatalogSyncLogProcessor.validate_item_toggle_request(payload)
+
+    def test_validate_item_toggle_request_nonboolean_instock(self):
+        file_path = Path("tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload_invalid_nonboolean_instock.json")
+        with file_path.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+
+        with pytest.raises(Exception, match="'inStock' must be a boolean"):
+            CatalogSyncLogProcessor.validate_item_toggle_request(payload)
+
+    def test_validate_item_toggle_request_missing_itemid(self):
+        file_path = Path("tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload_invalid_missing_itemid.json")
+        with file_path.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+
+        with pytest.raises(Exception, match="Missing required field: 'itemID'"):
+            CatalogSyncLogProcessor.validate_item_toggle_request(payload)
+
+    def test_sync_type_allowed_valid_push_menu(self):
+        bot = "test_bot"
+        user = "test_user"
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch",
+            branch_bot=bot,
+            user=user,
+            process_push_menu=True,
+            process_item_toggle=False
+        ).save()
+
+        CatalogSyncLogProcessor.is_sync_type_allowed(bot, SyncType.push_menu)
+
+        BotSyncConfig.objects.delete()
+
+    def test_sync_type_allowed_valid_item_toggle(self):
+        bot = "test_bot"
+        user = "test_user"
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch",
+            branch_bot=bot,
+            user=user,
+            process_push_menu=False,
+            process_item_toggle=True
+        ).save()
+
+        CatalogSyncLogProcessor.is_sync_type_allowed(bot, SyncType.item_toggle)
+
+        BotSyncConfig.objects.delete()
+
+    def test_sync_type_push_menu_not_allowed(self):
+        bot = "test_bot"
+        user = "test_user"
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch",
+            branch_bot=bot,
+            user=user,
+            process_push_menu=False,
+            process_item_toggle=True
+        ).save()
+
+        with pytest.raises(Exception, match="Push menu processing is disabled for this bot"):
+            CatalogSyncLogProcessor.is_sync_type_allowed(bot, SyncType.push_menu)
+
+        BotSyncConfig.objects.delete()
+
+    def test_sync_type_item_toggle_not_allowed(self):
+        bot = "test_bot"
+        user = "test_user"
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch",
+            branch_bot=bot,
+            user=user,
+            process_push_menu=True,
+            process_item_toggle=False
+        ).save()
+
+        with pytest.raises(Exception, match="Item toggle is disabled for this bot"):
+            CatalogSyncLogProcessor.is_sync_type_allowed(bot, SyncType.item_toggle)
+
+        BotSyncConfig.objects.delete()
+
+    def test_sync_type_config_missing(self):
+        bot = "test_bot"
+        BotSyncConfig.objects.delete()
+
+        with pytest.raises(Exception, match="No bot sync config found for bot"):
+            CatalogSyncLogProcessor.is_sync_type_allowed(bot, SyncType.push_menu)
+
+    def test_ai_enabled_true(self):
+        bot = "test_bot"
+        user = "test_user"
+
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch",
+            branch_bot=bot,
+            user=user,
+            ai_enabled=True
+        ).save()
+
+        result = CatalogSyncLogProcessor.is_ai_enabled(bot)
+        assert result is True
+
+        BotSyncConfig.objects.delete()
+
+    def test_ai_enabled_false(self):
+        bot = "test_bot"
+        user = "test_user"
+
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch",
+            branch_bot=bot,
+            user=user,
+            ai_enabled=False
+        ).save()
+
+        result = CatalogSyncLogProcessor.is_ai_enabled(bot)
+        assert result is False
+
+        BotSyncConfig.objects.delete()
+
+    def test_ai_enabled_no_config(self):
+        bot = "test_bot"
+        BotSyncConfig.objects.delete()
+
+        with pytest.raises(Exception, match="No bot sync config found for bot"):
+            CatalogSyncLogProcessor.is_ai_enabled(bot)
+
+    def test_meta_enabled_true(self):
+        bot = "test_bot"
+        user = "test_user"
+
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch",
+            branch_bot=bot,
+            user=user,
+            meta_enabled=True
+        ).save()
+
+        result = CatalogSyncLogProcessor.is_meta_enabled(bot)
+        assert result is True
+
+        BotSyncConfig.objects.delete()
+
+    def test_meta_enabled_false(self):
+        bot = "test_bot"
+        user = "test_user"
+
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch",
+            branch_bot=bot,
+            user=user,
+            meta_enabled=False
+        ).save()
+
+        result = CatalogSyncLogProcessor.is_meta_enabled(bot)
+        assert result is False
+
+        BotSyncConfig.objects.delete()
+
+    def test_meta_enabled_no_config(self):
+        bot = "test_bot"
+        BotSyncConfig.objects.delete()
+
+        with pytest.raises(Exception, match="No bot sync config found for bot"):
+            CatalogSyncLogProcessor.is_meta_enabled(bot)
+
+    def test_get_execution_id_for_bot_returns_latest_pending(self):
+        bot = "test_bot"
+        user = "test_user"
+
+        CatalogSyncLogs(
+            execution_id="completed_1",
+            raw_payload={"item":"Test raw payload"},
+            bot=bot,
+            user=user,
+            provider="demo",
+            sync_type="push_menu",
+            sync_status=SYNC_STATUS.COMPLETED.value,
+            start_timestamp=datetime.utcnow() - timedelta(minutes=10)
+        ).save()
+
+        CatalogSyncLogs(
+            execution_id="failed_1",
+            raw_payload={"item":"Test raw payload"},
+            bot=bot,
+            user=user,
+            provider="demo",
+            sync_type="push_menu",
+            sync_status=SYNC_STATUS.FAILED.value,
+            start_timestamp=datetime.utcnow() - timedelta(minutes=5)
+        ).save()
+
+        CatalogSyncLogs(
+            execution_id="valid_pending_1",
+            raw_payload={"item":"Test raw payload"},
+            bot=bot,
+            user=user,
+            provider="demo",
+            sync_type="push_menu",
+            sync_status=SYNC_STATUS.PREPROCESSING.value,
+            start_timestamp=datetime.utcnow()
+        ).save()
+
+        execution_id = CatalogSyncLogProcessor.get_execution_id_for_bot(bot)
+        assert execution_id == "valid_pending_1"
+
+        CatalogSyncLogs.objects.delete()
+
+    def test_get_execution_id_for_bot_returns_none_if_all_completed_or_failed(self):
+        bot = "test_bot"
+        user = "test_user"
+
+        CatalogSyncLogs(
+            execution_id="completed_2",
+            raw_payload={"item":"Test raw payload"},
+            bot=bot,
+            user=user,
+            provider="demo",
+            sync_type="push_menu",
+            sync_status=SYNC_STATUS.COMPLETED.value,
+            start_timestamp=datetime.utcnow()
+        ).save()
+
+        CatalogSyncLogs(
+            execution_id="failed_2",
+            raw_payload={"item":"Test raw payload"},
+            bot=bot,
+            user=user,
+            provider="demo",
+            sync_type="push_menu",
+            sync_status=SYNC_STATUS.FAILED.value,
+            start_timestamp=datetime.utcnow()
+        ).save()
+
+        execution_id = CatalogSyncLogProcessor.get_execution_id_for_bot(bot)
+        assert execution_id is None
+
+        CatalogSyncLogs.objects.delete()
+
+    def test_validate_image_configurations_when_catalog_images_exists(self):
+        bot = "test_bot"
+        user = "test_user"
+
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo_provider",
+            branch_name="Test Branch",
+            branch_bot=bot,
+            user=user
+        ).save()
+
+        CollectionData(
+            collection_name="test_restaurant_test_branch_catalog_images",
+            data={
+                "image_type": "global",
+                "image_url": "http://example.com/global_fallback.jpg",
+                "image_base64": ""
+            },
+            user=user,
+            bot=bot,
+            status=True,
+            timestamp=datetime.utcnow()
+        ).save()
+
+        CatalogSyncLogProcessor.validate_image_configurations(bot, user)
+
+        BotSyncConfig.objects.delete()
+        CollectionData.objects.delete()
+
+    def test_validate_image_configurations_when_catalog_images_missing_global_fallback(self):
+        bot = "test_bot"
+        user = "test_user"
+
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo_provider",
+            branch_name="Test Branch",
+            branch_bot=bot,
+            user=user
+        ).save()
+
+        with pytest.raises(Exception, match="Global fallback image URL not found"):
+            CatalogSyncLogProcessor.validate_image_configurations(bot, user)
+
+        BotSyncConfig.objects.delete()

--- a/tests/unit_test/data_processor/catalog_sync_log_processor_test.py
+++ b/tests/unit_test/data_processor/catalog_sync_log_processor_test.py
@@ -569,3 +569,4 @@ class TestCatalogSyncLogProcessor:
             CatalogSyncLogProcessor.validate_image_configurations(bot, user)
 
         BotSyncConfig.objects.delete()
+        CollectionData.objects.delete()

--- a/tests/unit_test/data_processor/data_processor_test.py
+++ b/tests/unit_test/data_processor/data_processor_test.py
@@ -1797,7 +1797,7 @@ class TestMongoProcessor:
         user = 'test_user'
         collection_name = 'groceries'
         primary_key_col = "id"
-        event_type = 'push_menu'
+        sync_type = 'push_menu'
 
         metadata = [
             {
@@ -1846,7 +1846,7 @@ class TestMongoProcessor:
         validation_summary = processor.validate_data(
             primary_key_col=primary_key_col,
             collection_name=collection_name,
-            event_type=event_type,
+            sync_type=sync_type,
             data=data,
             bot=bot
         )
@@ -1854,12 +1854,12 @@ class TestMongoProcessor:
         assert validation_summary == {}
         CognitionSchema.objects(bot=bot, collection_name="groceries").delete()
 
-    def test_validate_data_field_update_success(self):
+    def test_validate_data_item_toggle_success(self):
         bot = 'test_bot'
         user = 'test_user'
         collection_name = 'groceries'
         primary_key_col = "id"
-        event_type = "field_update"
+        sync_type = "item_toggle"
 
         metadata = [
             {
@@ -1940,7 +1940,7 @@ class TestMongoProcessor:
         validation_summary = processor.validate_data(
             primary_key_col=primary_key_col,
             collection_name=collection_name,
-            event_type=event_type,
+            sync_type=sync_type,
             data=data,
             bot=bot
         )
@@ -1949,20 +1949,20 @@ class TestMongoProcessor:
         CognitionSchema.objects(bot=bot, collection_name="groceries").delete()
         CognitionData.objects(bot=bot, collection="groceries").delete()
 
-    def test_validate_data_event_type_does_not_exist(self):
+    def test_validate_data_sync_type_does_not_exist(self):
         bot = 'test_bot'
         collection_name = 'groceries'
         primary_key_col = "id"
         data = [{"id": 1, "item": "Juice", "price": 2.50, "quantity": 10}]
-        event_type = 'non_existent_event_type'
+        sync_type = 'non_existent_sync_type'
 
         processor = CognitionDataProcessor()
 
-        with pytest.raises(AppException, match=f"Event type does not exist"):
+        with pytest.raises(AppException, match=f"Sync type does not exist"):
             processor.validate_data(
                 primary_key_col=primary_key_col,
                 collection_name=collection_name,
-                event_type=event_type,
+                sync_type=sync_type,
                 data=data,
                 bot=bot
             )
@@ -1972,7 +1972,7 @@ class TestMongoProcessor:
         collection_name = 'nonexistent_collection'
         primary_key_col = "id"
         data = [{"id": 1, "item": "Juice", "price": 2.50, "quantity": 10}]
-        event_type = 'push_menu'
+        sync_type = 'push_menu'
 
         processor = CognitionDataProcessor()
 
@@ -1980,7 +1980,7 @@ class TestMongoProcessor:
             processor.validate_data(
                 primary_key_col=primary_key_col,
                 collection_name=collection_name,
-                event_type=event_type,
+                sync_type=sync_type,
                 data=data,
                 bot=bot
             )
@@ -1990,7 +1990,7 @@ class TestMongoProcessor:
         user = 'test_user'
         collection_name = 'groceries'
         primary_key_col = "id"
-        event_type = 'push_menu'
+        sync_type = 'push_menu'
 
         metadata = [
             {"column_name": "id", "data_type": "int", "enable_search": True, "create_embeddings": True},
@@ -2020,7 +2020,7 @@ class TestMongoProcessor:
                 primary_key_col=primary_key_col,
                 collection_name=collection_name,
                 data=data,
-                event_type=event_type,
+                sync_type=sync_type,
                 bot=bot
             )
         CognitionSchema.objects(bot=bot, collection_name="groceries").delete()
@@ -2030,7 +2030,7 @@ class TestMongoProcessor:
         user = 'test_user'
         collection_name = 'groceries'
         primary_key_col = "id"
-        event_type = 'push_menu'
+        sync_type = 'push_menu'
 
         metadata = [
             {"column_name": "id", "data_type": "int", "enable_search": True, "create_embeddings": True},
@@ -2057,7 +2057,7 @@ class TestMongoProcessor:
         validation_summary = processor.validate_data(
             primary_key_col=primary_key_col,
             collection_name=collection_name,
-            event_type=event_type,
+            sync_type=sync_type,
             data=data,
             bot=bot
         )
@@ -2072,7 +2072,7 @@ class TestMongoProcessor:
         user = 'test_user'
         collection_name = 'groceries'
         primary_key_col = "id"
-        event_type = 'push_menu'
+        sync_type = 'push_menu'
 
         metadata = [
             {"column_name": "id", "data_type": "int", "enable_search": True, "create_embeddings": True},
@@ -2099,7 +2099,7 @@ class TestMongoProcessor:
         validation_summary = processor.validate_data(
             primary_key_col=primary_key_col,
             collection_name=collection_name,
-            event_type=event_type,
+            sync_type=sync_type,
             data=data,
             bot=bot
         )
@@ -2114,7 +2114,7 @@ class TestMongoProcessor:
         user = 'test_user'
         collection_name = 'groceries'
         primary_key_col = "id"
-        event_type = 'field_update'
+        sync_type = 'item_toggle'
 
         metadata = [
             {"column_name": "id", "data_type": "int", "enable_search": True, "create_embeddings": True},
@@ -2157,7 +2157,7 @@ class TestMongoProcessor:
         validation_summary = processor.validate_data(
             primary_key_col=primary_key_col,
             collection_name=collection_name,
-            event_type=event_type,
+            sync_type=sync_type,
             data=data,
             bot=bot
         )
@@ -2179,7 +2179,7 @@ class TestMongoProcessor:
         user = 'test_user'
         collection_name = 'groceries'
         primary_key_col = 'id'
-        event_type = 'push_menu'
+        sync_type = 'push_menu'
 
         metadata = [
             {"column_name": "id", "data_type": "int", "enable_search": True, "create_embeddings": True},
@@ -2241,7 +2241,7 @@ class TestMongoProcessor:
         result = await processor.upsert_data(
             primary_key_col=primary_key_col,
             collection_name=collection_name,
-            event_type=event_type,
+            sync_type=sync_type,
             data=upsert_data,
             bot=bot,
             user=user
@@ -2273,14 +2273,14 @@ class TestMongoProcessor:
     @patch.object(LLMProcessor, "__create_collection__", autospec=True)
     @patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
     @patch.object(litellm, "aembedding", autospec=True)
-    async def test_upsert_data_field_update_success(self, mock_embedding, mock_collection_upsert,
+    async def test_upsert_data_item_toggle_success(self, mock_embedding, mock_collection_upsert,
                                                     mock_create_collection,
                                                     mock_collection_exists):
         bot = 'test_bot'
         user = 'test_user'
         collection_name = 'groceries'
         primary_key_col = 'id'
-        event_type = 'field_update'
+        sync_type = 'item_toggle'
 
         metadata = [
             {"column_name": "id", "data_type": "int", "enable_search": True, "create_embeddings": True},
@@ -2358,7 +2358,7 @@ class TestMongoProcessor:
         result = await processor.upsert_data(
             primary_key_col=primary_key_col,
             collection_name=collection_name,
-            event_type=event_type,
+            sync_type=sync_type,
             data=upsert_data,
             bot=bot,
             user=user
@@ -2396,7 +2396,7 @@ class TestMongoProcessor:
         user = 'test_user'
         collection_name = 'groceries'
         primary_key_col = 'id'
-        event_type = 'push_menu'
+        sync_type = 'push_menu'
 
         metadata = [
             {"column_name": "id", "data_type": "int", "enable_search": True, "create_embeddings": True},
@@ -2454,7 +2454,7 @@ class TestMongoProcessor:
         result = await processor.upsert_data(
             primary_key_col=primary_key_col,
             collection_name=collection_name,
-            event_type=event_type,
+            sync_type=sync_type,
             data=upsert_data,
             bot=bot,
             user=user
@@ -2679,16 +2679,16 @@ class TestMongoProcessor:
         with pytest.raises(ValueError, match="Unsupported data type: unknown"):
             CognitionDataProcessor.get_pydantic_type('unknown')
 
-    def test_validate_event_type_valid(self):
+    def test_validate_sync_type_valid(self):
         processor = CognitionDataProcessor()
-        valid_event_type = list(VaultSyncType.__members__.keys())[0]
-        processor._validate_sync_type(valid_event_type)
+        valid_sync_type = list(VaultSyncType.__members__.keys())[0]
+        processor._validate_sync_type(valid_sync_type)
 
-    def test_validate_event_type_invalid(self):
+    def test_validate_sync_type_invalid(self):
         processor = CognitionDataProcessor()
-        invalid_event_type = "invalid_event"
-        with pytest.raises(AppException, match="Event type does not exist"):
-            processor._validate_sync_type(invalid_event_type)
+        invalid_sync_type = "invalid_event"
+        with pytest.raises(AppException, match="Sync type does not exist"):
+            processor._validate_sync_type(invalid_sync_type)
 
     def test_validate_collection_exists_valid(self):
         bot = 'test_bot'

--- a/tests/unit_test/data_processor/data_processor_test.py
+++ b/tests/unit_test/data_processor/data_processor_test.py
@@ -2406,8 +2406,9 @@ class TestMongoProcessor:
     @patch.object(LLMProcessor, "__collection_exists__", autospec=True)
     @patch.object(LLMProcessor, "__create_collection__", autospec=True)
     @patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+    @patch.object(LLMProcessor, "__delete_collection_points__",autospec=True)
     @patch.object(litellm, "aembedding", autospec=True)
-    async def test_upsert_data_empty_data_list(self, mock_embedding, mock_collection_upsert, mock_create_collection,
+    async def test_upsert_data_empty_data_list(self, mock_embedding, mock_delete_collection_points, mock_collection_upsert, mock_create_collection,
                                                mock_collection_exists):
         bot = 'test_bot'
         user = 'test_user'
@@ -2463,6 +2464,7 @@ class TestMongoProcessor:
         mock_collection_exists.return_value = False
         mock_create_collection.return_value = None
         mock_collection_upsert.return_value = None
+        mock_delete_collection_points.return_value = None
 
         embedding = list(np.random.random(1532))
         mock_embedding.return_value = {'data': [{'embedding': embedding}, {'embedding': embedding}]}

--- a/tests/unit_test/meta/meta_processor_test.py
+++ b/tests/unit_test/meta/meta_processor_test.py
@@ -1,0 +1,439 @@
+import json
+import os
+from urllib.parse import unquote, urlparse, parse_qs
+
+import pytest
+import requests
+from mongoengine import connect
+from unittest.mock import patch, Mock
+from kairon import Utility
+from kairon.meta.processor import MetaProcessor
+from kairon.shared.catalog_sync.data_objects import CatalogProviderMapping
+
+os.environ["system_file"] = "./tests/testing_data/system.yaml"
+Utility.load_environment()
+Utility.load_system_metadata()
+
+class TestMetaProcessor:
+
+    @pytest.fixture(autouse=True, scope='class')
+    def init_connection(self):
+        connect(**Utility.mongoengine_connection())
+
+    def test_preprocess_data_create_success(self):
+        bot = "test_bot"
+        method = "CREATE"
+        catalog_id = "12345"
+        access_token = "test_token"
+        provider = "petpooja"
+
+        CatalogProviderMapping(
+            provider=provider,
+            meta_mappings={
+                "name": {"source": "itemname", "default": "No title"},
+                "description": {"source": "itemdescription", "default": "No description available"},
+                "price": {"source": "price", "default": 0.0},
+                "availability": {"source": "in_stock", "default": "out of stock"},
+                "image_url": {"source": "item_image_url", "default": "https://www.kairon.com/default-image.jpg"},
+                "url": {"source": None, "default": "https://www.kairon.com/"},
+                "brand": {"source": None, "default": "Sattva"},
+                "condition": {"source": None, "default": "new"}
+            },
+            kv_mappings={
+                "title": {"source": "itemname", "default": "No title"},
+                "description": {"source": "itemdescription", "default": "No description available"},
+                "price": {"source": "price", "default": 0.0},
+                "facebook_product_category": {"source": "item_categoryid", "default": "Food and drink > General"},
+                "availability": {"source": "in_stock", "default": "out of stock"}
+            }
+        ).save()
+
+        payload_data = [
+            {
+                "id": "10539634",
+                "name": "Potter 4",
+                "description": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                "price": 8700,
+                "availability": "in stock",
+                "image_url": "https://picsum.photos/id/237/200/300",
+                "url": "https://www.kairon.com/",
+                "brand": "Test Restaurant",
+                "condition": "new"
+            },
+            {
+                "id": "10539699",
+                "name": "Potter 99",
+                "description": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                "price": 3426,
+                "availability": "in stock",
+                "image_url": "https://picsum.photos/id/237/200/300",
+                "url": "https://www.kairon.com/",
+                "brand": "Test Restaurant",
+                "condition": "new"
+            },
+            {
+                "id": "10539580",
+                "name": "Potter 5",
+                "description": "chicken fillet  nuggets come with a sauce of your choice (nugget/garlic sauce). Bite-sized pieces of tender all breast chicken fillets, marinated in our unique & signature blend, breaded and seasoned to perfection, then deep-fried until deliciously tender, crispy with a golden crust",
+                "price": 3159,
+                "availability": "in stock",
+                "image_url": "https://picsum.photos/id/237/200/300",
+                "url": "https://www.kairon.com/",
+                "brand": "Test Restaurant",
+                "condition": "new"
+            }
+        ]
+
+        processor  = MetaProcessor(catalog_id=catalog_id, access_token=access_token)
+        processed_data = processor.preprocess_data(bot, payload_data, method, provider)
+        expected_processed_data = [
+            {
+                "retailer_id": "10539634",
+                "data": {
+                    "currency": "INR",
+                    "name": "Potter 4",
+                    "description": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                    "price": 8700,
+                    "availability": "in stock",
+                    "image_url": "https://picsum.photos/id/237/200/300",
+                    "url": "https://www.kairon.com/",
+                    "brand": "Test Restaurant",
+                    "condition": "new"
+                },
+                "method": "CREATE",
+                "item_type": "PRODUCT_ITEM"
+            },
+            {
+                "retailer_id": "10539699",
+                "data": {
+                    "currency": "INR",
+                    "name": "Potter 99",
+                    "description": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                    "price": 3426,
+                    "availability": "in stock",
+                    "image_url": "https://picsum.photos/id/237/200/300",
+                    "url": "https://www.kairon.com/",
+                    "brand": "Test Restaurant",
+                    "condition": "new"
+                },
+                "method": "CREATE",
+                "item_type": "PRODUCT_ITEM"
+            },
+            {
+                "retailer_id": "10539580",
+                "data": {
+                    "currency": "INR",
+                    "name": "Potter 5",
+                    "description": "chicken fillet  nuggets come with a sauce of your choice (nugget/garlic sauce). Bite-sized pieces of tender all breast chicken fillets, marinated in our unique & signature blend, breaded and seasoned to perfection, then deep-fried until deliciously tender, crispy with a golden crust",
+                    "price": 3159,
+                    "availability": "in stock",
+                    "image_url": "https://picsum.photos/id/237/200/300",
+                    "url": "https://www.kairon.com/",
+                    "brand": "Test Restaurant",
+                    "condition": "new"
+                },
+                "method": "CREATE",
+                "item_type": "PRODUCT_ITEM"
+            }
+        ]
+
+        assert processed_data == expected_processed_data
+        CatalogProviderMapping.objects.delete()
+
+
+    def test_preprocess_data_update_success(self):
+        bot = "test_bot"
+        method = "UPDATE"
+        catalog_id = "12345"
+        access_token = "test_token"
+        provider = "petpooja"
+
+        CatalogProviderMapping(
+            provider=provider,
+            meta_mappings={
+                "name": {"source": "itemname", "default": "No title"},
+                "description": {"source": "itemdescription", "default": "No description available"},
+                "price": {"source": "price", "default": 0.0},
+                "availability": {"source": "in_stock", "default": "out of stock"},
+                "image_url": {"source": "item_image_url", "default": "https://www.kairon.com/default-image.jpg"},
+                "url": {"source": None, "default": "https://www.kairon.com/"},
+                "brand": {"source": None, "default": "Test Restaurant"},
+                "condition": {"source": None, "default": "new"}
+            },
+            kv_mappings={
+                "title": {"source": "itemname", "default": "No title"},
+                "description": {"source": "itemdescription", "default": "No description available"},
+                "price": {"source": "price", "default": 0.0},
+                "facebook_product_category": {"source": "item_categoryid", "default": "Food and drink > General"},
+                "availability": {"source": "in_stock", "default": "out of stock"}
+            }
+        ).save()
+
+        payload_data = [
+            {"id": "10539580", "availability": "out of stock"},
+            {"id": "10539634", "availability": "out of stock"},
+        ]
+
+        processor  = MetaProcessor(catalog_id=catalog_id, access_token=access_token)
+        processed_data = processor.preprocess_data(bot, payload_data, method, provider)
+        expected_processed_data = [
+            {
+                "retailer_id": "10539580",
+                "data": {
+                    "availability": "out of stock"
+                },
+                "method": "UPDATE",
+                "item_type": "PRODUCT_ITEM"
+            },
+            {
+                "retailer_id": "10539634",
+                "data": {
+                    "availability": "out of stock"
+                },
+                "method": "UPDATE",
+                "item_type": "PRODUCT_ITEM"
+            }
+        ]
+
+        assert processed_data == expected_processed_data
+        CatalogProviderMapping.objects.delete()
+
+    def test_preprocess_delete_data_success(self):
+        catalog_id = "12345"
+        access_token = "test_token"
+
+        payload_data = ['10539580','10539634']
+
+        processor  = MetaProcessor(catalog_id=catalog_id, access_token=access_token)
+        processed_data = processor.preprocess_delete_data(payload_data)
+        expected_processed_data = [
+            {'retailer_id': '10539580', 'method': 'DELETE'},
+            {'retailer_id': '10539634', 'method': 'DELETE'}
+        ]
+
+        assert processed_data == expected_processed_data
+        CatalogProviderMapping.objects.delete()
+
+    @pytest.mark.asyncio
+    async def test_push_meta_catalog_success(self):
+        access_token = "test_token"
+        catalog_id = "12345"
+
+        processor = MetaProcessor(access_token=access_token, catalog_id=catalog_id)
+
+        processor.processed_data = [
+            {
+                "retailer_id": "10539634",
+                "data": {
+                    "currency": "INR",
+                    "name": "Potter 4",
+                    "description": "Tasty item",
+                    "price": 8700,
+                    "availability": "in stock",
+                    "image_url": "https://picsum.photos/id/237/200/300",
+                    "url": "https://www.kairon.com/",
+                    "brand": "Test Restaurant",
+                    "condition": "new"
+                },
+                "method": "CREATE",
+                "item_type": "PRODUCT_ITEM"
+            },
+            {
+                "retailer_id": "1053963",
+                "data": {
+                    "currency": "INR",
+                    "name": "Potter 4",
+                    "description": "Tasty item",
+                    "price": 8700,
+                    "availability": "in stock",
+                    "image_url": "https://picsum.photos/id/237/200/300",
+                    "url": "https://www.kairon.com/",
+                    "brand": "Test Restaurant",
+                    "condition": "new"
+                },
+                "method": "CREATE",
+                "item_type": "PRODUCT_ITEM"
+            }
+        ]
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {'handles': ['Acy4vFScxA7q5jquK1vKf20tlbWuXEW0dqxj3aSHY68QLMZriJaMuojJummx1sZhqlfj5DdKxqBw09YQ9DWVT2-6']}
+
+        with patch("kairon.meta.processor.requests.post", return_value=mock_response) as mock_post:
+            await processor.push_meta_catalog()
+
+            assert mock_post.called is True
+            called_url = mock_post.call_args[0][0]
+            assert f"https://graph.facebook.com/v21.0/{catalog_id}/batch" in called_url
+
+            data_arg = mock_post.call_args[1]["data"]
+            assert data_arg["access_token"] == access_token
+
+            called_url = mock_post.call_args[0][0]
+            query_params = parse_qs(urlparse(called_url).query)
+            encoded_requests = query_params.get("requests")[0]
+            decoded_requests = json.loads(unquote(encoded_requests))
+
+            assert any(item.get("method") == "CREATE" for item in decoded_requests)
+
+    @pytest.mark.asyncio
+    async def test_push_meta_catalog_failure(self):
+        access_token = "test_token"
+        catalog_id = "12345"
+
+        processor = MetaProcessor(access_token=access_token, catalog_id=catalog_id)
+
+        processor.processed_data = [
+            {
+                "retailer_id": "10539634",
+                "data": {
+                    "currency": "INR",
+                    "name": "Potter 4",
+                    "price": 8700,
+                },
+                "method": "CREATE",
+                "item_type": "PRODUCT_ITEM"
+            }
+        ]
+
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "400 Client Error: Bad Request for url")
+
+        with patch("kairon.meta.processor.requests.post", return_value=mock_response):
+            with patch("kairon.meta.processor.logger") as mock_logger:
+                with pytest.raises(requests.exceptions.HTTPError):
+                    await processor.push_meta_catalog()
+
+                assert mock_logger.exception.called
+                log_message = mock_logger.exception.call_args[0][0]
+                assert "Error syncing product items to Meta catalog for push menu" in log_message
+
+    @pytest.mark.asyncio
+    async def test_update_meta_catalog_success(self):
+        access_token = "test_token"
+        catalog_id = "12345"
+
+        processor = MetaProcessor(access_token=access_token, catalog_id=catalog_id)
+
+        processor.processed_data = [
+            {
+                "retailer_id": "10539580",
+                "data": {
+                    "availability": "out of stock"
+                },
+                "method": "UPDATE",
+                "item_type": "PRODUCT_ITEM"
+            }
+        ]
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {'handles': ['Acy4vFScxA7q5jquK1vKf20tlbWuXEW0dqxj3aSHY68QLMZriJaMuojJummx1sZhqlfj5DdKxqBw09YQ9DWVT2-6']}
+
+        with patch("kairon.meta.processor.requests.post", return_value=mock_response) as mock_post:
+            await processor.update_meta_catalog()
+
+            assert mock_post.called is True
+            called_url = mock_post.call_args[0][0]
+            assert f"https://graph.facebook.com/v21.0/{catalog_id}/batch" in called_url
+
+            data_arg = mock_post.call_args[1]["data"]
+            assert data_arg["access_token"] == access_token
+
+            called_url = mock_post.call_args[0][0]
+            query_params = parse_qs(urlparse(called_url).query)
+            encoded_requests = query_params.get("requests")[0]
+            decoded_requests = json.loads(unquote(encoded_requests))
+
+            assert any(item.get("method") == "UPDATE" for item in decoded_requests)
+
+    @pytest.mark.asyncio
+    async def test_update_meta_catalog_failure(self):
+        access_token = "test_token"
+        catalog_id = "12345"
+
+        processor = MetaProcessor(access_token=access_token, catalog_id=catalog_id)
+
+        processor.processed_data = [
+            {
+                "retailer_id": "10539580",
+                "data": {
+                    "availability": "out of stock"
+                },
+                "method": "UPDATE",
+                "item_type": "PRODUCT_ITEM"
+            }
+        ]
+
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "400 Client Error: Bad Request for url")
+
+        with patch("kairon.meta.processor.requests.post", return_value=mock_response):
+            with patch("kairon.meta.processor.logger") as mock_logger:
+                with pytest.raises(requests.exceptions.HTTPError):
+                    await processor.update_meta_catalog()
+
+                assert mock_logger.exception.called
+                log_message = mock_logger.exception.call_args[0][0]
+                assert "Error syncing product items to Meta catalog for item toggle" in log_message
+
+    @pytest.mark.asyncio
+    async def test_delete_meta_catalog_success(self):
+        access_token = "test_token"
+        catalog_id = "12345"
+
+        processor = MetaProcessor(access_token=access_token, catalog_id=catalog_id)
+
+        delete_payload = [
+            {'retailer_id': '10539580', 'method': 'DELETE'},
+            {'retailer_id': '10539634', 'method': 'DELETE'}
+        ]
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {'handles': ['Acy4vFScxA7q5jquK1vKf20tlbWuXEW0dqxj3aSHY68QLMZriJaMuojJummx1sZhqlfj5DdKxqBw09YQ9DWVT2-6']}
+
+        with patch("kairon.meta.processor.requests.post", return_value=mock_response) as mock_post:
+            await processor.delete_meta_catalog(delete_payload)
+
+            assert mock_post.called is True
+            called_url = mock_post.call_args[0][0]
+            assert f"https://graph.facebook.com/v21.0/{catalog_id}/batch" in called_url
+
+            data_arg = mock_post.call_args[1]["data"]
+            assert data_arg["access_token"] == access_token
+
+            called_url = mock_post.call_args[0][0]
+            query_params = parse_qs(urlparse(called_url).query)
+            encoded_requests = query_params.get("requests")[0]
+            decoded_requests = json.loads(unquote(encoded_requests))
+
+            assert any(item.get("method") == "DELETE" for item in decoded_requests)
+
+    @pytest.mark.asyncio
+    async def test_delete_meta_catalog_failure(self):
+        access_token = "test_token"
+        catalog_id = "12345"
+
+        processor = MetaProcessor(access_token=access_token, catalog_id=catalog_id)
+
+        delete_payload = [
+            {'retailer_id': '10539580', 'method': 'DELETE'},
+            {'retailer_id': '10539634', 'method': 'DELETE'}
+        ]
+
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "400 Client Error: Bad Request for url")
+
+        with patch("kairon.meta.processor.requests.post", return_value=mock_response):
+            with patch("kairon.meta.processor.logger") as mock_logger:
+                with pytest.raises(requests.exceptions.HTTPError):
+                    await processor.delete_meta_catalog(delete_payload)
+
+                assert mock_logger.exception.called
+                log_message = mock_logger.exception.call_args[0][0]
+                assert "Error deleting data from meta" in log_message


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced catalog synchronization capabilities, including support for POS provider integration (e.g., Petpooja) and Meta (Facebook) catalog sync.
  - Added endpoints for catalog sync operations and reruns, with detailed logging and status tracking.
  - Enabled catalog sync status email notifications with a new customizable template.
  - Added configuration options for catalog sync limits and provider mappings.

- **Bug Fixes**
  - Improved validation and error handling for catalog sync requests and payloads.

- **Tests**
  - Added comprehensive unit tests for catalog sync logging, validation, and data processing.
  - Added new test data payloads for catalog sync scenarios.

- **Documentation**
  - Added new email template for catalog sync status notifications.

- **Chores**
  - Updated configuration files and data models to support catalog sync features and limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->