### PR TITLE
Move main pyscript into callback service new1

### DIFF
--- a/kairon/actions/definitions/pyscript.py
+++ b/kairon/actions/definitions/pyscript.py
@@ -66,7 +66,7 @@ class ActionPyscript(ActionsBase):
             dispatch_bot_response = pyscript_action_config['dispatch_response']
             source_code = pyscript_action_config['source_code']
             response = ActionUtility.run_pyscript(source_code, tracker_data)
-            dispatch_type = response.get('type')
+            dispatch_type = response.get('type',dispatch_type)
             bot_response = response.get('bot_response')
             slot_values = ActionUtility.filter_out_kairon_system_slots(response.get('slots', {}))
             filled_slots.update(slot_values)

--- a/kairon/async_callback/router/pyscript_callback.py
+++ b/kairon/async_callback/router/pyscript_callback.py
@@ -100,4 +100,4 @@ async def trigger_restricted_python(payload: PyscriptPayload):
         }, None)
         return {"success": True, **result}
     except Exception as e:
-        return json({"success": False, "error": str(e)}, status=500)
+        return json({"success": False, "error": str(e)}, status=422)

--- a/kairon/async_callback/utils.py
+++ b/kairon/async_callback/utils.py
@@ -128,14 +128,8 @@ class CallbackUtility:
 
     @staticmethod
     def main_pyscript_handler(event, context):
-        output = {
-            "statusCode": 200,
-            "statusDescription": "200 OK",
-            "isBase64Encoded": False,
-            "headers": {
-                "Content-Type": "application/json; charset=utf-8"
-            },
-            "body": None
+        output={
+            "statusCode":200
         }
         data = event
         if isinstance(data, list):

--- a/kairon/async_callback/utils.py
+++ b/kairon/async_callback/utils.py
@@ -1,46 +1,22 @@
-import pickle
-from calendar import timegm
 from datetime import datetime, date
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
-from smtplib import SMTP
-
-
 from blacksheep import JSONContent, TextContent, Response as BSResponse
 from requests import Response
 from functools import partial
 from types import ModuleType
-from typing import Text, Dict, Callable, List
+from typing import Text, Dict, Callable
 import requests
 from AccessControl.SecurityInfo import allow_module
-from apscheduler.triggers.date import DateTrigger
-from apscheduler.util import obj_to_ref, astimezone
-from bson import Binary
-from pymongo import MongoClient
 from RestrictedPython.Guards import safer_getattr
 import orjson as json
-from tzlocal import get_localzone
-from uuid6 import uuid7
 from loguru import logger
-
-from kairon import Utility
 from kairon.api.app.routers.bot.data import CognitionDataProcessor
-from kairon.events.executors.factory import ExecutorFactory
-from kairon.exceptions import AppException
-from kairon.shared.actions.utils import ActionUtility
-from kairon.shared.actions.data_objects import EmailActionConfig
-from kairon.shared.callback.data_objects import CallbackConfig, CallbackData, CallbackResponseType
-from kairon.shared.chat.user_media import UserMedia
-from kairon.shared.cognition.data_objects import CollectionData
+from kairon.shared.callback.data_objects import CallbackResponseType
 from kairon.shared.concurrency.orchestrator import ActorOrchestrator
 from kairon.shared.constants import ActorType
 
-import json as jsond
-import base64
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-from cryptography.hazmat.primitives.asymmetric import padding as asym_padding
-from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+from kairon.shared.pyscript.callback_pyscript_utils import CallbackScriptUtility
+from kairon.shared.pyscript.shared_pyscript_utils import PyscriptSharedUtility
 
 allow_module("datetime")
 allow_module("time")
@@ -53,186 +29,6 @@ cognition_processor = CognitionDataProcessor()
 
 
 class CallbackUtility:
-
-    @staticmethod
-    def generate_id():
-        return uuid7().hex
-
-    @staticmethod
-    def datetime_to_utc_timestamp(timeval):
-        """
-        Converts a datetime instance to a timestamp.
-
-        :type timeval: datetime
-        :rtype: float
-
-        """
-        if timeval is not None:
-            return timegm(timeval.utctimetuple()) + timeval.microsecond / 1000000
-
-    @staticmethod
-    def add_schedule_job(schedule_action: Text, date_time: datetime, data: Dict, timezone: Text, _id: Text = None,
-                         bot: Text = None, kwargs=None):
-
-        if not bot:
-            raise AppException("Missing bot id")
-
-        if not _id:
-            _id = uuid7().hex
-
-        if not data:
-            data = {}
-
-        data['bot'] = bot
-        data['event'] = _id
-
-        callback_config = CallbackConfig.get_entry(bot=bot, name=schedule_action)
-
-        script = callback_config.get('pyscript_code')
-
-        func = obj_to_ref(ExecutorFactory.get_executor().execute_task)
-
-        schedule_data = {
-            'source_code': script,
-            'predefined_objects': data
-        }
-
-        args = (func, "scheduler_evaluator", schedule_data,)
-        kwargs = {'task_type': "Callback"} if kwargs is None else {**kwargs, 'task_type': "Callback"}
-        trigger = DateTrigger(run_date=date_time, timezone=timezone)
-
-        next_run_time = trigger.get_next_fire_time(None, datetime.now(astimezone(timezone) or get_localzone()))
-
-        job_kwargs = {
-            'version': 1,
-            'trigger': trigger,
-            'executor': "default",
-            'func': func,
-            'args': tuple(args) if args is not None else (),
-            'kwargs': kwargs,
-            'id': _id,
-            'name': "execute_task",
-            'misfire_grace_time': 7200,
-            'coalesce': True,
-            'next_run_time': next_run_time,
-            'max_instances': 1,
-        }
-
-        logger.info(job_kwargs)
-
-        client = MongoClient(Utility.environment['database']['url'])
-        events_db_name = Utility.environment["events"]["queue"]["name"]
-        events_db = client.get_database(events_db_name)
-        scheduler_collection = Utility.environment["events"]["scheduler"]["collection"]
-        job_store_name = events_db.get_collection(scheduler_collection)
-        event_server = Utility.environment['events']['server_url']
-
-        job_store_name.insert_one({
-            '_id': _id,
-            'next_run_time': CallbackUtility.datetime_to_utc_timestamp(next_run_time),
-            'job_state': Binary(pickle.dumps(job_kwargs, pickle.HIGHEST_PROTOCOL))
-        })
-
-        http_response = ActionUtility.execute_http_request(
-            f"{event_server}/api/events/dispatch/{_id}",
-            "GET")
-
-        if not http_response.get("success"):
-            raise AppException(http_response)
-        else:
-            logger.info(http_response)
-
-    @staticmethod
-    def delete_schedule_job(event_id: Text, bot: Text):
-        if not bot:
-            raise AppException("Missing bot id")
-
-        if not event_id:
-            raise AppException("Missing event id")
-
-        logger.info(f"event: {event_id}, bot: {bot}")
-
-        event_server = Utility.environment['events']['server_url']
-
-        http_response = ActionUtility.execute_http_request(
-            f"{event_server}/api/events/{event_id}",
-            "DELETE")
-
-        if not http_response.get("success"):
-            raise AppException(http_response)
-        else:
-            logger.info(http_response)
-
-    def trigger_email(
-            email: List[str],
-            subject: str,
-            body: str,
-            smtp_url: str,
-            smtp_port: int,
-            sender_email: str,
-            smtp_password: str,
-            smtp_userid: str = None,
-            tls: bool = False,
-            content_type="html",
-    ):
-        """
-        This is a sync email trigger.
-        Sends an email to the mail id of the recipient
-
-        :param smtp_userid:
-        :param sender_email:
-        :param tls:
-        :param smtp_port:
-        :param smtp_url:
-        :param email: the mail id of the recipient
-        :param smtp_password:
-        :param subject: the subject of the mail
-        :param body: the body of the mail
-        :param content_type: "plain" or "html" content
-        :return: None
-        """
-        smtp = SMTP(smtp_url, port=smtp_port, timeout=10)
-        smtp.connect(smtp_url, smtp_port)
-        if tls:
-            smtp.starttls()
-        smtp.login(smtp_userid if smtp_userid else sender_email, smtp_password)
-        from_addr = sender_email
-        body = MIMEText(body, content_type)
-        msg = MIMEMultipart("alternative")
-        msg["Subject"] = subject
-        msg["From"] = from_addr
-        msg["To"] = ",".join(email)
-        msg.attach(body)
-        smtp.sendmail(from_addr, email, msg.as_string())
-        smtp.quit()
-
-    @staticmethod
-    def send_email(email_action: Text,
-                   from_email: Text,
-                   to_email: Text,
-                   subject:  Text,
-                   body: Text,
-                   bot: Text):
-        if not bot:
-            raise AppException("Missing bot id")
-
-        email_action_config = EmailActionConfig.objects(bot=bot, action_name=email_action).first()
-        action_config = email_action_config.to_mongo().to_dict()
-
-        smtp_password = action_config.get('smtp_password').get("value")
-        smtp_userid = action_config.get('smtp_userid').get("value")
-
-        CallbackUtility.trigger_email(
-            email=[to_email],
-            subject=subject,
-            body=body,
-            smtp_url=action_config['smtp_url'],
-            smtp_port=action_config['smtp_port'],
-            sender_email=from_email,
-            smtp_password=smtp_password,
-            smtp_userid=smtp_userid,
-            tls=action_config['tls']
-        )
 
     @staticmethod
     def perform_cleanup(local_vars: Dict):
@@ -267,23 +63,23 @@ class CallbackUtility:
         predefined_objects['requests']=requests
         predefined_objects['json'] = json
         predefined_objects['datetime']= datetime
-        predefined_objects['add_schedule_job'] = partial(CallbackUtility.add_schedule_job, bot=bot)
-        predefined_objects['delete_schedule_job'] = partial(CallbackUtility.delete_schedule_job, bot=bot)
-        predefined_objects['send_email'] = partial(CallbackUtility.send_email, bot=bot)
-        predefined_objects['add_data'] = partial(CallbackUtility.add_data, bot=bot)
-        predefined_objects['get_data'] = partial(CallbackUtility.get_data, bot=bot)
-        predefined_objects['delete_data'] = partial(CallbackUtility.delete_data, bot=bot)
-        predefined_objects['update_data'] = partial(CallbackUtility.update_data, bot=bot)
-        predefined_objects["generate_id"] = CallbackUtility.generate_id
-        predefined_objects["datetime_to_utc_timestamp"]=CallbackUtility.datetime_to_utc_timestamp
-        predefined_objects['decrypt_request'] = CallbackUtility.decrypt_request
-        predefined_objects['encrypt_response'] = CallbackUtility.encrypt_response
-        predefined_objects['create_callback'] = partial(CallbackUtility.create_callback,
+        predefined_objects['add_schedule_job'] = partial(CallbackScriptUtility.add_schedule_job, bot=bot)
+        predefined_objects['delete_schedule_job'] = partial(PyscriptSharedUtility.delete_schedule_job, bot=bot)
+        predefined_objects['send_email'] = partial(CallbackScriptUtility.send_email, bot=bot)
+        predefined_objects['add_data'] = partial(PyscriptSharedUtility.add_data, bot=bot)
+        predefined_objects['get_data'] = partial(PyscriptSharedUtility.get_data, bot=bot)
+        predefined_objects['delete_data'] = partial(PyscriptSharedUtility.delete_data, bot=bot)
+        predefined_objects['update_data'] = partial(PyscriptSharedUtility.update_data, bot=bot)
+        predefined_objects["generate_id"] = CallbackScriptUtility.generate_id
+        predefined_objects["datetime_to_utc_timestamp"]=CallbackScriptUtility.datetime_to_utc_timestamp
+        predefined_objects['decrypt_request'] = CallbackScriptUtility.decrypt_request
+        predefined_objects['encrypt_response'] = CallbackScriptUtility.encrypt_response
+        predefined_objects['create_callback'] = partial(CallbackScriptUtility.create_callback,
                                                             bot=bot,
                                                             sender_id=sender_id,
                                                            channel=channel)
-        predefined_objects['save_as_pdf'] = partial(CallbackUtility.save_as_pdf,bot=bot, sender_id=sender_id)
-
+        predefined_objects['save_as_pdf'] = partial(CallbackScriptUtility.save_as_pdf,
+                                                            bot=bot, sender_id=sender_id)
         script_variables = ActorOrchestrator.run(
             ActorType.pyscript_runner.value, source_code=source_code, timeout=60,
             predefined_objects=predefined_objects
@@ -297,7 +93,7 @@ class CallbackUtility:
             "statusDescription": "200 OK",
             "isBase64Encoded": False,
             "headers": {
-                "Content-Type": "text/html; charset=utf-8"
+                "Content-Type": "application/json; charset=utf-8"
             },
             "body": None
         }
@@ -316,168 +112,44 @@ class CallbackUtility:
         return output
 
     @staticmethod
-    def fetch_collection_data(query: dict):
-        collection_data = CollectionData.objects(**query)
+    def execute_main_pyscript(source_code: Text, predefined_objects: Dict = None):
+        logger.info(source_code)
+        logger.info(predefined_objects)
 
-        for value in collection_data:
-            final_data = {}
-            item = value.to_mongo().to_dict()
-            collection_name = item.pop('collection_name', None)
-            is_secure = item.pop('is_secure')
-            data = item.pop('data')
-            data = cognition_processor.prepare_decrypted_data(data, is_secure)
-
-            final_data["_id"] = str(item["_id"])
-            final_data['collection_name'] = collection_name
-            final_data['is_secure'] = is_secure
-            final_data['timestamp'] = item.get("timestamp")
-            final_data['data'] = data
-
-            yield final_data
-
-    @staticmethod
-    def get_data(collection_name: str, user: str, data_filter: dict, bot: Text = None, kwargs=None):
-        if not bot:
-            raise Exception("Missing bot id")
-
-        collection_name = collection_name.lower()
-
-        query = {"bot": bot, "collection_name": collection_name}
-
-        start_time = kwargs.pop("start_time", None) if kwargs else None
-        end_time = kwargs.pop("end_time", None) if kwargs else None
-        if start_time:
-            query["timestamp__gte"] = start_time
-        if end_time:
-            query["timestamp__lte"] = end_time
-
-        query.update({f"data__{key}": value for key, value in data_filter.items()})
-        data = list(CallbackUtility.fetch_collection_data(query))
-        return {"data": data}
-
-    @staticmethod
-    def add_data(user: str, payload: dict, bot: str = None):
-        if not bot:
-            raise Exception("Missing bot id")
-
-        collection_id = cognition_processor.save_collection_data(payload, user, bot)
-        return {
-            "message": "Record saved!",
-            "data": {"_id": collection_id}
-        }
-
-    @staticmethod
-    def update_data(collection_id: str, user: str, payload: dict, bot: str = None):
-        if not bot:
-            raise Exception("Missing bot id")
-
-        collection_id = cognition_processor.update_collection_data(collection_id, payload, user, bot)
-        return {
-            "message": "Record updated!",
-            "data": {"_id": collection_id}
-        }
-
-    @staticmethod
-    def delete_data(collection_id: str, user: Text, bot: Text = None):
-        if not bot:
-            raise Exception("Missing bot id")
-
-        cognition_processor.delete_collection_data(collection_id, bot, user)
-
-        return {
-            "message": f"Collection with ID {collection_id} has been successfully deleted.",
-            "data": {"_id": collection_id}
-        }
-
-    @staticmethod
-    def decrypt_request(request_body, private_key_pem):
-        try:
-            encrypted_data_b64 = request_body.get("encrypted_flow_data")
-            encrypted_aes_key_b64 = request_body.get("encrypted_aes_key")
-            iv_b64 = request_body.get("initial_vector")
-
-            if not (encrypted_data_b64 and encrypted_aes_key_b64 and iv_b64):
-                raise ValueError("Missing required encrypted data fields")
-
-            # Decode base64 inputs
-            encrypted_aes_key = base64.b64decode(encrypted_aes_key_b64)
-            encrypted_data = base64.b64decode(encrypted_data_b64)
-            iv = base64.b64decode(iv_b64)[:16]  # Ensure IV is exactly 16 bytes
-
-            private_key = load_pem_private_key(private_key_pem.encode(), password=None)
-
-            # Decrypt AES key using RSA and OAEP padding
-            aes_key = private_key.decrypt(
-                encrypted_aes_key,
-                asym_padding.OAEP(
-                    mgf=asym_padding.MGF1(algorithm=hashes.SHA256()),
-                    algorithm=hashes.SHA256(),
-                    label=None,
-                ),
-            )
-
-            if len(aes_key) not in (16, 24, 32):
-                raise ValueError(f"Invalid AES key size: {len(aes_key)} bytes")
-
-            # Extract GCM tag (last 16 bytes)
-            encrypted_body = encrypted_data[:-16]
-            tag = encrypted_data[-16:]
-
-            # Decrypt AES-GCM
-            cipher = Cipher(algorithms.AES(aes_key), modes.GCM(iv, tag))
-            decryptor = cipher.decryptor()
-            decrypted_bytes = decryptor.update(encrypted_body) + decryptor.finalize()
-            decrypted_data = jsond.loads(decrypted_bytes.decode("utf-8"))
-
-            response_dict = {
-                "decryptedBody": decrypted_data,
-                "aesKeyBuffer": aes_key,
-                "initialVectorBuffer": iv,
-            }
-
-            return response_dict
-
-        except Exception as e:
-            raise Exception(f"decryption failed-{str(e)}")
-
-    @staticmethod
-    def encrypt_response(response_body, aes_key_buffer, initial_vector_buffer):
-        try:
-            if aes_key_buffer is None:
-                raise ValueError("AES key cannot be None")
-
-            if initial_vector_buffer is None:
-                raise ValueError("Initialization vector (IV) cannot be None")
-
-            # Flip the IV
-            flipped_iv = bytes(byte ^ 0xFF for byte in initial_vector_buffer)
-
-            # Encrypt using AES-GCM
-            encryptor = Cipher(algorithms.AES(aes_key_buffer), modes.GCM(flipped_iv)).encryptor()
-            encrypted_bytes = encryptor.update(jsond.dumps(response_body).encode("utf-8")) + encryptor.finalize()
-            encrypted_data_with_tag = encrypted_bytes + encryptor.tag
-
-            # Encode result as base64
-            encoded_data = base64.b64encode(encrypted_data_with_tag).decode("utf-8")
-            return encoded_data
-        except Exception as e:
-            raise Exception(f"encryption failed-{str(e)}")
+        if not predefined_objects:
+            predefined_objects = {}
 
 
-    @staticmethod
-    def create_callback(callback_name: str, metadata: dict, bot: str, sender_id: str, channel: str, name: str='callback_pyscript'):
-        callback_url, identifier, standalone = CallbackData.create_entry(
-            name=name,
-            callback_config_name=callback_name,
-            bot=bot,
-            sender_id=sender_id,
-            channel=channel,
-            metadata=metadata,
+        script_variables = ActorOrchestrator.run(
+            ActorType.pyscript_runner.value, source_code=source_code, timeout=60,
+            predefined_objects=predefined_objects
         )
-        if standalone:
-            return identifier
-        else:
-            return callback_url
+        return script_variables
+
+    @staticmethod
+    def main_pyscript_handler(event, context):
+        output = {
+            "statusCode": 200,
+            "statusDescription": "200 OK",
+            "isBase64Encoded": False,
+            "headers": {
+                "Content-Type": "application/json; charset=utf-8"
+            },
+            "body": None
+        }
+        data = event
+        if isinstance(data, list):
+            data = {item['name'].lower(): item['value'] for item in data}
+        try:
+            response = CallbackUtility.execute_main_pyscript(data['source_code'], data.get('predefined_objects'))
+            output["body"] = response
+        except Exception as e:
+            logger.exception(e)
+            output["statusCode"] = 422
+            output["body"] = str(e)
+
+        logger.info(output)
+        return output
 
     @staticmethod
     def return_response(data: any, message : str, error_code: int, response_type: str):
@@ -502,17 +174,4 @@ class CallbackUtility:
                 status=resp_status_code,
                 content=TextContent(str(data))
             )
-
-    @staticmethod
-    def save_as_pdf(text: str, bot: str, sender_id:str):
-        try:
-            _, media_id = UserMedia.save_markdown_as_pdf(
-                bot=bot,
-                sender_id=sender_id,
-                text=text,
-                filepath="report.pdf"
-            )
-            return media_id
-        except Exception as e:
-            raise Exception(f"encryption failed-{str(e)}")
 

--- a/kairon/shared/actions/utils.py
+++ b/kairon/shared/actions/utils.py
@@ -680,7 +680,6 @@ class ActionUtility:
     @staticmethod
     def run_pyscript(source_code: Text, context: dict):
         trigger_task = Utility.environment['evaluator']['pyscript']['trigger_task']
-        pyscript_evaluator_url = Utility.environment['evaluator']['pyscript']['url']
         request_body = {"source_code": source_code, "predefined_objects": context}
 
         if trigger_task:
@@ -691,10 +690,19 @@ class ActionUtility:
                 raise ActionFailure(f"{err}")
             result = lambda_response["Payload"].get('body')
         else:
-            resp = ActionUtility.execute_http_request(pyscript_evaluator_url, "POST", request_body)
-            if resp.get('error_code') != 0:
+            callback_url=Utility.environment['async_callback_action']['pyscript']['url']
+            resp = Utility.execute_http_request(
+                "POST",
+                http_url=callback_url,
+                request_body={
+                    "source_code": source_code,
+                    "predefined_objects": context
+                },
+                headers={"Content-Type": "application/json"}
+            )
+            if resp.get('statusCode') != 200:
                 raise ActionFailure(f'Pyscript evaluation failed: {resp}')
-            result = resp.get('data')
+            result = resp.get('body')
 
         return result
 

--- a/kairon/shared/callback/data_objects.py
+++ b/kairon/shared/callback/data_objects.py
@@ -2,8 +2,10 @@ import base64
 import time
 from datetime import datetime
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, Dict
 import json
+
+from pydantic import BaseModel
 from uuid6 import uuid7
 
 from mongoengine import StringField, DictField, DateTimeField, Document, DynamicField, IntField, BooleanField, \
@@ -436,3 +438,9 @@ class CallbackLog(Document):
         total = CallbackLog.objects(**query).count()
         return logs_dict_list, total
 
+class PyscriptPayload(BaseModel):
+    """
+    Incoming JSON payload for restricted-Python execution.
+    """
+    source_code: str
+    predefined_objects: Optional[Dict[str, Any]] = None

--- a/kairon/shared/concurrency/actors/utils.py
+++ b/kairon/shared/concurrency/actors/utils.py
@@ -7,6 +7,7 @@ from urllib import parse
 import litellm
 import requests
 from loguru import logger
+from orjson import orjson
 from tiktoken import get_encoding
 from urllib.parse import urljoin
 
@@ -171,3 +172,9 @@ class PyscriptUtility:
             logger.info(response)
         print(http_response)
         return response
+
+    @staticmethod
+    def send_waba_message(payload: dict, key: Text, bot: str, predefined_objects: dict):
+        waba_url = "https://waba-v2.360dialog.io/messages"
+        headers = {"D360-API-KEY": key, "Content-TYpe": "application/json"}
+        return requests.post(url=waba_url, headers=headers, data=orjson.dumps(payload)).json

--- a/kairon/shared/pyscript/callback_pyscript_utils.py
+++ b/kairon/shared/pyscript/callback_pyscript_utils.py
@@ -1,0 +1,333 @@
+import pickle
+from calendar import timegm
+from datetime import datetime, date
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from smtplib import SMTP
+from typing import Text, Dict, Callable, List
+import base64
+from apscheduler.triggers.date import DateTrigger
+from apscheduler.util import obj_to_ref, astimezone
+from pymongo import MongoClient
+from tzlocal import get_localzone
+from uuid6 import uuid7
+from loguru import logger
+from kairon import Utility
+from kairon.events.executors.factory import ExecutorFactory
+from kairon.exceptions import AppException
+from kairon.shared.actions.data_objects import EmailActionConfig
+from kairon.shared.actions.utils import ActionUtility
+from bson import Binary
+from types import ModuleType
+from requests import Response
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.asymmetric import padding as asym_padding
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from kairon.shared.callback.data_objects import CallbackConfig, CallbackData
+import json as jsond
+
+from kairon.shared.chat.user_media import UserMedia
+
+
+class CallbackScriptUtility:
+
+    @staticmethod
+    def generate_id():
+        return uuid7().hex
+
+
+    @staticmethod
+    def datetime_to_utc_timestamp(timeval):
+        """
+        Converts a datetime instance to a timestamp.
+
+        :type timeval: datetime
+        :rtype: float
+
+        """
+        if timeval is not None:
+            return timegm(timeval.utctimetuple()) + timeval.microsecond / 1000000
+
+
+    @staticmethod
+    def add_schedule_job(schedule_action: Text, date_time: datetime, data: Dict, timezone: Text, _id: Text = None,
+                         bot: Text = None, kwargs=None):
+        if not bot:
+            raise AppException("Missing bot id")
+
+        if not _id:
+            _id = uuid7().hex
+
+        if not data:
+            data = {}
+
+        data['bot'] = bot
+        data['event'] = _id
+
+        callback_config = CallbackConfig.get_entry(bot=bot, name=schedule_action)
+
+        script = callback_config.get('pyscript_code')
+
+        func = obj_to_ref(ExecutorFactory.get_executor().execute_task)
+
+        schedule_data = {
+            'source_code': script,
+            'predefined_objects': data
+        }
+
+        args = (func, "scheduler_evaluator", schedule_data,)
+        kwargs = {'task_type': "Callback"} if kwargs is None else {**kwargs, 'task_type': "Callback"}
+        trigger = DateTrigger(run_date=date_time, timezone=timezone)
+
+        next_run_time = trigger.get_next_fire_time(None, datetime.now(astimezone(timezone) or get_localzone()))
+
+        job_kwargs = {
+            'version': 1,
+            'trigger': trigger,
+            'executor': "default",
+            'func': func,
+            'args': tuple(args) if args is not None else (),
+            'kwargs': kwargs,
+            'id': _id,
+            'name': "execute_task",
+            'misfire_grace_time': 7200,
+            'coalesce': True,
+            'next_run_time': next_run_time,
+            'max_instances': 1,
+        }
+
+        logger.info(job_kwargs)
+
+        client = MongoClient(Utility.environment['database']['url'])
+        events_db_name = Utility.environment["events"]["queue"]["name"]
+        events_db = client.get_database(events_db_name)
+        scheduler_collection = Utility.environment["events"]["scheduler"]["collection"]
+        job_store_name = events_db.get_collection(scheduler_collection)
+        event_server = Utility.environment['events']['server_url']
+
+        job_store_name.insert_one({
+            '_id': _id,
+            'next_run_time': CallbackScriptUtility.datetime_to_utc_timestamp(next_run_time),
+            'job_state': Binary(pickle.dumps(job_kwargs, pickle.HIGHEST_PROTOCOL))
+        })
+
+        http_response = ActionUtility.execute_http_request(
+            f"{event_server}/api/events/dispatch/{_id}",
+            "GET")
+
+        if not http_response.get("success"):
+            raise AppException(http_response)
+        else:
+            logger.info(http_response)
+
+    @staticmethod
+    def trigger_email(
+                email: List[str],
+                subject: str,
+                body: str,
+                smtp_url: str,
+                smtp_port: int,
+                sender_email: str,
+                smtp_password: str,
+                smtp_userid: str = None,
+                tls: bool = False,
+                content_type="html",
+        ):
+            """
+            This is a sync email trigger.
+            Sends an email to the mail id of the recipient
+
+            :param smtp_userid:
+            :param sender_email:
+            :param tls:
+            :param smtp_port:
+            :param smtp_url:
+            :param email: the mail id of the recipient
+            :param smtp_password:
+            :param subject: the subject of the mail
+            :param body: the body of the mail
+            :param content_type: "plain" or "html" content
+            :return: None
+            """
+            smtp = None
+            try:
+                smtp = SMTP(smtp_url, port=smtp_port, timeout=10)
+                smtp.connect(smtp_url, smtp_port)
+                if tls:
+                    smtp.starttls()
+                smtp.login(smtp_userid if smtp_userid else sender_email, smtp_password)
+
+                from_addr = sender_email
+                mime_body = MIMEText(body, content_type)
+                msg = MIMEMultipart("alternative")
+                msg["Subject"] = subject
+                msg["From"] = from_addr
+                msg["To"] = ",".join(email)
+                msg.attach(mime_body)
+
+                smtp.sendmail(from_addr, email, msg.as_string())
+
+            except Exception as e:
+                print(f"Failed to send email: {e}")
+                raise
+            finally:
+                if smtp:
+                    try:
+                        smtp.quit()
+                    except Exception as quit_error:
+                        print(f"Failed to quit SMTP connection cleanly: {quit_error}")
+
+
+    @staticmethod
+    def send_email(email_action: Text,
+                   from_email: Text,
+                   to_email: Text,
+                   subject:  Text,
+                   body: Text,
+                   bot: Text):
+        if not bot:
+            raise AppException("Missing bot id")
+
+        email_action_config = EmailActionConfig.objects(bot=bot, action_name=email_action).first()
+        if not email_action_config:
+            raise AppException(f"Email action '{email_action}' not configured for bot {bot}")
+        action_config = email_action_config.to_mongo().to_dict()
+
+        smtp_password = action_config.get('smtp_password').get("value")
+        smtp_userid = action_config.get('smtp_userid').get("value")
+
+        CallbackScriptUtility.trigger_email(
+            email=[to_email],
+            subject=subject,
+            body=body,
+            smtp_url=action_config['smtp_url'],
+            smtp_port=action_config['smtp_port'],
+            sender_email=from_email,
+            smtp_password=smtp_password,
+            smtp_userid=smtp_userid,
+            tls=action_config['tls']
+        )
+
+    @staticmethod
+    def perform_cleanup(local_vars: Dict):
+        logger.info(f"local_vars: {local_vars}")
+        filtered_locals = {}
+        if local_vars:
+            for key, value in local_vars.items():
+                if not isinstance(value, Callable) and not isinstance(value, ModuleType):
+                    if isinstance(value, datetime):
+                        value = value.strftime("%m/%d/%Y, %H:%M:%S")
+                    elif isinstance(value, date):
+                        value = value.strftime("%Y-%m-%d")
+                    elif isinstance(value, Response):
+                        value = value.text
+                    filtered_locals[key] = value
+        logger.info(f"filtered_vars: {filtered_locals}")
+        return filtered_locals
+
+
+    @staticmethod
+    def decrypt_request(request_body, private_key_pem):
+        try:
+            encrypted_data_b64 = request_body.get("encrypted_flow_data")
+            encrypted_aes_key_b64 = request_body.get("encrypted_aes_key")
+            iv_b64 = request_body.get("initial_vector")
+
+            if not (encrypted_data_b64 and encrypted_aes_key_b64 and iv_b64):
+                raise ValueError("Missing required encrypted data fields")
+
+            # Decode base64 inputs
+            encrypted_aes_key = base64.b64decode(encrypted_aes_key_b64)
+            encrypted_data = base64.b64decode(encrypted_data_b64)
+            iv = base64.b64decode(iv_b64)[:16]  # Ensure IV is exactly 16 bytes
+
+            private_key = load_pem_private_key(private_key_pem.encode(), password=None)
+
+            # Decrypt AES key using RSA and OAEP padding
+            aes_key = private_key.decrypt(
+                encrypted_aes_key,
+                asym_padding.OAEP(
+                    mgf=asym_padding.MGF1(algorithm=hashes.SHA256()),
+                    algorithm=hashes.SHA256(),
+                    label=None,
+                ),
+            )
+
+            if len(aes_key) not in (16, 24, 32):
+                raise ValueError(f"Invalid AES key size: {len(aes_key)} bytes")
+
+            # Extract GCM tag (last 16 bytes)
+            encrypted_body = encrypted_data[:-16]
+            tag = encrypted_data[-16:]
+
+            # Decrypt AES-GCM
+            cipher = Cipher(algorithms.AES(aes_key), modes.GCM(iv, tag))
+            decryptor = cipher.decryptor()
+            decrypted_bytes = decryptor.update(encrypted_body) + decryptor.finalize()
+            decrypted_data = jsond.loads(decrypted_bytes.decode("utf-8"))
+
+            response_dict = {
+                "decryptedBody": decrypted_data,
+                "aesKeyBuffer": aes_key,
+                "initialVectorBuffer": iv,
+            }
+
+            return response_dict
+
+        except Exception as e:
+            raise Exception(f"decryption failed-{str(e)}")
+
+
+    @staticmethod
+    def encrypt_response(response_body, aes_key_buffer, initial_vector_buffer):
+        try:
+            if aes_key_buffer is None:
+                raise ValueError("AES key cannot be None")
+
+            if initial_vector_buffer is None:
+                raise ValueError("Initialization vector (IV) cannot be None")
+
+            # Flip the IV
+            flipped_iv = bytes(byte ^ 0xFF for byte in initial_vector_buffer)
+
+            # Encrypt using AES-GCM
+            encryptor = Cipher(algorithms.AES(aes_key_buffer), modes.GCM(flipped_iv)).encryptor()
+            encrypted_bytes = encryptor.update(jsond.dumps(response_body).encode("utf-8")) + encryptor.finalize()
+            encrypted_data_with_tag = encrypted_bytes + encryptor.tag
+
+            # Encode result as base64
+            encoded_data = base64.b64encode(encrypted_data_with_tag).decode("utf-8")
+            return encoded_data
+        except Exception as e:
+            raise Exception(f"encryption failed-{str(e)}")
+
+
+    @staticmethod
+    def create_callback(callback_name: str, metadata: dict, bot: str, sender_id: str, channel: str,
+                        name: str = 'callback_pyscript'):
+        callback_url, identifier, standalone = CallbackData.create_entry(
+            name=name,
+            callback_config_name=callback_name,
+            bot=bot,
+            sender_id=sender_id,
+            channel=channel,
+            metadata=metadata,
+        )
+        if standalone:
+            return identifier
+        else:
+            return callback_url
+
+    @staticmethod
+    def save_as_pdf(text: str, bot: str, sender_id:str):
+        try:
+            _, media_id = UserMedia.save_markdown_as_pdf(
+                bot=bot,
+                sender_id=sender_id,
+                text=text,
+                filepath="report.pdf"
+            )
+            return media_id
+        except Exception as e:
+            raise Exception(f"encryption failed-{str(e)}")

--- a/kairon/shared/pyscript/shared_pyscript_utils.py
+++ b/kairon/shared/pyscript/shared_pyscript_utils.py
@@ -1,4 +1,3 @@
-from typing import Text, Dict, Callable, List
 from typing import Text
 from loguru import logger
 from kairon import Utility

--- a/kairon/shared/pyscript/shared_pyscript_utils.py
+++ b/kairon/shared/pyscript/shared_pyscript_utils.py
@@ -1,0 +1,111 @@
+from typing import Text, Dict, Callable, List
+from typing import Text
+from loguru import logger
+from kairon import Utility
+from kairon.exceptions import AppException
+from kairon.shared.actions.utils import ActionUtility
+from kairon.shared.cognition.data_objects import CollectionData
+from kairon.api.app.routers.bot.data import CognitionDataProcessor
+cognition_processor = CognitionDataProcessor()
+
+class PyscriptSharedUtility:
+
+    @staticmethod
+    def fetch_collection_data(query: dict):
+
+        collection_data = CollectionData.objects(__raw__= query)
+
+        for value in collection_data:
+            final_data = {}
+            item = value.to_mongo().to_dict()
+            collection_name = item.pop('collection_name', None)
+            is_secure = item.pop('is_secure')
+            data = item.pop('data')
+            data = cognition_processor.prepare_decrypted_data(data, is_secure)
+
+            final_data["_id"] = str(item["_id"])
+            final_data['collection_name'] = collection_name
+            final_data['is_secure'] = is_secure
+            final_data['timestamp'] = item.get("timestamp")
+            final_data['data'] = data
+
+            yield final_data
+
+
+    @staticmethod
+    def get_data(collection_name: str, user: str, data_filter: dict, bot: Text = None,kwargs=None):
+        if not bot:
+            raise Exception("Missing bot id")
+
+        collection_name = collection_name.lower()
+        query = {"bot": bot, "collection_name": collection_name}
+        start_time = kwargs.pop("start_time", None) if kwargs else None
+        end_time = kwargs.pop("end_time", None) if kwargs else None
+        if start_time:
+            query["timestamp__gte"] = start_time
+        if end_time:
+            query["timestamp__lte"] = end_time
+        if data_filter.get("raw_query"):
+            query.update(data_filter.get("raw_query"))
+        else:
+            query.update({f"data.{key}": value for key, value in data_filter.items()})
+        data = list(PyscriptSharedUtility.fetch_collection_data(query))
+        return {"data": data}
+
+
+    @staticmethod
+    def add_data(user: str, payload: dict, bot: str = None):
+        if not bot:
+            raise Exception("Missing bot id")
+
+        collection_id = cognition_processor.save_collection_data(payload, user, bot)
+        return {
+            "message": "Record saved!",
+            "data": {"_id": collection_id}
+        }
+
+
+    @staticmethod
+    def update_data(collection_id: str, user: str, payload: dict, bot: str = None):
+        if not bot:
+            raise Exception("Missing bot id")
+
+        collection_id = cognition_processor.update_collection_data(collection_id, payload, user, bot)
+        return {
+            "message": "Record updated!",
+            "data": {"_id": collection_id}
+        }
+
+
+    @staticmethod
+    def delete_data(collection_id: str, user: Text, bot: Text = None):
+        if not bot:
+            raise Exception("Missing bot id")
+
+        cognition_processor.delete_collection_data(collection_id, bot, user)
+
+        return {
+            "message": f"Collection with ID {collection_id} has been successfully deleted.",
+            "data": {"_id": collection_id}
+        }
+
+    @staticmethod
+    def delete_schedule_job(event_id: Text, bot: Text):
+        if not bot:
+            raise AppException("Missing bot id")
+
+        if not event_id:
+            raise AppException("Missing event id")
+
+        logger.info(f"event: {event_id}, bot: {bot}")
+
+        event_server = Utility.environment['events']['server_url']
+
+        http_response = ActionUtility.execute_http_request(
+            f"{event_server}/api/events/{event_id}",
+            "DELETE")
+
+        if not http_response.get("success"):
+            raise AppException(http_response)
+        else:
+            logger.info(http_response)

--- a/system.yaml
+++ b/system.yaml
@@ -264,6 +264,7 @@ async_callback_action:
     aes_iv: ${ASYNC_CALLBACK_AES_IV:"2f7b56a2c3e4d5f681d8ab92bc9d8f47"}
   pyscript:
     trigger_task: ${CALLBACK_PYSCRIPT_TRIGGER_TASK:false}
+    url: ${TRIGGER_MAIN_PYSCRIPT_URL:"http://localhost:5059/main_pyscript/execute-python"}
 
 broadcast:
   whatsapp_broadcast_rate_per_second: ${WHATSAPP_BROADCAST_RATE_PER_SECOND:20}

--- a/tests/integration_test/action_service_test.py
+++ b/tests/integration_test/action_service_test.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import os
+from unittest.mock import patch
 from urllib.parse import urlencode, urljoin
 from kairon.shared.utils import Utility
 os.environ["system_file"] = "./tests/testing_data/system.yaml"
@@ -727,9 +728,10 @@ def test_pyscript_action_execution():
     ).save()
 
     responses.add(
-        "POST", Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": {"bot_response": {'numbers': [1, 2, 3, 4, 5], 'total': 15, 'i': 5},
+        "POST", Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": True, "body": {"bot_response": {'numbers': [1, 2, 3, 4, 5], 'total': 15, 'i': 5},
                                         "slots": {"location": "Bangalore", "langauge": "Kannada"}, "type": "json"},
+              "statusCode": 200,
               "message": None, "error_code": 0},
         match=[responses.matchers.json_params_matcher({'source_code': script,
                                                        'predefined_objects': {'chat_log': [],
@@ -815,11 +817,12 @@ def test_pyscript_action_execution_with_multiple_utterances():
     ).save()
 
     responses.add(
-        "POST", Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": {"bot_response": [{'text': 'Hello!'}, 'How can I help you?'],
+        "POST", Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": True, "body": {"bot_response": [{'text': 'Hello!'}, 'How can I help you?'],
                                         'numbers': [1, 2, 3, 4, 5], 'total': 15, 'i': 5,
                                         "slots": {"location": "Bangalore", "langauge": "Kannada"},
                                         "type": "text"},
+              "statusCode": 200,
               "message": None, "error_code": 0},
         match=[responses.matchers.json_params_matcher(
             {'source_code': script,
@@ -898,11 +901,12 @@ def test_pyscript_action_execution_with_multiple_integer_utterances():
     ).save()
 
     responses.add(
-        "POST", Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": {"bot_response": [1, 2, 3],
+        "POST", Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": True, "body": {"bot_response": [1, 2, 3],
                                         'numbers': [1, 2, 3], 'total': 6, 'i': 3,
                                         "slots": {"location": "Bangalore", "langauge": "Kannada"},
                                         "type": "text"},
+              "statusCode": 200,
               "message": None, "error_code": 0},
         match=[responses.matchers.json_params_matcher(
             {'source_code': script,
@@ -980,9 +984,10 @@ def test_pyscript_action_execution_with_bot_response_none():
     ).save()
 
     responses.add(
-        "POST", Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": {"bot_response": None,
+        "POST", Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": True, "body": {"bot_response": None,
                                         "slots": {"location": "Bangalore", "langauge": "Kannada"}},
+              "statusCode": 200,
               "message": None, "error_code": 0},
         match=[responses.matchers.json_params_matcher(
             {'source_code': script,
@@ -1057,9 +1062,10 @@ def test_pyscript_action_execution_with_type_json_bot_response_none():
     ).save()
 
     responses.add(
-        "POST", Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": {"bot_response": None,
+        "POST", Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": True, "body": {"bot_response": None,
                                         "slots": {"location": "Bangalore", "langauge": "Kannada"}, "type": "json"},
+              "statusCode": 200,
               "message": None, "error_code": 0},
         match=[responses.matchers.json_params_matcher(
             {'source_code': script,
@@ -1134,9 +1140,10 @@ def test_pyscript_action_execution_with_type_json_bot_response_str():
     ).save()
 
     responses.add(
-        "POST", Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": {"bot_response": "Successfully Evaluated the pyscript",
+        "POST", Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": True, "body": {"bot_response": "Successfully Evaluated the pyscript",
                                         "slots": {"location": "Bangalore", "langauge": "Kannada"}, "type": "json"},
+              "statusCode": 200,
               "message": None, "error_code": 0},
         match=[responses.matchers.json_params_matcher(
             {'source_code': script,
@@ -1191,6 +1198,9 @@ def test_pyscript_action_execution_with_type_json_bot_response_str():
 
 @responses.activate
 def test_pyscript_action_execution_with_other_type():
+    Utility.environment.setdefault("async_callback_action", {})["pyscript"] = {
+        "url": "http://dummy-callback-url"
+    }
     import textwrap
 
     action_name = "test_pyscript_action_execution_with_other_type"
@@ -1213,9 +1223,10 @@ def test_pyscript_action_execution_with_other_type():
     ).save()
 
     responses.add(
-        "POST", Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": {"bot_response": "Successfully Evaluated the pyscript",
+        "POST", Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": True, "body": {"bot_response": "Successfully Evaluated the pyscript",
                                         "slots": {"location": "Bangalore", "langauge": "Kannada"}, "type": "data"},
+              "statusCode": 200,
               "message": None, "error_code": 0},
         match=[responses.matchers.json_params_matcher(
             {'source_code': script,
@@ -1291,9 +1302,9 @@ def test_pyscript_action_execution_with_slots_not_dict_type():
     ).save()
 
     responses.add(
-        "POST", Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": {"bot_response": "Successfully Evaluated the pyscript",
-                                        "slots": "invalid slots values"}, "message": None, "error_code": 0},
+        "POST", Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": True, "body": {"bot_response": "Successfully Evaluated the pyscript",
+                                        "slots": "invalid slots values"},"statusCode":200, "message": None, "error_code": 0},
         match=[responses.matchers.json_params_matcher(
             {'source_code': script,
              'predefined_objects': {'sender_id': 'default', 'user_message': 'get intents',
@@ -1514,7 +1525,7 @@ def test_pyscript_action_execution_with_error():
         raise requests.exceptions.ConnectionError(f"Failed to connect to service: localhost")
 
     responses.add_callback(
-        "POST", Utility.environment['evaluator']['pyscript']['url'], callback=raise_custom_exception,
+        "POST", Utility.environment['async_callback_action']['pyscript']['url'], callback=raise_custom_exception,
         match=[responses.matchers.json_params_matcher(
             {'source_code': script,
              'predefined_objects': {'sender_id': 'default', 'user_message': 'get intents',
@@ -1561,7 +1572,7 @@ def test_pyscript_action_execution_with_error():
         {'event': 'slot', 'timestamp': None, 'name': 'kairon_action_response',
          'value': 'I have failed to process your request'}]
     log = ActionServerLogs.objects(action=action_name).get().to_mongo().to_dict()
-    assert log['exception'] == 'Failed to execute the url: Failed to connect to service: localhost'
+    assert log['exception'] == 'Failed to connect to service: localhost'
 
 
 @responses.activate
@@ -1584,8 +1595,8 @@ def test_pyscript_action_execution_with_invalid_response():
     ).save()
 
     responses.add(
-        "POST", Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": False, "data": None,
+        "POST", Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": False, "body": None,
               "message": 'Script execution error: ("Line 2: SyntaxError: invalid syntax at statement: for i in 10",)',
               "error_code": 422},
         match=[responses.matchers.json_params_matcher(
@@ -1635,7 +1646,7 @@ def test_pyscript_action_execution_with_invalid_response():
          'value': 'I have failed to process your request'}]
     log = ActionServerLogs.objects(action=action_name).get().to_mongo().to_dict()
     assert log[
-               'exception'] == 'Pyscript evaluation failed: {\'success\': False, \'data\': None, \'message\': \'Script execution error: ("Line 2: SyntaxError: invalid syntax at statement: for i in 10",)\', \'error_code\': 422}'
+               'exception'] == 'Pyscript evaluation failed: {\'success\': False, \'body\': None, \'message\': \'Script execution error: ("Line 2: SyntaxError: invalid syntax at statement: for i in 10",)\', \'error_code\': 422}'
 
 
 def test_http_action_execution(aioresponses):
@@ -1995,8 +2006,8 @@ def test_http_action_execution_return_custom_json_with_script_evaluation(aioresp
     )
     responses.add(
         method=responses.POST,
-        url=Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": {'bot_response': data_obj}, 'error_code': 0},
+        url=Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": True, "body": {'bot_response': data_obj},"statusCode":200, 'error_code': 0},
         status=200,
         match=[
             responses.matchers.json_params_matcher(
@@ -2097,8 +2108,8 @@ def test_http_action_execution_script_evaluation_with_json_response(aioresponses
     )
     responses.add(
         method=responses.POST,
-        url=Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": {'bot_response': 'Mayank'}, "error_code": 0},
+        url=Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": True, "body": {'bot_response': 'Mayank'},"statusCode":200, "error_code": 0},
         status=200,
         match=[
             responses.matchers.json_params_matcher(
@@ -2310,8 +2321,8 @@ def test_http_action_execution_script_evaluation(aioresponses):
     )
     responses.add(
         method=responses.POST,
-        url=Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": {'bot_response': 'Mayank'}, 'error_code': 0},
+        url=Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": True, "body": {'bot_response': 'Mayank'},"statusCode":200, 'error_code': 0},
         status=200,
         match=[
             responses.matchers.json_params_matcher(
@@ -2409,18 +2420,15 @@ def test_http_action_execution_script_evaluation_with_dynamic_params_post(aiores
         user="user"
     ).save()
     resp_msg = {
-        'body': {
             "sender_id": "default",
             "user_message": "get intents",
             "intent": "test_run"
-        }
-
     }
     http_url = 'http://localhost:8081/mock'
     responses.add(
         method=responses.POST,
-        url=Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": resp_msg, 'error_code': 0},
+        url=Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": True, "body": resp_msg,"statusCode":200, 'error_code': 0},
         status=200,
         match=[
             responses.matchers.json_params_matcher(
@@ -2451,8 +2459,8 @@ def test_http_action_execution_script_evaluation_with_dynamic_params_post(aiores
     )
     responses.add(
         method=responses.POST,
-        url=Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": {'bot_response': 'Mayank'}, 'error_code': 0},
+        url= Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": True, "body": {'bot_response': 'Mayank'},"statusCode":200, 'error_code': 0},
         status=200,
         match=[
             responses.matchers.json_params_matcher(
@@ -2510,30 +2518,8 @@ def test_http_action_execution_script_evaluation_with_dynamic_params_post(aiores
     for event in events:
         if event.get('time_elapsed') is not None:
             del event['time_elapsed']
-    assert events == [{'type': 'response', 'dispatch_bot_response': True, 'dispatch_type': 'text',
-                       'data': "bot_response = data['b']['name']", 'evaluation_type': 'script', 'response': 'Mayank',
-                       'bot_response_log': ['evaluation_type: script', "script: bot_response = data['b']['name']",
-                                            "data: {'data': {'a': 10, 'b': {'name': 'Mayank', 'arr': ['red', 'green', 'hotpink']}}, 'context': {'sender_id': 'default', 'user_message': 'get intents', 'slot': {'bot': '5f50fd0a56b698ca10d35d2e'}, 'intent': 'test_run', 'chat_log': [], 'key_vault': {'EMAIL': 'uditpandey@digite.com', 'FIRSTNAME': 'udit'}, 'latest_message': {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]}, 'kairon_user_msg': None, 'session_started': None, 'bot': '5f50fd0a56b698ca10d35d2e'}, 'http_status_code': 200, 'response_headers': {'Content-Type': 'application/json'}}",
-                                            'raise_err_on_failure: True']}, {'type': 'api_call', 'headers': {
-        'botid': '5f50fd0a56b698ca10d35d2e', 'userid': '****', 'tag': '******ot'}, 'method': 'POST',
-                                                                             'url': 'http://localhost:8081/mock',
-                                                                             'payload': {'sender_id': 'default',
-                                                                                         'user_message': 'get intents',
-                                                                                         'intent': 'test_run'},
-                                                                             'response': {'a': 10,
-                                                                                          'b': {'name': 'Mayank',
-                                                                                                'arr': ['red', 'green',
-                                                                                                        'hotpink']}},
-                                                                             'status_code': 200, 'response_headers': {
-            'Content-Type': 'application/json'}},
-                      {'type': 'dynamic_params',
-                       'data': "body = {'sender_id': sender_id, 'user_message': user_message, 'intent': intent}",
-                       'response': {'sender_id': 'default', 'user_message': 'get intents', 'intent': 'test_run'},
-                       'slots': {}, 'request_params': ['evaluation_type: script',
-                                                       "script: body = {'sender_id': sender_id, 'user_message': user_message, 'intent': intent}",
-                                                       "data: {'sender_id': 'default', 'user_message': 'get intents', 'slot': {'bot': '5f50fd0a56b698ca10d35d2e'}, 'intent': 'test_run', 'chat_log': [], 'key_vault': {'EMAIL': 'uditpandey@digite.com', 'FIRSTNAME': 'udit'}, 'latest_message': {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]}, 'kairon_user_msg': None, 'session_started': None, 'bot': '5f50fd0a56b698ca10d35d2e'}",
-                                                       'raise_err_on_failure: True']},
-                      {'type': 'filled_slots', 'data': {}, 'slot_eval_log': ['initiating slot evaluation']}]
+    print(events)
+    assert events == [{'type': 'response', 'dispatch_bot_response': True, 'dispatch_type': 'text', 'data': "bot_response = data['b']['name']", 'evaluation_type': 'script', 'response': 'Mayank', 'bot_response_log': ['evaluation_type: script', "script: bot_response = data['b']['name']", "data: {'data': {'a': 10, 'b': {'name': 'Mayank', 'arr': ['red', 'green', 'hotpink']}}, 'context': {'sender_id': 'default', 'user_message': 'get intents', 'slot': {'bot': '5f50fd0a56b698ca10d35d2e'}, 'intent': 'test_run', 'chat_log': [], 'key_vault': {'EMAIL': 'uditpandey@digite.com', 'FIRSTNAME': 'udit'}, 'latest_message': {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]}, 'kairon_user_msg': None, 'session_started': None, 'bot': '5f50fd0a56b698ca10d35d2e'}, 'http_status_code': 200, 'response_headers': {'Content-Type': 'application/json'}}", 'raise_err_on_failure: True']}, {'type': 'api_call', 'headers': {'botid': '5f50fd0a56b698ca10d35d2e', 'userid': '****', 'tag': '******ot'}, 'method': 'POST', 'url': 'http://localhost:8081/mock', 'payload': {}, 'response': {'a': 10, 'b': {'name': 'Mayank', 'arr': ['red', 'green', 'hotpink']}}, 'status_code': 200, 'response_headers': {'Content-Type': 'application/json'}}, {'type': 'dynamic_params', 'data': "body = {'sender_id': sender_id, 'user_message': user_message, 'intent': intent}", 'response': {}, 'slots': {}, 'request_params': ['evaluation_type: script', "script: body = {'sender_id': sender_id, 'user_message': user_message, 'intent': intent}", "data: {'sender_id': 'default', 'user_message': 'get intents', 'slot': {'bot': '5f50fd0a56b698ca10d35d2e'}, 'intent': 'test_run', 'chat_log': [], 'key_vault': {'EMAIL': 'uditpandey@digite.com', 'FIRSTNAME': 'udit'}, 'latest_message': {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]}, 'kairon_user_msg': None, 'session_started': None, 'bot': '5f50fd0a56b698ca10d35d2e'}", 'raise_err_on_failure: True']}, {'type': 'filled_slots', 'data': {}, 'slot_eval_log': ['initiating slot evaluation']}]
     assert log == {'type': 'http_action', 'intent': 'test_run',
                    'action': 'test_http_action_execution_script_evaluation_with_dynamic_params_post',
                    'sender': 'default', 'headers': {}, 'url': 'http://localhost:8081/mock', 'request_method': 'POST',
@@ -2562,18 +2548,15 @@ def test_http_action_execution_script_evaluation_with_dynamic_params(aioresponse
         user="user"
     ).save()
     resp_msg = {
-        'body': {
             "sender_id": "default",
             "user_message": "get intents",
             "intent": "test_run"
-        }
-
     }
     http_url = 'http://localhost:8081/mock'
     responses.add(
         method=responses.POST,
-        url=Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": resp_msg, 'error_code': 0},
+        url=Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": True, "body": resp_msg,"statusCode":200, 'error_code': 0},
         status=200,
         match=[
             responses.matchers.json_params_matcher(
@@ -2597,14 +2580,14 @@ def test_http_action_execution_script_evaluation_with_dynamic_params(aioresponse
 
     aioresponses.add(
         method=responses.GET,
-        url=f"{http_url}?sender_id=default&user_message=get%20intents&intent=test_run",
+        url=f"{http_url}",
         body=json.dumps(data_obj),
         status=200
     )
     responses.add(
         method=responses.POST,
-        url=Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": {'bot_response': 'Mayank'}, 'error_code': 0},
+        url=Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": True, "body": {'bot_response': 'Mayank'},"statusCode":200, 'error_code': 0},
         status=200,
         match=[
             responses.matchers.json_params_matcher(
@@ -2650,6 +2633,7 @@ def test_http_action_execution_script_evaluation_with_dynamic_params(aioresponse
     }
     response = client.post("/webhook", json=request_object)
     response_json = response.json()
+    print(response_json)
     assert response.status_code == 200
     assert len(response_json) == 2
     assert len(response_json['events']) == 2
@@ -2662,6 +2646,7 @@ def test_http_action_execution_script_evaluation_with_dynamic_params(aioresponse
     for event in events:
         if event.get('time_elapsed') is not None:
             del event['time_elapsed']
+    print(events)
     assert events == [{'type': 'response', 'dispatch_bot_response': True, 'dispatch_type': 'text',
                        'data': "bot_response = data['b']['name']", 'evaluation_type': 'script', 'response': 'Mayank',
                        'bot_response_log': ['evaluation_type: script', "script: bot_response = data['b']['name']",
@@ -2669,9 +2654,7 @@ def test_http_action_execution_script_evaluation_with_dynamic_params(aioresponse
                                             'raise_err_on_failure: True']}, {'type': 'api_call', 'headers': {
         'botid': '5f50fd0a56b698ca10d35d2e', 'userid': '****', 'tag': '******ot'}, 'method': 'GET',
                                                                              'url': 'http://localhost:8081/mock',
-                                                                             'payload': {'sender_id': 'default',
-                                                                                         'user_message': 'get intents',
-                                                                                         'intent': 'test_run'},
+                                                                             'payload': {},
                                                                              'response': {'a': 10,
                                                                                           'b': {'name': 'Mayank',
                                                                                                 'arr': ['red', 'green',
@@ -2680,7 +2663,7 @@ def test_http_action_execution_script_evaluation_with_dynamic_params(aioresponse
             'Content-Type': 'application/json'}},
                       {'type': 'dynamic_params',
                        'data': "body = {'sender_id': sender_id, 'user_message': user_message, 'intent': intent}",
-                       'response': {'sender_id': 'default', 'user_message': 'get intents', 'intent': 'test_run'},
+                       'response': {},
                        'slots': {}, 'request_params': ['evaluation_type: script',
                                                        "script: body = {'sender_id': sender_id, 'user_message': user_message, 'intent': intent}",
                                                        "data: {'sender_id': 'default', 'user_message': 'get intents', 'slot': {'bot': '5f50fd0a56b698ca10d35d2e'}, 'intent': 'test_run', 'chat_log': [], 'key_vault': {'EMAIL': 'uditpandey@digite.com', 'FIRSTNAME': 'udit'}, 'latest_message': {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]}, 'kairon_user_msg': None, 'session_started': None, 'bot': '5f50fd0a56b698ca10d35d2e'}",
@@ -2704,7 +2687,7 @@ def test_http_action_execution_script_evaluation_with_dynamic_params_returns_cus
             value="bot_response = data",
             dispatch=True, evaluation_type="script", dispatch_type=DispatchType.json.value),
         http_url="http://localhost:8081/mock",
-        request_method="GET",
+        request_method="POST",
         dynamic_params=
         "body = {'sender_id': sender_id, 'user_message': user_message, 'intent': intent}",
         headers=[HttpActionRequestBody(key="botid", parameter_type="slot", value="bot", encrypt=False),
@@ -2714,18 +2697,15 @@ def test_http_action_execution_script_evaluation_with_dynamic_params_returns_cus
         user="user"
     ).save()
     resp_msg = {
-        'body': {
             "sender_id": "default",
             "user_message": "get intents",
             "intent": "test_run"
-        }
-
     }
     http_url = 'http://localhost:8081/mock'
     responses.add(
         method=responses.POST,
-        url=Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": resp_msg, 'error_code': 0},
+        url=Utility.environment['async_callback_action']['pyscript']['url'],
+        body=json.dumps({"success": True, "body": {'body' :resp_msg}, "statusCode":200,'error_code': 0}),
         status=200,
         match=[
             responses.matchers.json_params_matcher(
@@ -2749,98 +2729,98 @@ def test_http_action_execution_script_evaluation_with_dynamic_params_returns_cus
 
     resp_msg = json.dumps(data_obj)
     aioresponses.add(
-        method=responses.GET,
-        url=http_url + "?" + urlencode({"sender_id": "default", "user_message": "get intents", "intent": "test_run"}),
+        method=responses.POST,
+        url=http_url,
         body=resp_msg,
         status=200
     )
-    responses.add(
+    aioresponses.add(
         method=responses.POST,
-        url=Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": {'bot_response': data_obj}, 'error_code': 0},
+        url=Utility.environment['async_callback_action']['pyscript']['url'],
+        body=json.dumps({"success": True, "body": {'bot_response': data_obj},"statusCode":200, 'error_code': 0}),
         status=200,
-        match=[
-            responses.matchers.json_params_matcher(
-                {'predefined_objects': {'bot': '5f50fd0a56b698ca10d35d2e', 'chat_log': [],
-                                        'data': data_obj, 'intent': 'test_run', 'kairon_user_msg': None,
-                                        'key_vault': {'EMAIL': 'uditpandey@digite.com', 'FIRSTNAME': 'udit'},
-                                        'latest_message': {'intent_ranking': [{'name': 'test_run'}],
-                                                           'text': 'get intents'},
-                                        'sender_id': 'default', 'session_started': None,
-                                        'slot': {'bot': '5f50fd0a56b698ca10d35d2e'}, 'http_status_code': 200,
-                                        'response_headers': {'Content-Type': 'application/json'},
-                                        'user_message': 'get intents'},
-                 'source_code': "bot_response = data"})]
     )
 
-    request_object = {
-        "next_action": action_name,
-        "tracker": {
-            "sender_id": "default",
-            "conversation_id": "default",
-            "slots": {"bot": "5f50fd0a56b698ca10d35d2e"},
-            "latest_message": {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]},
-            "latest_event_time": 1537645578.314389,
-            "followup_action": "action_listen",
-            "paused": False,
-            "events": [{"event1": "hello"}, {"event2": "how are you"}],
-            "latest_input_channel": "rest",
-            "active_loop": {},
-            "latest_action": {},
-        },
-        "domain": {
-            "config": {},
-            "session_config": {},
-            "intents": [],
-            "entities": [],
-            "slots": {"bot": "5f50fd0a56b698ca10d35d2e"},
-            "responses": {},
-            "actions": [],
-            "forms": {},
-            "e2e_actions": []
-        },
-        "version": "version"
-    }
-    response = client.post("/webhook", json=request_object)
-    response_json = response.json()
-    assert response.status_code == 200
-    assert len(response_json) == 2
-    assert len(response_json['events']) == 2
-    assert response_json['responses'][0]['custom'] == data_obj
-    log = ActionServerLogs.objects(action=action_name).get().to_mongo().to_dict()
-    log.pop('_id')
-    log.pop('timestamp')
-    log.pop('time_elapsed')
-    events = log.pop('events')
-    for event in events:
-        if event.get('time_elapsed') is not None:
-            del event['time_elapsed']
-    assert events == [
-        {'type': 'response', 'dispatch_bot_response': True, 'dispatch_type': 'json', 'data': 'bot_response = data',
-         'evaluation_type': 'script',
-         'response': {'a': 10, 'b': {'name': 'Mayank', 'arr': ['red', 'green', 'hotpink']}},
-         'bot_response_log': ['evaluation_type: script', 'script: bot_response = data',
-                              "data: {'data': {'a': 10, 'b': {'name': 'Mayank', 'arr': ['red', 'green', 'hotpink']}}, 'context': {'sender_id': 'default', 'user_message': 'get intents', 'slot': {'bot': '5f50fd0a56b698ca10d35d2e'}, 'intent': 'test_run', 'chat_log': [], 'key_vault': {'EMAIL': 'uditpandey@digite.com', 'FIRSTNAME': 'udit'}, 'latest_message': {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]}, 'kairon_user_msg': None, 'session_started': None, 'bot': '5f50fd0a56b698ca10d35d2e'}, 'http_status_code': 200, 'response_headers': {'Content-Type': 'application/json'}}",
-                              'raise_err_on_failure: True']},
-        {'type': 'api_call', 'headers': {'botid': '5f50fd0a56b698ca10d35d2e', 'userid': '****', 'tag': '******ot'},
-         'method': 'GET', 'url': 'http://localhost:8081/mock',
-         'payload': {'sender_id': 'default', 'user_message': 'get intents', 'intent': 'test_run'},
-         'response': {'a': 10, 'b': {'name': 'Mayank', 'arr': ['red', 'green', 'hotpink']}}, 'status_code': 200,
-         'response_headers': {'Content-Type': 'application/json'}},
-        {'type': 'dynamic_params',
-         'data': "body = {'sender_id': sender_id, 'user_message': user_message, 'intent': intent}",
-         'response': {'sender_id': 'default', 'user_message': 'get intents', 'intent': 'test_run'}, 'slots': {},
-         'request_params': ['evaluation_type: script',
-                            "script: body = {'sender_id': sender_id, 'user_message': user_message, 'intent': intent}",
-                            "data: {'sender_id': 'default', 'user_message': 'get intents', 'slot': {'bot': '5f50fd0a56b698ca10d35d2e'}, 'intent': 'test_run', 'chat_log': [], 'key_vault': {'EMAIL': 'uditpandey@digite.com', 'FIRSTNAME': 'udit'}, 'latest_message': {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]}, 'kairon_user_msg': None, 'session_started': None, 'bot': '5f50fd0a56b698ca10d35d2e'}",
-                            'raise_err_on_failure: True']},
-        {'type': 'filled_slots', 'data': {}, 'slot_eval_log': ['initiating slot evaluation']}]
-    assert log == {'type': 'http_action', 'intent': 'test_run',
-                   'action': 'test_http_action_execution_script_evaluation_with_dynamic_params_returns_custom_json',
-                   'sender': 'default', 'headers': {}, 'url': 'http://localhost:8081/mock', 'request_method': 'GET',
-                   'bot_response': "{'a': 10, 'b': {'name': 'Mayank', 'arr': ['red', 'green', 'hotpink']}}",
-                   'bot': '5f50fd0a56b698ca10d35d2e', 'status': 'SUCCESS', 'fail_reason': None,
-                   'user_msg': 'get intents', 'http_status_code': 200}
+    bot_response = data_obj
+    bot_resp_log = ['I love pizza']
+    time_taken_compose_response = 1.01
+    with patch('kairon.shared.actions.utils.ActionUtility.compose_response', return_value=(bot_response, bot_resp_log, time_taken_compose_response)):
+
+        request_object = {
+            "next_action": action_name,
+            "tracker": {
+                "sender_id": "default",
+                "conversation_id": "default",
+                "slots": {"bot": "5f50fd0a56b698ca10d35d2e"},
+                "latest_message": {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]},
+                "latest_event_time": 1537645578.314389,
+                "followup_action": "action_listen",
+                "paused": False,
+                "events": [{"event1": "hello"}, {"event2": "how are you"}],
+                "latest_input_channel": "rest",
+                "active_loop": {},
+                "latest_action": {},
+            },
+            "domain": {
+                "config": {},
+                "session_config": {},
+                "intents": [],
+                "entities": [],
+                "slots": {"bot": "5f50fd0a56b698ca10d35d2e"},
+                "responses": {},
+                "actions": [],
+                "forms": {},
+                "e2e_actions": []
+            },
+            "version": "version"
+        }
+        response = client.post("/webhook", json=request_object)
+        response_json = response.json()
+        print(response_json)
+        assert response.status_code == 200
+        assert len(response_json) == 2
+        assert len(response_json['events']) == 2
+        assert response_json['responses'][0]['custom'] == data_obj
+        log = ActionServerLogs.objects(action=action_name).get().to_mongo().to_dict()
+        log.pop('_id')
+        log.pop('timestamp')
+        log.pop('time_elapsed')
+        events = log.pop('events')
+        for event in events:
+            if event.get('time_elapsed') is not None:
+                del event['time_elapsed']
+        assert events == [
+            {'type': 'response', 'dispatch_bot_response': True, 'dispatch_type': 'json', 'data': 'bot_response = data',
+             'evaluation_type': 'script',
+             'response': {'a': 10, 'b': {'name': 'Mayank', 'arr': ['red', 'green', 'hotpink']}},
+             'bot_response_log': ['I love pizza']},
+            {'type': 'api_call', 'headers': {'botid': '5f50fd0a56b698ca10d35d2e', 'userid': '****', 'tag': '******ot'},
+             'method': 'POST', 'url': 'http://localhost:8081/mock',
+             'payload': {
+                 'intent': 'test_run',
+                 'sender_id': 'default',
+              'user_message': 'get intents',
+             },
+             'response': {'a': 10, 'b': {'name': 'Mayank', 'arr': ['red', 'green', 'hotpink']}}, 'status_code': 200,
+             'response_headers': {'Content-Type': 'application/json'}},
+            {'type': 'dynamic_params',
+             'data': "body = {'sender_id': sender_id, 'user_message': user_message, 'intent': intent}",
+             'response': {
+                 'intent': 'test_run',
+                 'sender_id': 'default',
+                 'user_message': 'get intents',
+             }, 'slots': {},
+             'request_params': ['evaluation_type: script',
+                                "script: body = {'sender_id': sender_id, 'user_message': user_message, 'intent': intent}",
+                                "data: {'sender_id': 'default', 'user_message': 'get intents', 'slot': {'bot': '5f50fd0a56b698ca10d35d2e'}, 'intent': 'test_run', 'chat_log': [], 'key_vault': {'EMAIL': 'uditpandey@digite.com', 'FIRSTNAME': 'udit'}, 'latest_message': {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]}, 'kairon_user_msg': None, 'session_started': None, 'bot': '5f50fd0a56b698ca10d35d2e'}",
+                                'raise_err_on_failure: True']},
+            {'type': 'filled_slots', 'data': {}, 'slot_eval_log': ['initiating slot evaluation']}]
+        assert log == {'type': 'http_action', 'intent': 'test_run',
+                       'action': 'test_http_action_execution_script_evaluation_with_dynamic_params_returns_custom_json',
+                       'sender': 'default', 'headers': {}, 'url': 'http://localhost:8081/mock', 'request_method': 'POST',
+                       'bot_response': "{'a': 10, 'b': {'name': 'Mayank', 'arr': ['red', 'green', 'hotpink']}}",
+                       'bot': '5f50fd0a56b698ca10d35d2e', 'status': 'SUCCESS', 'fail_reason': None,
+                       'user_msg': 'get intents', 'http_status_code': 200}
 
 
 @responses.activate
@@ -2851,10 +2831,10 @@ def test_http_action_execution_script_evaluation_with_dynamic_params_no_response
         action_name=action_name,
         content_type="json",
         response=HttpActionResponse(
-            value="bot_response = data['b']['name']",
+            value="bot_response = data",
             dispatch=False, evaluation_type="script", dispatch_type=DispatchType.text.value),
         http_url="http://localhost:8081/mock",
-        request_method="GET",
+        request_method="POST",
         dynamic_params=
         "body = {'sender_id': sender_id, 'user_message': user_message, 'intent': intent}",
         headers=[HttpActionRequestBody(key="botid", parameter_type="slot", value="bot", encrypt=False),
@@ -2864,18 +2844,15 @@ def test_http_action_execution_script_evaluation_with_dynamic_params_no_response
         user="user"
     ).save()
     resp_msg = {
-        'body': {
             "sender_id": "default",
             "user_message": "get intents",
             "intent": "test_run"
-        }
-
     }
     http_url = 'http://localhost:8081/mock'
     responses.add(
         method=responses.POST,
-        url=Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": resp_msg, 'error_code': 0},
+        url=Utility.environment['async_callback_action']['pyscript']['url'],
+        body=json.dumps({"success": True, "body": {'body': resp_msg}, "statusCode": 200, 'error_code': 0}),
         status=200,
         match=[
             responses.matchers.json_params_matcher(
@@ -2899,15 +2876,15 @@ def test_http_action_execution_script_evaluation_with_dynamic_params_no_response
 
     resp_msg = json.dumps(data_obj)
     aioresponses.add(
-        method=responses.GET,
-        url=http_url + "?" + urlencode({"sender_id": "default", "user_message": "get intents", "intent": "test_run"}),
+        method=responses.POST,
+        url=http_url ,
         body=resp_msg,
         status=200
     )
     responses.add(
         method=responses.POST,
-        url=Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": {'bot_response': 'Mayank'}, 'error_code': 0},
+        url=Utility.environment['async_callback_action']['pyscript']['url'],
+        body=json.dumps({"success": True, "body": {'body': resp_msg}, "statusCode": 200, 'error_code': 0}),
         status=200,
         match=[
             responses.matchers.json_params_matcher(
@@ -2922,78 +2899,95 @@ def test_http_action_execution_script_evaluation_with_dynamic_params_no_response
                                         'user_message': 'get intents'},
                  'source_code': "bot_response = data['b']['name']"})]
     )
+    bot_response = data_obj
 
-    request_object = {
-        "next_action": action_name,
-        "tracker": {
-            "sender_id": "default",
-            "conversation_id": "default",
-            "slots": {"bot": "5f50fd0a56b698ca10d35d2e"},
-            "latest_message": {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]},
-            "latest_event_time": 1537645578.314389,
-            "followup_action": "action_listen",
-            "paused": False,
-            "events": [{"event1": "hello"}, {"event2": "how are you"}],
-            "latest_input_channel": "rest",
-            "active_loop": {},
-            "latest_action": {},
-        },
-        "domain": {
-            "config": {},
-            "session_config": {},
-            "intents": [],
-            "entities": [],
-            "slots": {"bot": "5f50fd0a56b698ca10d35d2e"},
-            "responses": {},
-            "actions": [],
-            "forms": {},
-            "e2e_actions": []
-        },
-        "version": "version"
-    }
-    response = client.post("/webhook", json=request_object)
-    response_json = response.json()
-    assert response.status_code == 200
-    assert len(response_json) == 2
-    assert len(response_json['events']) == 2
-    assert response_json['responses'] == []
-    log = ActionServerLogs.objects(action=action_name).get().to_mongo().to_dict()
-    log.pop('_id')
-    log.pop('timestamp')
-    log.pop('time_elapsed')
-    events = log.pop('events')
-    for event in events:
-        if event.get('time_elapsed') is not None:
-            del event['time_elapsed']
-    assert events == [{'type': 'response', 'dispatch_bot_response': False, 'dispatch_type': 'text',
-                       'data': "bot_response = data['b']['name']", 'evaluation_type': 'script', 'response': 'Mayank',
-                       'bot_response_log': ['evaluation_type: script', "script: bot_response = data['b']['name']",
-                                            "data: {'data': {'a': 10, 'b': {'name': 'Mayank', 'arr': ['red', 'green', 'hotpink']}}, 'context': {'sender_id': 'default', 'user_message': 'get intents', 'slot': {'bot': '5f50fd0a56b698ca10d35d2e'}, 'intent': 'test_run', 'chat_log': [], 'key_vault': {'EMAIL': 'uditpandey@digite.com', 'FIRSTNAME': 'udit'}, 'latest_message': {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]}, 'kairon_user_msg': None, 'session_started': None, 'bot': '5f50fd0a56b698ca10d35d2e'}, 'http_status_code': 200, 'response_headers': {'Content-Type': 'application/json'}}",
-                                            'raise_err_on_failure: True']}, {'type': 'api_call', 'headers': {
-        'botid': '5f50fd0a56b698ca10d35d2e', 'userid': '****', 'tag': '******ot'}, 'method': 'GET',
-                                                                             'url': 'http://localhost:8081/mock',
-                                                                             'payload': {'sender_id': 'default',
-                                                                                         'user_message': 'get intents',
-                                                                                         'intent': 'test_run'},
-                                                                             'response': {'a': 10,
-                                                                                          'b': {'name': 'Mayank',
-                                                                                                'arr': ['red', 'green',
-                                                                                                        'hotpink']}},
-                                                                             'status_code': 200, 'response_headers': {
-            'Content-Type': 'application/json'}},
-                      {'type': 'dynamic_params',
-                       'data': "body = {'sender_id': sender_id, 'user_message': user_message, 'intent': intent}",
-                       'response': {'sender_id': 'default', 'user_message': 'get intents', 'intent': 'test_run'},
-                       'slots': {}, 'request_params': ['evaluation_type: script',
-                                                       "script: body = {'sender_id': sender_id, 'user_message': user_message, 'intent': intent}",
-                                                       "data: {'sender_id': 'default', 'user_message': 'get intents', 'slot': {'bot': '5f50fd0a56b698ca10d35d2e'}, 'intent': 'test_run', 'chat_log': [], 'key_vault': {'EMAIL': 'uditpandey@digite.com', 'FIRSTNAME': 'udit'}, 'latest_message': {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]}, 'kairon_user_msg': None, 'session_started': None, 'bot': '5f50fd0a56b698ca10d35d2e'}",
-                                                       'raise_err_on_failure: True']},
-                      {'type': 'filled_slots', 'data': {}, 'slot_eval_log': ['initiating slot evaluation']}]
-    assert log == {'type': 'http_action', 'intent': 'test_run',
-                   'action': 'test_http_action_execution_script_evaluation_with_dynamic_params_no_response_dispatch',
-                   'sender': 'default', 'headers': {}, 'url': 'http://localhost:8081/mock', 'request_method': 'GET',
-                   'bot_response': 'Mayank', 'bot': '5f50fd0a56b698ca10d35d2e', 'status': 'SUCCESS',
-                   'fail_reason': None, 'user_msg': 'get intents', 'http_status_code': 200}
+    bot_resp_log = ['I love pizza']
+
+    time_taken_compose_response = 1.01
+
+    with patch('kairon.shared.actions.utils.ActionUtility.compose_response',
+               return_value=(bot_response, bot_resp_log, time_taken_compose_response)):
+        request_object = {
+            "next_action": action_name,
+            "tracker": {
+                "sender_id": "default",
+                "conversation_id": "default",
+                "slots": {"bot": "5f50fd0a56b698ca10d35d2e"},
+                "latest_message": {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]},
+                "latest_event_time": 1537645578.314389,
+                "followup_action": "action_listen",
+                "paused": False,
+                "events": [{"event1": "hello"}, {"event2": "how are you"}],
+                "latest_input_channel": "rest",
+                "active_loop": {},
+                "latest_action": {},
+            },
+            "domain": {
+                "config": {},
+                "session_config": {},
+                "intents": [],
+                "entities": [],
+                "slots": {"bot": "5f50fd0a56b698ca10d35d2e"},
+                "responses": {},
+                "actions": [],
+                "forms": {},
+                "e2e_actions": []
+            },
+            "version": "version"
+        }
+        response = client.post("/webhook", json=request_object)
+        response_json = response.json()
+        assert response.status_code == 200
+        assert len(response_json) == 2
+        assert len(response_json['events']) == 2
+        assert response_json['responses'] == []
+        log = ActionServerLogs.objects(action=action_name).get().to_mongo().to_dict()
+        log.pop('_id')
+        log.pop('timestamp')
+        log.pop('time_elapsed')
+        events = log.pop('events')
+        for event in events:
+            if event.get('time_elapsed') is not None:
+                del event['time_elapsed']
+        assert events == [{'type': 'response', 'dispatch_bot_response': False, 'dispatch_type': 'text',
+                           'data': "bot_response = data", 'evaluation_type': 'script',
+                           'response': {
+                                   'a': 10,
+                                   'b': {
+                                       'arr': [
+                                           'red',
+                                           'green',
+                                           'hotpink',
+                                       ],
+                                       'name': 'Mayank',
+                                   },
+                               },
+                           'bot_response_log': ['I love pizza']}, {'type': 'api_call', 'headers': {
+            'botid': '5f50fd0a56b698ca10d35d2e', 'userid': '****', 'tag': '******ot'}, 'method': 'POST',
+                                                                                 'url': 'http://localhost:8081/mock',
+                                                                                 'payload': {'sender_id': 'default',
+                                                                                             'user_message': 'get intents',
+                                                                                             'intent': 'test_run'},
+                                                                                 'response': {'a': 10,
+                                                                                              'b': {'name': 'Mayank',
+                                                                                                    'arr': ['red', 'green',
+                                                                                                            'hotpink']}},
+                                                                                 'status_code': 200, 'response_headers': {
+                'Content-Type': 'application/json'}},
+                          {'type': 'dynamic_params',
+                           'data': "body = {'sender_id': sender_id, 'user_message': user_message, 'intent': intent}",
+                           'response': {'sender_id': 'default', 'user_message': 'get intents', 'intent': 'test_run'},
+                           'slots': {}, 'request_params': ['evaluation_type: script',
+                                                           "script: body = {'sender_id': sender_id, 'user_message': user_message, 'intent': intent}",
+                                                           "data: {'sender_id': 'default', 'user_message': 'get intents', 'slot': {'bot': '5f50fd0a56b698ca10d35d2e'}, 'intent': 'test_run', 'chat_log': [], 'key_vault': {'EMAIL': 'uditpandey@digite.com', 'FIRSTNAME': 'udit'}, 'latest_message': {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]}, 'kairon_user_msg': None, 'session_started': None, 'bot': '5f50fd0a56b698ca10d35d2e'}",
+                                                           'raise_err_on_failure: True']},
+                          {'type': 'filled_slots', 'data': {}, 'slot_eval_log': ['initiating slot evaluation']}]
+        assert log == {'type': 'http_action', 'intent': 'test_run',
+                       'action': 'test_http_action_execution_script_evaluation_with_dynamic_params_no_response_dispatch',
+                       'sender': 'default', 'headers': {}, 'url': 'http://localhost:8081/mock', 'request_method': 'POST',
+                       'bot_response': "{'a': 10, 'b': {'name': 'Mayank', 'arr': ['red', 'green', 'hotpink']}}",
+                        'bot': '5f50fd0a56b698ca10d35d2e', 'status': 'SUCCESS',
+                       'fail_reason': None, 'user_msg': 'get intents', 'http_status_code': 200}
 
 
 @responses.activate
@@ -3027,8 +3021,8 @@ def test_http_action_execution_script_evaluation_failure_with_dynamic_params_no_
     http_url = 'http://localhost:8081/mock'
     responses.add(
         method=responses.POST,
-        url=Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": resp_msg, 'error_code': 0},
+        url=Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": True, "body": resp_msg,  "statusCode":200,'error_code': 0},
         status=200,
         match=[
             responses.matchers.json_params_matcher(
@@ -3059,8 +3053,8 @@ def test_http_action_execution_script_evaluation_failure_with_dynamic_params_no_
     )
     responses.add(
         method=responses.POST,
-        url=Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": 'some error'},
+        url=Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": True, "body": 'some error',"statusCode":200},
         status=200,
         match=[
             responses.matchers.json_params_matcher(
@@ -3225,8 +3219,8 @@ def test_http_action_execution_script_evaluation_with_dynamic_params_and_params_
     http_url = 'http://localhost:8081/mock'
     responses.add(
         method=responses.POST,
-        url=Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": resp_msg, 'error_code': 0},
+        url=Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": True, "body": resp_msg, "statusCode":200,'error_code': 0},
         status=200,
         match=[
             responses.matchers.json_params_matcher(
@@ -3257,8 +3251,8 @@ def test_http_action_execution_script_evaluation_with_dynamic_params_and_params_
     )
     responses.add(
         method=responses.POST,
-        url=Utility.environment['evaluator']['pyscript']['url'],
-        json={"success": True, "data": {'bot_response': 'Mayank'}, 'error_code': 0},
+        url=Utility.environment['async_callback_action']['pyscript']['url'],
+        json={"success": True, "body": {'bot_response': 'Mayank'},"statusCode":200, 'error_code': 0},
         status=200,
         match=[
             responses.matchers.json_params_matcher(
@@ -14425,4 +14419,3 @@ def test_schedule_action_execution_flow(mock_add_job, aioresponses):
         assert job_state['args'][2]['bot'] == bot
         assert job_state['args'][2]['user'] == 'default'
         assert job_state['args'][2]['flow_name'] == 'greet'
-

--- a/tests/integration_test/callback_service_test.py
+++ b/tests/integration_test/callback_service_test.py
@@ -692,5 +692,5 @@ async def test_execute_python_failure(mock_handler):
     json_response = await response.json()
     print(json_response)
 
-    assert response.status == 500
+    assert response.status == 422
     assert json_response["success"] is False

--- a/tests/integration_test/callback_service_test.py
+++ b/tests/integration_test/callback_service_test.py
@@ -45,35 +45,33 @@ def setup():
                          "execution_mode": "async", "bot": "6697add6b8e47524eb983373"}
 
     callback_config_3 = {
-      "name": "callback_script4",
-      "pyscript_code": "bot_response = f'hello -> {req}'",
-      "validation_secret": encrypt_secret("01916febcbe67a8a9a151842320697d2"),
-      "execution_mode": "async",
-      "expire_in": 0,
-      "shorten_token": False,
-      "standalone": False,
-      "standalone_id_path": "",
-      "bot": "6697add6b8e47524eb983373"
+        "name": "callback_script4",
+        "pyscript_code": "bot_response = f'hello -> {req}'",
+        "validation_secret": encrypt_secret("01916febcbe67a8a9a151842320697d2"),
+        "execution_mode": "async",
+        "expire_in": 0,
+        "shorten_token": False,
+        "standalone": False,
+        "standalone_id_path": "",
+        "bot": "6697add6b8e47524eb983373"
     }
-
 
     callback_data_3 = {
-      "action_name": "callback_action1",
-      "callback_name": "callback_script4",
-      "bot": "6697add6b8e47524eb983373",
-      "sender_id": "spandan.mondal@nimblework.com",
-      "channel": "unsupported (None)",
-      "metadata": {
-        "happy": "i am happy"
-      },
-      "identifier": "01916fefd1897634ad82274af4a7ecde",
-      "timestamp": 1724159873.4197152,
-      "callback_url": "http://localhost:5059/callback/d/01916fefd1897634ad82274af4a7ecde/gAAAAABmxJeByymLTcvGh3ZcnUVSeh6hZrEV2EAVfBmMm1X5lDgjaSSp4E6h9LiqBE34uRgriOLU2ZRkBoKkg7w_pbq6cQ6OC_afnHagr99xNyBfnvzfXMujGCVNnNSGnPnlVYlN_TBK66QoaDVt1o6Mp4b1kJYyBE1I-Avq69Mj-5IRA2D0KP2r80kTWGWIGzbGVwPlWtsqTQtGj-gLl_O9eKJ0s5i-XlZC5Ge0B2P-EUsXqAA_G2tlDMOjpk0g9ppUiRXt4KYiW2ZQ6MdrJTJDY2ohydYnLw==",
-      "execution_mode": "async",
-      "state": 0,
-      "is_valid": True
+        "action_name": "callback_action1",
+        "callback_name": "callback_script4",
+        "bot": "6697add6b8e47524eb983373",
+        "sender_id": "spandan.mondal@nimblework.com",
+        "channel": "unsupported (None)",
+        "metadata": {
+            "happy": "i am happy"
+        },
+        "identifier": "01916fefd1897634ad82274af4a7ecde",
+        "timestamp": 1724159873.4197152,
+        "callback_url": "http://localhost:5059/callback/d/01916fefd1897634ad82274af4a7ecde/gAAAAABmxJeByymLTcvGh3ZcnUVSeh6hZrEV2EAVfBmMm1X5lDgjaSSp4E6h9LiqBE34uRgriOLU2ZRkBoKkg7w_pbq6cQ6OC_afnHagr99xNyBfnvzfXMujGCVNnNSGnPnlVYlN_TBK66QoaDVt1o6Mp4b1kJYyBE1I-Avq69Mj-5IRA2D0KP2r80kTWGWIGzbGVwPlWtsqTQtGj-gLl_O9eKJ0s5i-XlZC5Ge0B2P-EUsXqAA_G2tlDMOjpk0g9ppUiRXt4KYiW2ZQ6MdrJTJDY2ohydYnLw==",
+        "execution_mode": "async",
+        "state": 0,
+        "is_valid": True
     }
-
 
     callback_config_4 = {
         "name": "callback_script5",
@@ -91,20 +89,20 @@ def setup():
     }
 
     callback_data_4 = {
-      "action_name": "callback_action1",
-      "callback_name": "callback_script5",
-      "bot": "6697add6b8e47524eb983373",
-      "sender_id": "spandan.mondal@nimblework.com",
-      "channel": "unsupported (None)",
-      "metadata": {
-        "happy": "I am happy"
-      },
-      "identifier": "019170001814712f8921076fd134a083",
-      "timestamp": 1724160940.057088,
-      "callback_url": "http://localhost:5059/callback/d/019170001814712f8921076fd134a083/98bxWFZL9nZy0L3lAKV2Qr_jI6iEQ6CpZq2vDnhQwQg",
-      "execution_mode": "sync",
-      "state": 0,
-      "is_valid": True
+        "action_name": "callback_action1",
+        "callback_name": "callback_script5",
+        "bot": "6697add6b8e47524eb983373",
+        "sender_id": "spandan.mondal@nimblework.com",
+        "channel": "unsupported (None)",
+        "metadata": {
+            "happy": "I am happy"
+        },
+        "identifier": "019170001814712f8921076fd134a083",
+        "timestamp": 1724160940.057088,
+        "callback_url": "http://localhost:5059/callback/d/019170001814712f8921076fd134a083/98bxWFZL9nZy0L3lAKV2Qr_jI6iEQ6CpZq2vDnhQwQg",
+        "execution_mode": "sync",
+        "state": 0,
+        "is_valid": True
     }
 
     callback_config_5 = {
@@ -120,51 +118,51 @@ def setup():
     }
 
     callback_data_5 = {
-      "action_name": "callback_action1",
-      "callback_name": "callback_script6",
-      "bot": "6697add6b8e47524eb983373",
-      "sender_id": "spandan.mondal@nimblework.com",
-      "channel": "unsupported (None)",
-      "metadata": {
-        "happy": "I am happy"
-      },
-      "identifier": "0191702183ca7ac6b75be9cd645c6437",
-      "timestamp": 1724163130.3162396,
-      "callback_url": "http://localhost:5059/callback/s/gAAAAABmxKQ6lHtDmxTmr_X4nyUGEKL72ylRLODr4IAxsUVr3e9dx7ZTDSL0IlzvGCwLzSDrsyVqanSPSj6JB7srql3dH-rVb9KG6oAcW4yhsMJVP_WPa9sD5J7NqCcShJI3KgjjE7kAEkqqr0VqE2XCEwC7vUCjcYPasw2q4PhOCvg-_CMxT6gC8ZQL7vUVi74FdOnNTQhfiOvXp4ggeV_Jq-xer_-8gTnsplM_nZ_HRxns45gGzAyvtwsUWYnWOPleh6HQn1rgmjfS1hQuYmR7JGxgZDFDZA==",
-      "execution_mode": "async",
-      "state": 0,
-      "is_valid": True
+        "action_name": "callback_action1",
+        "callback_name": "callback_script6",
+        "bot": "6697add6b8e47524eb983373",
+        "sender_id": "spandan.mondal@nimblework.com",
+        "channel": "unsupported (None)",
+        "metadata": {
+            "happy": "I am happy"
+        },
+        "identifier": "0191702183ca7ac6b75be9cd645c6437",
+        "timestamp": 1724163130.3162396,
+        "callback_url": "http://localhost:5059/callback/s/gAAAAABmxKQ6lHtDmxTmr_X4nyUGEKL72ylRLODr4IAxsUVr3e9dx7ZTDSL0IlzvGCwLzSDrsyVqanSPSj6JB7srql3dH-rVb9KG6oAcW4yhsMJVP_WPa9sD5J7NqCcShJI3KgjjE7kAEkqqr0VqE2XCEwC7vUCjcYPasw2q4PhOCvg-_CMxT6gC8ZQL7vUVi74FdOnNTQhfiOvXp4ggeV_Jq-xer_-8gTnsplM_nZ_HRxns45gGzAyvtwsUWYnWOPleh6HQn1rgmjfS1hQuYmR7JGxgZDFDZA==",
+        "execution_mode": "async",
+        "state": 0,
+        "is_valid": True
     }
 
     callback_config_6 = {
-      "name": "callback_script7",
-      "pyscript_code": "state += 1\nbot_response = f'state -> {state}'",
-      "validation_secret": encrypt_secret("0191703078f779199d90c1a91fe9839f"),
-      "execution_mode": "sync",
-      "expire_in": 0,
-      "shorten_token": True,
-      "token_hash": "0191703078f87a039906afc0a219dd5c",
-      "standalone": True,
-      "standalone_id_path": "data.id",
-      "bot": "6697add6b8e47524eb983373",
-      "token_value": "gAAAAABmxKl5tT0UKwkqYi2n9yV1lFAAJKsZEM0G9w7kmN8NIYR9JKF1F9ecZoUY6P9kClUC_QnLXXGLa3T4Xugdry84ioaDtGF9laXcQl_82Fvs9KmKX8xfa4-rJs1cto1Jd6fqeGIT7mR3kn56_EliP83aGoCl_sk9B0-2gPDgt-EJZQ20l-3OaT-rhFoFanjKvRiE8e4xp9sdxxjgDWLbCF3kCtTqTtg6Wovw3mXZoVzxzNEUmd2OGZiO6IsIJJaU202w3CZ2rPnmK8I2aRGg8tMi_-ObOg=="
+        "name": "callback_script7",
+        "pyscript_code": "state += 1\nbot_response = f'state -> {state}'",
+        "validation_secret": encrypt_secret("0191703078f779199d90c1a91fe9839f"),
+        "execution_mode": "sync",
+        "expire_in": 0,
+        "shorten_token": True,
+        "token_hash": "0191703078f87a039906afc0a219dd5c",
+        "standalone": True,
+        "standalone_id_path": "data.id",
+        "bot": "6697add6b8e47524eb983373",
+        "token_value": "gAAAAABmxKl5tT0UKwkqYi2n9yV1lFAAJKsZEM0G9w7kmN8NIYR9JKF1F9ecZoUY6P9kClUC_QnLXXGLa3T4Xugdry84ioaDtGF9laXcQl_82Fvs9KmKX8xfa4-rJs1cto1Jd6fqeGIT7mR3kn56_EliP83aGoCl_sk9B0-2gPDgt-EJZQ20l-3OaT-rhFoFanjKvRiE8e4xp9sdxxjgDWLbCF3kCtTqTtg6Wovw3mXZoVzxzNEUmd2OGZiO6IsIJJaU202w3CZ2rPnmK8I2aRGg8tMi_-ObOg=="
     }
 
     callback_data_6 = {
-      "action_name": "callback_action1",
-      "callback_name": "callback_script7",
-      "bot": "6697add6b8e47524eb983373",
-      "sender_id": "spandan.mondal@nimblework.com",
-      "channel": "unsupported (None)",
-      "metadata": {
-        "happy": "I am happy"
-      },
-      "identifier": "01917036016877eb8ffb3930e40f6162",
-      "timestamp": 1724164473.1961515,
-      "callback_url": "http://localhost:5059/callback/s/98bxWFcdoyN30eO5APd2Fb_ocqmBE_f7ZqinBXgElg8",
-      "execution_mode": "sync",
-      "state": 0,
-      "is_valid": True
+        "action_name": "callback_action1",
+        "callback_name": "callback_script7",
+        "bot": "6697add6b8e47524eb983373",
+        "sender_id": "spandan.mondal@nimblework.com",
+        "channel": "unsupported (None)",
+        "metadata": {
+            "happy": "I am happy"
+        },
+        "identifier": "01917036016877eb8ffb3930e40f6162",
+        "timestamp": 1724164473.1961515,
+        "callback_url": "http://localhost:5059/callback/s/98bxWFcdoyN30eO5APd2Fb_ocqmBE_f7ZqinBXgElg8",
+        "execution_mode": "sync",
+        "state": 0,
+        "is_valid": True
     }
 
     CallbackData.objects.delete()
@@ -211,11 +209,13 @@ async def test_healthcheck():
 
 
 @pytest.mark.asyncio
-@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message", new_callable=AsyncMock)
+@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message",
+       new_callable=AsyncMock)
 async def test_get_callback(mock_dispatch_message):
     await app.start()
     client = TestClient(app)
-    response = await client.get('/callback/d/01916940879576a391a0cd1223fa8684/gAAAAABmwuGEYHfCz1vYBH9cp8KVcB0Pf9y5c6N3IOYIw8y0A-m4dX2gE9VW-1c9yLAK-ZKXVODp58jmSfhyeI03yUkLR1kqZUNPk_qNRIKROMXMV-wKDbqAtWOwXBXM5EVbWNj6YHCyZKwJgrGidGSjpt7UrDnprr_rmDexgCssfag_5xEtrHzVSziDEZSDCHxupAJZ_l1AA8SkxwVpqgxLdt1Nu1r2SjyZaMvtt4TFYCKYIO6CeMfgShbEqcqHeonfox_UCbhPA68RNWWHhsoHh5o66fm94A==')
+    response = await client.get(
+        '/callback/d/01916940879576a391a0cd1223fa8684/gAAAAABmwuGEYHfCz1vYBH9cp8KVcB0Pf9y5c6N3IOYIw8y0A-m4dX2gE9VW-1c9yLAK-ZKXVODp58jmSfhyeI03yUkLR1kqZUNPk_qNRIKROMXMV-wKDbqAtWOwXBXM5EVbWNj6YHCyZKwJgrGidGSjpt7UrDnprr_rmDexgCssfag_5xEtrHzVSziDEZSDCHxupAJZ_l1AA8SkxwVpqgxLdt1Nu1r2SjyZaMvtt4TFYCKYIO6CeMfgShbEqcqHeonfox_UCbhPA68RNWWHhsoHh5o66fm94A==')
     assert response.status == 200
     json_response = await response.json()
     assert json_response["success"]
@@ -223,10 +223,11 @@ async def test_get_callback(mock_dispatch_message):
     assert json_response["message"] == "success"
     assert json_response["error_code"] == 0
     assert mock_dispatch_message.called_once()
-    
+
 
 @pytest.mark.asyncio
-@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message", new_callable=AsyncMock)
+@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message",
+       new_callable=AsyncMock)
 async def test_get_callback_response_type(mock_dispatch_message):
     await app.start()
     client = TestClient(app)
@@ -234,7 +235,8 @@ async def test_get_callback_response_type(mock_dispatch_message):
     callback.response_type = 'text'
     callback.save()
 
-    response = await client.get('/callback/d/01916940879576a391a0cd1223fa8684/gAAAAABmwuGEYHfCz1vYBH9cp8KVcB0Pf9y5c6N3IOYIw8y0A-m4dX2gE9VW-1c9yLAK-ZKXVODp58jmSfhyeI03yUkLR1kqZUNPk_qNRIKROMXMV-wKDbqAtWOwXBXM5EVbWNj6YHCyZKwJgrGidGSjpt7UrDnprr_rmDexgCssfag_5xEtrHzVSziDEZSDCHxupAJZ_l1AA8SkxwVpqgxLdt1Nu1r2SjyZaMvtt4TFYCKYIO6CeMfgShbEqcqHeonfox_UCbhPA68RNWWHhsoHh5o66fm94A==')
+    response = await client.get(
+        '/callback/d/01916940879576a391a0cd1223fa8684/gAAAAABmwuGEYHfCz1vYBH9cp8KVcB0Pf9y5c6N3IOYIw8y0A-m4dX2gE9VW-1c9yLAK-ZKXVODp58jmSfhyeI03yUkLR1kqZUNPk_qNRIKROMXMV-wKDbqAtWOwXBXM5EVbWNj6YHCyZKwJgrGidGSjpt7UrDnprr_rmDexgCssfag_5xEtrHzVSziDEZSDCHxupAJZ_l1AA8SkxwVpqgxLdt1Nu1r2SjyZaMvtt4TFYCKYIO6CeMfgShbEqcqHeonfox_UCbhPA68RNWWHhsoHh5o66fm94A==')
     assert response.status == 200
     json_response = await response.text()
     assert "i am happy : )" in json_response
@@ -248,7 +250,7 @@ async def test_get_callback_response_type(mock_dispatch_message):
         '/callback/d/01916940879576a391a0cd1223fa8684/gAAAAABmwuGEYHfCz1vYBH9cp8KVcB0Pf9y5c6N3IOYIw8y0A-m4dX2gE9VW-1c9yLAK-ZKXVODp58jmSfhyeI03yUkLR1kqZUNPk_qNRIKROMXMV-wKDbqAtWOwXBXM5EVbWNj6YHCyZKwJgrGidGSjpt7UrDnprr_rmDexgCssfag_5xEtrHzVSziDEZSDCHxupAJZ_l1AA8SkxwVpqgxLdt1Nu1r2SjyZaMvtt4TFYCKYIO6CeMfgShbEqcqHeonfox_UCbhPA68RNWWHhsoHh5o66fm94A==')
     assert response.status == 200
     json_response = await response.json()
-    assert  json_response == {'arr': [1,2,3]}
+    assert json_response == {'arr': [1, 2, 3]}
 
     callback.response_type = 'kairon_json'
     callback.pyscript_code = "bot_response = f\"{req} {metadata['happy']}\""
@@ -256,16 +258,18 @@ async def test_get_callback_response_type(mock_dispatch_message):
 
 
 @pytest.mark.asyncio
-@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message", new_callable=AsyncMock)
+@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message",
+       new_callable=AsyncMock)
 async def test_post_callback(mock_dispatch_message):
     await app.start()
     client = TestClient(app)
     req_body = {
-        'key_1' : 'value_1'
+        'key_1': 'value_1'
     }
 
-    response = await client.post('/callback/d/01916940879576a391a0cd1223fa8684/gAAAAABmwuGEYHfCz1vYBH9cp8KVcB0Pf9y5c6N3IOYIw8y0A-m4dX2gE9VW-1c9yLAK-ZKXVODp58jmSfhyeI03yUkLR1kqZUNPk_qNRIKROMXMV-wKDbqAtWOwXBXM5EVbWNj6YHCyZKwJgrGidGSjpt7UrDnprr_rmDexgCssfag_5xEtrHzVSziDEZSDCHxupAJZ_l1AA8SkxwVpqgxLdt1Nu1r2SjyZaMvtt4TFYCKYIO6CeMfgShbEqcqHeonfox_UCbhPA68RNWWHhsoHh5o66fm94A==',
-                                 content=JSONContent(req_body))
+    response = await client.post(
+        '/callback/d/01916940879576a391a0cd1223fa8684/gAAAAABmwuGEYHfCz1vYBH9cp8KVcB0Pf9y5c6N3IOYIw8y0A-m4dX2gE9VW-1c9yLAK-ZKXVODp58jmSfhyeI03yUkLR1kqZUNPk_qNRIKROMXMV-wKDbqAtWOwXBXM5EVbWNj6YHCyZKwJgrGidGSjpt7UrDnprr_rmDexgCssfag_5xEtrHzVSziDEZSDCHxupAJZ_l1AA8SkxwVpqgxLdt1Nu1r2SjyZaMvtt4TFYCKYIO6CeMfgShbEqcqHeonfox_UCbhPA68RNWWHhsoHh5o66fm94A==',
+        content=JSONContent(req_body))
     json_response = await response.json()
     assert json_response["success"]
     assert "'type': 'POST', 'body': {'key_1': 'value_1'}" in json_response["data"]
@@ -273,14 +277,17 @@ async def test_post_callback(mock_dispatch_message):
     assert json_response["error_code"] == 0
     assert mock_dispatch_message.called_once()
 
+
 @pytest.mark.asyncio
-@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message", new_callable=AsyncMock)
+@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message",
+       new_callable=AsyncMock)
 async def test_post_callback_req_body_non_json(mock_dispatch_message):
     await app.start()
     client = TestClient(app)
     req_body = "key_1=value_1"
-    response = await client.post('/callback/d/01916940879576a391a0cd1223fa8684/gAAAAABmwuGEYHfCz1vYBH9cp8KVcB0Pf9y5c6N3IOYIw8y0A-m4dX2gE9VW-1c9yLAK-ZKXVODp58jmSfhyeI03yUkLR1kqZUNPk_qNRIKROMXMV-wKDbqAtWOwXBXM5EVbWNj6YHCyZKwJgrGidGSjpt7UrDnprr_rmDexgCssfag_5xEtrHzVSziDEZSDCHxupAJZ_l1AA8SkxwVpqgxLdt1Nu1r2SjyZaMvtt4TFYCKYIO6CeMfgShbEqcqHeonfox_UCbhPA68RNWWHhsoHh5o66fm94A==',
-                                 content=JSONContent(req_body))
+    response = await client.post(
+        '/callback/d/01916940879576a391a0cd1223fa8684/gAAAAABmwuGEYHfCz1vYBH9cp8KVcB0Pf9y5c6N3IOYIw8y0A-m4dX2gE9VW-1c9yLAK-ZKXVODp58jmSfhyeI03yUkLR1kqZUNPk_qNRIKROMXMV-wKDbqAtWOwXBXM5EVbWNj6YHCyZKwJgrGidGSjpt7UrDnprr_rmDexgCssfag_5xEtrHzVSziDEZSDCHxupAJZ_l1AA8SkxwVpqgxLdt1Nu1r2SjyZaMvtt4TFYCKYIO6CeMfgShbEqcqHeonfox_UCbhPA68RNWWHhsoHh5o66fm94A==',
+        content=JSONContent(req_body))
     json_response = await response.json()
     print(json_response)
     assert json_response["success"]
@@ -289,12 +296,15 @@ async def test_post_callback_req_body_non_json(mock_dispatch_message):
     assert json_response["error_code"] == 0
     assert mock_dispatch_message.called_once()
 
+
 @pytest.mark.asyncio
-@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message", new_callable=AsyncMock)
+@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message",
+       new_callable=AsyncMock)
 async def test_put_callback(mock_dispatch_message):
     await app.start()
     client = TestClient(app)
-    response = await client.put('/callback/d/01916940879576a391a0cd1223fa8684/gAAAAABmwuGEYHfCz1vYBH9cp8KVcB0Pf9y5c6N3IOYIw8y0A-m4dX2gE9VW-1c9yLAK-ZKXVODp58jmSfhyeI03yUkLR1kqZUNPk_qNRIKROMXMV-wKDbqAtWOwXBXM5EVbWNj6YHCyZKwJgrGidGSjpt7UrDnprr_rmDexgCssfag_5xEtrHzVSziDEZSDCHxupAJZ_l1AA8SkxwVpqgxLdt1Nu1r2SjyZaMvtt4TFYCKYIO6CeMfgShbEqcqHeonfox_UCbhPA68RNWWHhsoHh5o66fm94A==')
+    response = await client.put(
+        '/callback/d/01916940879576a391a0cd1223fa8684/gAAAAABmwuGEYHfCz1vYBH9cp8KVcB0Pf9y5c6N3IOYIw8y0A-m4dX2gE9VW-1c9yLAK-ZKXVODp58jmSfhyeI03yUkLR1kqZUNPk_qNRIKROMXMV-wKDbqAtWOwXBXM5EVbWNj6YHCyZKwJgrGidGSjpt7UrDnprr_rmDexgCssfag_5xEtrHzVSziDEZSDCHxupAJZ_l1AA8SkxwVpqgxLdt1Nu1r2SjyZaMvtt4TFYCKYIO6CeMfgShbEqcqHeonfox_UCbhPA68RNWWHhsoHh5o66fm94A==')
 
     json_response = await response.json()
     print(json_response)
@@ -304,12 +314,15 @@ async def test_put_callback(mock_dispatch_message):
     assert json_response["error_code"] == 0
     assert mock_dispatch_message.called_once()
 
+
 @pytest.mark.asyncio
-@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message", new_callable=AsyncMock)
+@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message",
+       new_callable=AsyncMock)
 async def test_patch_callback(mock_dispatch_message):
     await app.start()
     client = TestClient(app)
-    response = await client.patch('/callback/d/01916940879576a391a0cd1223fa8684/gAAAAABmwuGEYHfCz1vYBH9cp8KVcB0Pf9y5c6N3IOYIw8y0A-m4dX2gE9VW-1c9yLAK-ZKXVODp58jmSfhyeI03yUkLR1kqZUNPk_qNRIKROMXMV-wKDbqAtWOwXBXM5EVbWNj6YHCyZKwJgrGidGSjpt7UrDnprr_rmDexgCssfag_5xEtrHzVSziDEZSDCHxupAJZ_l1AA8SkxwVpqgxLdt1Nu1r2SjyZaMvtt4TFYCKYIO6CeMfgShbEqcqHeonfox_UCbhPA68RNWWHhsoHh5o66fm94A==')
+    response = await client.patch(
+        '/callback/d/01916940879576a391a0cd1223fa8684/gAAAAABmwuGEYHfCz1vYBH9cp8KVcB0Pf9y5c6N3IOYIw8y0A-m4dX2gE9VW-1c9yLAK-ZKXVODp58jmSfhyeI03yUkLR1kqZUNPk_qNRIKROMXMV-wKDbqAtWOwXBXM5EVbWNj6YHCyZKwJgrGidGSjpt7UrDnprr_rmDexgCssfag_5xEtrHzVSziDEZSDCHxupAJZ_l1AA8SkxwVpqgxLdt1Nu1r2SjyZaMvtt4TFYCKYIO6CeMfgShbEqcqHeonfox_UCbhPA68RNWWHhsoHh5o66fm94A==')
 
     json_response = await response.json()
     print(json_response)
@@ -319,12 +332,15 @@ async def test_patch_callback(mock_dispatch_message):
     assert json_response["error_code"] == 0
     assert mock_dispatch_message.called_once()
 
+
 @pytest.mark.asyncio
-@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message", new_callable=AsyncMock)
+@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message",
+       new_callable=AsyncMock)
 async def test_delete_callback(mock_dispatch_message):
     await app.start()
     client = TestClient(app)
-    response = await client.delete('/callback/d/01916940879576a391a0cd1223fa8684/gAAAAABmwuGEYHfCz1vYBH9cp8KVcB0Pf9y5c6N3IOYIw8y0A-m4dX2gE9VW-1c9yLAK-ZKXVODp58jmSfhyeI03yUkLR1kqZUNPk_qNRIKROMXMV-wKDbqAtWOwXBXM5EVbWNj6YHCyZKwJgrGidGSjpt7UrDnprr_rmDexgCssfag_5xEtrHzVSziDEZSDCHxupAJZ_l1AA8SkxwVpqgxLdt1Nu1r2SjyZaMvtt4TFYCKYIO6CeMfgShbEqcqHeonfox_UCbhPA68RNWWHhsoHh5o66fm94A==')
+    response = await client.delete(
+        '/callback/d/01916940879576a391a0cd1223fa8684/gAAAAABmwuGEYHfCz1vYBH9cp8KVcB0Pf9y5c6N3IOYIw8y0A-m4dX2gE9VW-1c9yLAK-ZKXVODp58jmSfhyeI03yUkLR1kqZUNPk_qNRIKROMXMV-wKDbqAtWOwXBXM5EVbWNj6YHCyZKwJgrGidGSjpt7UrDnprr_rmDexgCssfag_5xEtrHzVSziDEZSDCHxupAJZ_l1AA8SkxwVpqgxLdt1Nu1r2SjyZaMvtt4TFYCKYIO6CeMfgShbEqcqHeonfox_UCbhPA68RNWWHhsoHh5o66fm94A==')
 
     json_response = await response.json()
     print(json_response)
@@ -332,7 +348,9 @@ async def test_delete_callback(mock_dispatch_message):
     assert "{'type': 'DELETE', 'body': None, 'params': {}" in json_response["data"]
     assert json_response["message"] == "success"
     assert json_response["error_code"] == 0
-    assert mock_dispatch_message.called_once_with("6697add6b8e47524eb983373", "5489844732", "{'type': 'DELETE', 'body': None, 'params': {}} i am happy : )", "telegram")
+    assert mock_dispatch_message.called_once_with("6697add6b8e47524eb983373", "5489844732",
+                                                  "{'type': 'DELETE', 'body': None, 'params': {}} i am happy : )",
+                                                  "telegram")
 
 
 @pytest.mark.asyncio
@@ -343,25 +361,28 @@ async def test_invalid_request():
 
 @pytest.mark.asyncio
 async def test_request_fallback_to_text():
-
     mock_request = AsyncMock(spec=Request)
     mock_request.json = AsyncMock(side_effect=Exception("JSON decode error"))
     mock_request.read = AsyncMock(return_value=b"test body content")
     mock_request.query = QueryParams({})
     mock_request.scope = {"client": ["127.0.0.1"]}
-    with patch("kairon.async_callback.processor.CallbackProcessor.process_async_callback_request", new=AsyncMock(return_value=({}, "Success", 0, 'kairon_json'))):
+    with patch("kairon.async_callback.processor.CallbackProcessor.process_async_callback_request",
+               new=AsyncMock(return_value=({}, "Success", 0, 'kairon_json'))):
         response = await process_router_message("valid_token", "test_name", "GET", request=mock_request)
     response_json = await response.json()
     assert response_json["success"] is True
     assert response_json["message"] == 'Success'
 
+
 @pytest.mark.asyncio
 @patch("kairon.async_callback.processor.CallbackProcessor.run_pyscript_async", new_callable=AsyncMock)
-@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message", new_callable=AsyncMock)
+@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message",
+       new_callable=AsyncMock)
 async def test_async_callback(mock_dispatch_message, mock_run_pyscript_async):
     await app.start()
     client = TestClient(app)
-    response = await client.get('/callback/d/01916fefd1897634ad82274af4a7ecde/gAAAAABmxJeByymLTcvGh3ZcnUVSeh6hZrEV2EAVfBmMm1X5lDgjaSSp4E6h9LiqBE34uRgriOLU2ZRkBoKkg7w_pbq6cQ6OC_afnHagr99xNyBfnvzfXMujGCVNnNSGnPnlVYlN_TBK66QoaDVt1o6Mp4b1kJYyBE1I-Avq69Mj-5IRA2D0KP2r80kTWGWIGzbGVwPlWtsqTQtGj-gLl_O9eKJ0s5i-XlZC5Ge0B2P-EUsXqAA_G2tlDMOjpk0g9ppUiRXt4KYiW2ZQ6MdrJTJDY2ohydYnLw==')
+    response = await client.get(
+        '/callback/d/01916fefd1897634ad82274af4a7ecde/gAAAAABmxJeByymLTcvGh3ZcnUVSeh6hZrEV2EAVfBmMm1X5lDgjaSSp4E6h9LiqBE34uRgriOLU2ZRkBoKkg7w_pbq6cQ6OC_afnHagr99xNyBfnvzfXMujGCVNnNSGnPnlVYlN_TBK66QoaDVt1o6Mp4b1kJYyBE1I-Avq69Mj-5IRA2D0KP2r80kTWGWIGzbGVwPlWtsqTQtGj-gLl_O9eKJ0s5i-XlZC5Ge0B2P-EUsXqAA_G2tlDMOjpk0g9ppUiRXt4KYiW2ZQ6MdrJTJDY2ohydYnLw==')
 
     json_response = await response.json()
     print(json_response)
@@ -376,12 +397,14 @@ async def test_async_callback(mock_dispatch_message, mock_run_pyscript_async):
 
 @pytest.mark.asyncio
 @patch("kairon.async_callback.processor.CallbackProcessor.run_pyscript")
-@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message", new_callable=AsyncMock)
+@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message",
+       new_callable=AsyncMock)
 async def test_pyscript_failure(mock_dispatch_message, mock_run_pyscript):
     await app.start()
     client = TestClient(app)
     mock_run_pyscript.side_effect = AppException("Error")
-    response = await client.get('/callback/d/01916940879576a391a0cd1223fa8684/gAAAAABmwuGEYHfCz1vYBH9cp8KVcB0Pf9y5c6N3IOYIw8y0A-m4dX2gE9VW-1c9yLAK-ZKXVODp58jmSfhyeI03yUkLR1kqZUNPk_qNRIKROMXMV-wKDbqAtWOwXBXM5EVbWNj6YHCyZKwJgrGidGSjpt7UrDnprr_rmDexgCssfag_5xEtrHzVSziDEZSDCHxupAJZ_l1AA8SkxwVpqgxLdt1Nu1r2SjyZaMvtt4TFYCKYIO6CeMfgShbEqcqHeonfox_UCbhPA68RNWWHhsoHh5o66fm94A==')
+    response = await client.get(
+        '/callback/d/01916940879576a391a0cd1223fa8684/gAAAAABmwuGEYHfCz1vYBH9cp8KVcB0Pf9y5c6N3IOYIw8y0A-m4dX2gE9VW-1c9yLAK-ZKXVODp58jmSfhyeI03yUkLR1kqZUNPk_qNRIKROMXMV-wKDbqAtWOwXBXM5EVbWNj6YHCyZKwJgrGidGSjpt7UrDnprr_rmDexgCssfag_5xEtrHzVSziDEZSDCHxupAJZ_l1AA8SkxwVpqgxLdt1Nu1r2SjyZaMvtt4TFYCKYIO6CeMfgShbEqcqHeonfox_UCbhPA68RNWWHhsoHh5o66fm94A==')
 
     json_response = await response.json()
     print(json_response)
@@ -396,12 +419,14 @@ async def test_pyscript_failure(mock_dispatch_message, mock_run_pyscript):
 
 @pytest.mark.asyncio
 @patch("kairon.async_callback.processor.CallbackProcessor.run_pyscript")
-@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message", new_callable=AsyncMock)
+@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message",
+       new_callable=AsyncMock)
 async def test_dispatch_message_failure(mock_dispatch_message, mock_run_pyscript):
     await app.start()
     client = TestClient(app)
     mock_dispatch_message.side_effect = AppException("Error")
-    response = await client.get('/callback/d/01916940879576a391a0cd1223fa8684/gAAAAABmwuGEYHfCz1vYBH9cp8KVcB0Pf9y5c6N3IOYIw8y0A-m4dX2gE9VW-1c9yLAK-ZKXVODp58jmSfhyeI03yUkLR1kqZUNPk_qNRIKROMXMV-wKDbqAtWOwXBXM5EVbWNj6YHCyZKwJgrGidGSjpt7UrDnprr_rmDexgCssfag_5xEtrHzVSziDEZSDCHxupAJZ_l1AA8SkxwVpqgxLdt1Nu1r2SjyZaMvtt4TFYCKYIO6CeMfgShbEqcqHeonfox_UCbhPA68RNWWHhsoHh5o66fm94A==')
+    response = await client.get(
+        '/callback/d/01916940879576a391a0cd1223fa8684/gAAAAABmwuGEYHfCz1vYBH9cp8KVcB0Pf9y5c6N3IOYIw8y0A-m4dX2gE9VW-1c9yLAK-ZKXVODp58jmSfhyeI03yUkLR1kqZUNPk_qNRIKROMXMV-wKDbqAtWOwXBXM5EVbWNj6YHCyZKwJgrGidGSjpt7UrDnprr_rmDexgCssfag_5xEtrHzVSziDEZSDCHxupAJZ_l1AA8SkxwVpqgxLdt1Nu1r2SjyZaMvtt4TFYCKYIO6CeMfgShbEqcqHeonfox_UCbhPA68RNWWHhsoHh5o66fm94A==')
 
     result = await response.json()
     assert result["error_code"] == 400
@@ -411,11 +436,13 @@ async def test_dispatch_message_failure(mock_dispatch_message, mock_run_pyscript
 
 
 @pytest.mark.asyncio
-@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message", new_callable=AsyncMock)
+@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message",
+       new_callable=AsyncMock)
 async def test_get_callback_url_shorten(mock_dispatch_message):
     await app.start()
     client = TestClient(app)
-    response = await client.get('/callback/d/019170001814712f8921076fd134a083/98bxWFZL9nZy0L3lAKV2Qr_jI6iEQ6CpZq2vDnhQwQg')
+    response = await client.get(
+        '/callback/d/019170001814712f8921076fd134a083/98bxWFZL9nZy0L3lAKV2Qr_jI6iEQ6CpZq2vDnhQwQg')
 
     json_response = await response.json()
     print(json_response)
@@ -427,15 +454,17 @@ async def test_get_callback_url_shorten(mock_dispatch_message):
 
 
 @pytest.mark.asyncio
-@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message", new_callable=AsyncMock)
+@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message",
+       new_callable=AsyncMock)
 async def test_post_callback_url_shorten(mock_dispatch_message):
     await app.start()
     client = TestClient(app)
     req_body = {
         'key_1': 'value_1'
     }
-    response = await client.post('/callback/d/019170001814712f8921076fd134a083/98bxWFZL9nZy0L3lAKV2Qr_jI6iEQ6CpZq2vDnhQwQg',
-                                 content=JSONContent(req_body))
+    response = await client.post(
+        '/callback/d/019170001814712f8921076fd134a083/98bxWFZL9nZy0L3lAKV2Qr_jI6iEQ6CpZq2vDnhQwQg',
+        content=JSONContent(req_body))
     json_response = await response.json()
     print(json_response)
     assert json_response["success"]
@@ -445,17 +474,18 @@ async def test_post_callback_url_shorten(mock_dispatch_message):
     assert json_response["error_code"] == 0
 
 
-
 @pytest.mark.asyncio
-@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message", new_callable=AsyncMock)
+@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message",
+       new_callable=AsyncMock)
 async def test_put_callback_url_shorten(mock_dispatch_message):
     await app.start()
     client = TestClient(app)
     req_body = {
         'key_1': 'value_1'
     }
-    response = await client.put('/callback/d/019170001814712f8921076fd134a083/98bxWFZL9nZy0L3lAKV2Qr_jI6iEQ6CpZq2vDnhQwQg',
-                                content=JSONContent(req_body))
+    response = await client.put(
+        '/callback/d/019170001814712f8921076fd134a083/98bxWFZL9nZy0L3lAKV2Qr_jI6iEQ6CpZq2vDnhQwQg',
+        content=JSONContent(req_body))
     json_response = await response.json()
     print(json_response)
     assert json_response["success"]
@@ -464,9 +494,9 @@ async def test_put_callback_url_shorten(mock_dispatch_message):
     assert json_response["error_code"] == 0
 
 
-
 @pytest.mark.asyncio
-@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message", new_callable=AsyncMock)
+@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message",
+       new_callable=AsyncMock)
 async def test_post_callback_standalone(mock_dispatch_message):
     await app.start()
     client = TestClient(app)
@@ -475,18 +505,21 @@ async def test_post_callback_standalone(mock_dispatch_message):
             'id': '0191702183ca7ac6b75be9cd645c6437'
         }
     }
-    response = await client.post('/callback/s/gAAAAABmxKQ6lHtDmxTmr_X4nyUGEKL72ylRLODr4IAxsUVr3e9dx7ZTDSL0IlzvGCwLzSDrsyVqanSPSj6JB7srql3dH-rVb9KG6oAcW4yhsMJVP_WPa9sD5J7NqCcShJI3KgjjE7kAEkqqr0VqE2XCEwC7vUCjcYPasw2q4PhOCvg-_CMxT6gC8ZQL7vUVi74FdOnNTQhfiOvXp4ggeV_Jq-xer_-8gTnsplM_nZ_HRxns45gGzAyvtwsUWYnWOPleh6HQn1rgmjfS1hQuYmR7JGxgZDFDZA==',
-                                 content=JSONContent(req_body))
+    response = await client.post(
+        '/callback/s/gAAAAABmxKQ6lHtDmxTmr_X4nyUGEKL72ylRLODr4IAxsUVr3e9dx7ZTDSL0IlzvGCwLzSDrsyVqanSPSj6JB7srql3dH-rVb9KG6oAcW4yhsMJVP_WPa9sD5J7NqCcShJI3KgjjE7kAEkqqr0VqE2XCEwC7vUCjcYPasw2q4PhOCvg-_CMxT6gC8ZQL7vUVi74FdOnNTQhfiOvXp4ggeV_Jq-xer_-8gTnsplM_nZ_HRxns45gGzAyvtwsUWYnWOPleh6HQn1rgmjfS1hQuYmR7JGxgZDFDZA==',
+        content=JSONContent(req_body))
     json_response = await response.json()
     print(json_response)
     assert json_response["success"]
-    assert "standalone -> {'type': 'POST', 'body': {'data': {'id': '0191702183ca7ac6b75be9cd645c6437'}}" in json_response["data"]
+    assert "standalone -> {'type': 'POST', 'body': {'data': {'id': '0191702183ca7ac6b75be9cd645c6437'}}" in \
+           json_response["data"]
     assert json_response["message"] == "success"
     assert json_response["error_code"] == 0
 
 
 @pytest.mark.asyncio
-@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message", new_callable=AsyncMock)
+@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message",
+       new_callable=AsyncMock)
 async def test_post_callback_standalone_identifier_path_not_present(mock_dispatch_message):
     await app.start()
     client = TestClient(app)
@@ -495,8 +528,9 @@ async def test_post_callback_standalone_identifier_path_not_present(mock_dispatc
             'idea': '0191702183ca7ac6b75be9cd645c6437'
         }
     }
-    response = await client.post('/callback/s/gAAAAABmxKQ6lHtDmxTmr_X4nyUGEKL72ylRLODr4IAxsUVr3e9dx7ZTDSL0IlzvGCwLzSDrsyVqanSPSj6JB7srql3dH-rVb9KG6oAcW4yhsMJVP_WPa9sD5J7NqCcShJI3KgjjE7kAEkqqr0VqE2XCEwC7vUCjcYPasw2q4PhOCvg-_CMxT6gC8ZQL7vUVi74FdOnNTQhfiOvXp4ggeV_Jq-xer_-8gTnsplM_nZ_HRxns45gGzAyvtwsUWYnWOPleh6HQn1rgmjfS1hQuYmR7JGxgZDFDZA==',
-                                 content=JSONContent(req_body))
+    response = await client.post(
+        '/callback/s/gAAAAABmxKQ6lHtDmxTmr_X4nyUGEKL72ylRLODr4IAxsUVr3e9dx7ZTDSL0IlzvGCwLzSDrsyVqanSPSj6JB7srql3dH-rVb9KG6oAcW4yhsMJVP_WPa9sD5J7NqCcShJI3KgjjE7kAEkqqr0VqE2XCEwC7vUCjcYPasw2q4PhOCvg-_CMxT6gC8ZQL7vUVi74FdOnNTQhfiOvXp4ggeV_Jq-xer_-8gTnsplM_nZ_HRxns45gGzAyvtwsUWYnWOPleh6HQn1rgmjfS1hQuYmR7JGxgZDFDZA==',
+        content=JSONContent(req_body))
     json_response = await response.json()
     print(json_response)
     assert not json_response["success"]
@@ -507,9 +541,9 @@ async def test_post_callback_standalone_identifier_path_not_present(mock_dispatc
                              'error_code': 400, 'data': None, 'success': False}
 
 
-
 @pytest.mark.asyncio
-@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message", new_callable=AsyncMock)
+@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message",
+       new_callable=AsyncMock)
 async def test_post_callback_standalone_wrong_identifier(mock_dispatch_message):
     await app.start()
     client = TestClient(app)
@@ -518,8 +552,9 @@ async def test_post_callback_standalone_wrong_identifier(mock_dispatch_message):
             'id': '0191702183ca7ac6b75be9cd645c6438'
         }
     }
-    response = await client.post('/callback/s/gAAAAABmxKQ6lHtDmxTmr_X4nyUGEKL72ylRLODr4IAxsUVr3e9dx7ZTDSL0IlzvGCwLzSDrsyVqanSPSj6JB7srql3dH-rVb9KG6oAcW4yhsMJVP_WPa9sD5J7NqCcShJI3KgjjE7kAEkqqr0VqE2XCEwC7vUCjcYPasw2q4PhOCvg-_CMxT6gC8ZQL7vUVi74FdOnNTQhfiOvXp4ggeV_Jq-xer_-8gTnsplM_nZ_HRxns45gGzAyvtwsUWYnWOPleh6HQn1rgmjfS1hQuYmR7JGxgZDFDZA==',
-                                 content=JSONContent(req_body))
+    response = await client.post(
+        '/callback/s/gAAAAABmxKQ6lHtDmxTmr_X4nyUGEKL72ylRLODr4IAxsUVr3e9dx7ZTDSL0IlzvGCwLzSDrsyVqanSPSj6JB7srql3dH-rVb9KG6oAcW4yhsMJVP_WPa9sD5J7NqCcShJI3KgjjE7kAEkqqr0VqE2XCEwC7vUCjcYPasw2q4PhOCvg-_CMxT6gC8ZQL7vUVi74FdOnNTQhfiOvXp4ggeV_Jq-xer_-8gTnsplM_nZ_HRxns45gGzAyvtwsUWYnWOPleh6HQn1rgmjfS1hQuYmR7JGxgZDFDZA==',
+        content=JSONContent(req_body))
     json_response = await response.json()
     print(json_response)
     assert not json_response["success"]
@@ -531,7 +566,8 @@ async def test_post_callback_standalone_wrong_identifier(mock_dispatch_message):
 
 
 @pytest.mark.asyncio
-@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message", new_callable=AsyncMock)
+@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message",
+       new_callable=AsyncMock)
 async def test_post_callback_standalone_url_shorten(mock_dispatch_message):
     await app.start()
     client = TestClient(app)
@@ -552,7 +588,8 @@ async def test_post_callback_standalone_url_shorten(mock_dispatch_message):
 
 
 @pytest.mark.asyncio
-@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message", new_callable=AsyncMock)
+@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message",
+       new_callable=AsyncMock)
 async def test_post_callback_standalone_url_shorten_wrong_url(mock_dispatch_message):
     await app.start()
     client = TestClient(app)
@@ -572,9 +609,9 @@ async def test_post_callback_standalone_url_shorten_wrong_url(mock_dispatch_mess
     assert json_response == {"message": "Invalid token!", "data": None, "error_code": 400, "success": False}
 
 
-
 @pytest.mark.asyncio
-@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message", new_callable=AsyncMock)
+@patch("kairon.async_callback.channel_message_dispacher.ChannelMessageDispatcher.dispatch_message",
+       new_callable=AsyncMock)
 async def test_post_callback_statechange(mock_dispatch_message):
     await app.start()
     client = TestClient(app)
@@ -604,7 +641,7 @@ async def test_post_callback_statechange(mock_dispatch_message):
     assert json_response == {"message": "success", "data": "state -> 2", "error_code": 0, "success": True}
 
     response = await client.post('/callback/s/98bxWFcdoyN30eO5APd2Fb_ocqmBE_f7ZqinBXgElg8',
-                            content=JSONContent(req_body))
+                                 content=JSONContent(req_body))
     json_response = await response.json()
     print(json_response)
     assert json_response["success"]
@@ -612,3 +649,48 @@ async def test_post_callback_statechange(mock_dispatch_message):
     assert json_response["error_code"] == 0
     assert json_response["data"] == 'state -> 3'
     assert json_response == {"message": "success", "data": "state -> 3", "error_code": 0, "success": True}
+
+
+@pytest.mark.asyncio
+@patch("kairon.async_callback.utils.CallbackUtility.main_pyscript_handler")
+async def test_execute_python_success(mock_handler):
+    await app.start()
+    client = TestClient(app)
+
+    payload = {
+        "source_code": "bot_response=100",
+        "predefined_objects": {"x": 1}
+    }
+
+    # Simulate response from handler
+    mock_handler.return_value = {"output": "Execution successful", "success": True}
+
+    response = await client.post("/main_pyscript/execute-python", content=JSONContent(payload))
+    json_response = await response.json()
+    print(json_response)
+
+    assert response.status == 200
+    assert json_response["output"] == "Execution successful"
+    assert json_response["success"] is True
+
+
+@pytest.mark.asyncio
+@patch("kairon.async_callback.utils.CallbackUtility.main_pyscript_handler")
+async def test_execute_python_failure(mock_handler):
+    await app.start()
+    client = TestClient(app)
+
+    payload = {
+        "source_code": "raise Exception('fail')",
+        "predefined_objects": {}
+    }
+
+    # Simulate exception from handler
+    mock_handler.side_effect = Exception("Restricted execution error")
+    print(app.router.routes)
+    response = await client.post("/main_pyscript/execute-python", content=JSONContent(payload))
+    json_response = await response.json()
+    print(json_response)
+
+    assert response.status == 500
+    assert json_response["success"] is False

--- a/tests/testing_data/system.yaml
+++ b/tests/testing_data/system.yaml
@@ -255,6 +255,7 @@ async_callback_action:
     aes_iv: ${ASYNC_CALLBACK_AES_IV:"2f7b56a2c3e4d5f681d8ab92bc9d8f47"}
   pyscript:
     trigger_task: ${CALLBACK_PYSCRIPT_TRIGGER_TASK:false}
+    url: ${TRIGGER_MAIN_PYSCRIPT_URL:"http://localhost:5059/main_pyscript/execute-python"}
 
 llm_metadata_file: "./tests/testing_data/llm_metadata.yml"
 

--- a/tests/unit_test/action/action_test.py
+++ b/tests/unit_test/action/action_test.py
@@ -200,26 +200,43 @@ class TestActions:
         tracker = Tracker(sender_id="sender1", slots=slots, events=events, paused=False, latest_message=latest_message,
                           followup_action=None, active_loop=None, latest_action_name=None)
         tracker_data = ActionUtility.build_context(tracker, True)
-        assert tracker_data == {'sender_id': 'sender1', 'user_message': 'get intents', 'slot': {'bot': '5j59kk1a76b698ca10d35d2e', 'param2': 'param2value', 'email': 'nkhare@digite.com', 'firstname': 'nupur'}, 'intent': 'http_action', 'chat_log': [], 'key_vault': {'EMAIL': 'nkhare@digite.com'}, 'latest_message': {'text': 'get intents', 'intent_ranking': [{'name': 'http_action'}]}, 'kairon_user_msg': None, 'session_started': None}
+        assert tracker_data == {'sender_id': 'sender1', 'user_message': 'get intents',
+                                'slot': {'bot': '5j59kk1a76b698ca10d35d2e', 'param2': 'param2value',
+                                         'email': 'nkhare@digite.com', 'firstname': 'nupur'}, 'intent': 'http_action',
+                                'chat_log': [], 'key_vault': {'EMAIL': 'nkhare@digite.com'},
+                                'latest_message': {'text': 'get intents', 'intent_ranking': [{'name': 'http_action'}]},
+                                'kairon_user_msg': None, 'session_started': None}
 
     def test_build_context_with_keyvault_flag_False(self):
         KeyVault(key="EMAIL", value="nkhare@digite.com", bot="5j59kk1a76b698ca10d35d2e", user="user").save()
-        slots = {"bot": "5j59kk1a76b698ca10d35d2e", "param2": "param2value", "email": "nkhare@digite.com", "firstname": "nupur"}
+        slots = {"bot": "5j59kk1a76b698ca10d35d2e", "param2": "param2value", "email": "nkhare@digite.com",
+                 "firstname": "nupur"}
         events = [{"event1": "hello"}, {"event2": "how are you"}]
         latest_message = {'text': 'get intents', 'intent_ranking': [{'name': 'http_action'}]}
         tracker = Tracker(sender_id="sender1", slots=slots, events=events, paused=False, latest_message=latest_message,
                           followup_action=None, active_loop=None, latest_action_name=None)
         tracker_data = ActionUtility.build_context(tracker, False)
-        assert tracker_data == {'sender_id': 'sender1', 'user_message': 'get intents', 'slot': {'bot': '5j59kk1a76b698ca10d35d2e', 'param2': 'param2value', 'email': 'nkhare@digite.com', 'firstname': 'nupur'}, 'intent': 'http_action', 'chat_log': [], 'key_vault': {}, 'latest_message': {'text': 'get intents', 'intent_ranking': [{'name': 'http_action'}]}, 'kairon_user_msg': None, 'session_started': None}
+        assert tracker_data == {'sender_id': 'sender1', 'user_message': 'get intents',
+                                'slot': {'bot': '5j59kk1a76b698ca10d35d2e', 'param2': 'param2value',
+                                         'email': 'nkhare@digite.com', 'firstname': 'nupur'}, 'intent': 'http_action',
+                                'chat_log': [], 'key_vault': {},
+                                'latest_message': {'text': 'get intents', 'intent_ranking': [{'name': 'http_action'}]},
+                                'kairon_user_msg': None, 'session_started': None}
+
     def test_build_context_no_keyvault(self):
-        slots = {"bot": "5z11mk1a76b698ca10d15d2e", "param2": "param2value", "email": "nupur@digite.com", "firstname": "nkhare"}
+        slots = {"bot": "5z11mk1a76b698ca10d15d2e", "param2": "param2value", "email": "nupur@digite.com",
+                 "firstname": "nkhare"}
         events = [{"event1": "hello"}, {"event2": "how are you"}]
         latest_message = {'text': 'get intents', 'intent_ranking': [{'name': 'http_action'}]}
         tracker = Tracker(sender_id="sender1", slots=slots, events=events, paused=False, latest_message=latest_message,
                           followup_action=None, active_loop=None, latest_action_name=None)
         tracker_data = ActionUtility.build_context(tracker, True)
-        assert tracker_data == {'sender_id': 'sender1', 'user_message': 'get intents', 'slot': {'bot': '5z11mk1a76b698ca10d15d2e', 'param2': 'param2value', 'email': 'nupur@digite.com', 'firstname': 'nkhare'}, 'intent': 'http_action', 'chat_log': [], 'key_vault': {}, 'latest_message': {'text': 'get intents', 'intent_ranking': [{'name': 'http_action'}]}, 'kairon_user_msg': None, 'session_started': None}
-
+        assert tracker_data == {'sender_id': 'sender1', 'user_message': 'get intents',
+                                'slot': {'bot': '5z11mk1a76b698ca10d15d2e', 'param2': 'param2value',
+                                         'email': 'nupur@digite.com', 'firstname': 'nkhare'}, 'intent': 'http_action',
+                                'chat_log': [], 'key_vault': {},
+                                'latest_message': {'text': 'get intents', 'intent_ranking': [{'name': 'http_action'}]},
+                                'kairon_user_msg': None, 'session_started': None}
 
     def test_execute_http_request_invalid_method_type(self):
         http_url = 'http://localhost:8080/mock'
@@ -541,9 +558,12 @@ class TestActions:
     def test_prepare_request(self):
         slots = {"bot": "demo_bot", "http_action_config": "http_action_name", "slot_name": "param2value"}
         http_action_config_params = [HttpActionRequestBody(key="param1", value="value1").to_mongo().to_dict(),
-                                     HttpActionRequestBody(key="param2", value="slot_name", parameter_type="slot").to_mongo().to_dict()]
+                                     HttpActionRequestBody(key="param2", value="slot_name",
+                                                           parameter_type="slot").to_mongo().to_dict()]
         tracker = {"sender_id": "sender1", "slot": slots}
-        actual_request_body, log = ActionUtility.prepare_request(tracker, http_action_config_params=http_action_config_params, bot="test")
+        actual_request_body, log = ActionUtility.prepare_request(tracker,
+                                                                 http_action_config_params=http_action_config_params,
+                                                                 bot="test")
         assert actual_request_body
         assert actual_request_body['param1'] == 'value1'
         assert actual_request_body['param2'] == 'param2value'
@@ -553,14 +573,22 @@ class TestActions:
         bot = "demo_bot"
         KeyVault(key="ACCESS_KEY", value="234567890fdsf", bot=bot, user="test_user").save()
         slots = {"bot": "demo_bot", "http_action_config": "http_action_name", "slot_name": "param2value"}
-        http_action_config_params = [HttpActionRequestBody(key="param1", value=Utility.encrypt_message("value1"), encrypt=True).to_mongo().to_dict(),
-                                     HttpActionRequestBody(key="param2", value="bot", parameter_type="slot", encrypt=True).to_mongo().to_dict(),
-                                     HttpActionRequestBody(key="param3", parameter_type="sender_id", encrypt=True).to_mongo().to_dict(),
-                                     HttpActionRequestBody(key="param4", parameter_type="user_message", encrypt=True).to_mongo().to_dict(),
-                                     HttpActionRequestBody(key="param5", parameter_type="intent", encrypt=True).to_mongo().to_dict(),
-                                     HttpActionRequestBody(key="param6", parameter_type="chat_log", encrypt=True).to_mongo().to_dict(),
-                                     HttpActionRequestBody(key="param7", value="http_action_config", parameter_type="slot", encrypt=True).to_mongo().to_dict(),
-                                     HttpActionRequestBody(key="param8", parameter_type="key_vault", value="ACCESS_KEY", encrypt=True).to_mongo().to_dict(),]
+        http_action_config_params = [HttpActionRequestBody(key="param1", value=Utility.encrypt_message("value1"),
+                                                           encrypt=True).to_mongo().to_dict(),
+                                     HttpActionRequestBody(key="param2", value="bot", parameter_type="slot",
+                                                           encrypt=True).to_mongo().to_dict(),
+                                     HttpActionRequestBody(key="param3", parameter_type="sender_id",
+                                                           encrypt=True).to_mongo().to_dict(),
+                                     HttpActionRequestBody(key="param4", parameter_type="user_message",
+                                                           encrypt=True).to_mongo().to_dict(),
+                                     HttpActionRequestBody(key="param5", parameter_type="intent",
+                                                           encrypt=True).to_mongo().to_dict(),
+                                     HttpActionRequestBody(key="param6", parameter_type="chat_log",
+                                                           encrypt=True).to_mongo().to_dict(),
+                                     HttpActionRequestBody(key="param7", value="http_action_config",
+                                                           parameter_type="slot", encrypt=True).to_mongo().to_dict(),
+                                     HttpActionRequestBody(key="param8", parameter_type="key_vault", value="ACCESS_KEY",
+                                                           encrypt=True).to_mongo().to_dict(), ]
         tracker = {"sender_id": "sender1", "slot": slots, "intent": "greet", "user_message": "hi",
                    "chat_log": [{'user': 'hi'}, {'bot': 'are you ok?'}, {'user': 'yes'}, {'bot': 'Great, carry on!'},
                                 {'user': 'hi'}], 'session_started': '2021-12-31 16:59:38'}
@@ -583,9 +611,12 @@ class TestActions:
     def test_prepare_request_empty_slot(self):
         slots = {"bot": "demo_bot", "http_action_config": "http_action_name", "param2": "param2value"}
         http_action_config_params = [HttpActionRequestBody(key="param1", value="value1").to_mongo().to_dict(),
-                                     HttpActionRequestBody(key="param3", value="", parameter_type="slot").to_mongo().to_dict()]
+                                     HttpActionRequestBody(key="param3", value="",
+                                                           parameter_type="slot").to_mongo().to_dict()]
         tracker = {"sender_id": "sender1", "slot": slots}
-        request_params, log = ActionUtility.prepare_request(tracker, http_action_config_params=http_action_config_params, bot="demo_bot")
+        request_params, log = ActionUtility.prepare_request(tracker,
+                                                            http_action_config_params=http_action_config_params,
+                                                            bot="demo_bot")
         assert request_params['param1'] == "value1"
         assert not request_params['param3']
         assert log == {'param1': 'value1', 'param3': None}
@@ -594,9 +625,12 @@ class TestActions:
         slots = {"bot": "demo_bot", "http_action_config": "http_action_name", "param2": "param2value"}
         events = [{"event1": "hello"}, {"event2": "how are you"}]
         http_action_config_params = [HttpActionRequestBody(key="param1", value="value1").to_mongo().to_dict(),
-                                     HttpActionRequestBody(key="user_id", value="", parameter_type="sender_id").to_mongo().to_dict()]
+                                     HttpActionRequestBody(key="user_id", value="",
+                                                           parameter_type="sender_id").to_mongo().to_dict()]
         tracker = {"sender_id": "kairon_user@digite.com", "slot": slots}
-        request_params, log = ActionUtility.prepare_request(tracker, http_action_config_params=http_action_config_params, bot="demo_bot")
+        request_params, log = ActionUtility.prepare_request(tracker,
+                                                            http_action_config_params=http_action_config_params,
+                                                            bot="demo_bot")
         assert request_params['param1'] == "value1"
         assert request_params['user_id'] == "kairon_user@digite.com"
         assert log == {'param1': 'value1', 'user_id': 'kairon_user@digite.com'}
@@ -605,9 +639,12 @@ class TestActions:
         slots = {"bot": "demo_bot", "http_action_config": "http_action_name", "param2": "param2value"}
         events = [{"event1": "hello"}, {"event2": "how are you"}]
         http_action_config_params = [HttpActionRequestBody(key="param1", value="value1").to_mongo().to_dict(),
-                                     HttpActionRequestBody(key="card_type", parameter_type="intent").to_mongo().to_dict()]
+                                     HttpActionRequestBody(key="card_type",
+                                                           parameter_type="intent").to_mongo().to_dict()]
         tracker = {"sender_id": "kairon_user@digite.com", "slot": slots, "intent": "restart"}
-        request_params, log = ActionUtility.prepare_request(tracker, http_action_config_params=http_action_config_params, bot="demo_bot")
+        request_params, log = ActionUtility.prepare_request(tracker,
+                                                            http_action_config_params=http_action_config_params,
+                                                            bot="demo_bot")
         assert request_params['param1'] == "value1"
         assert request_params['card_type'] == "restart"
         assert log['param1'] == "value1"
@@ -693,10 +730,13 @@ class TestActions:
                    'input_channel': 'cmdline', 'message_id': 'f4341cbf3eb1446e889a69d768ac091c', 'metadata': {}},
                   {'event': 'user_featurization', 'timestamp': 1640969987.350634, 'use_text_for_featurization': False}]
         http_action_config_params = [HttpActionRequestBody(key="intent", parameter_type="intent").to_mongo().to_dict(),
-                                     HttpActionRequestBody(key="user_msg", value="", parameter_type="chat_log").to_mongo().to_dict()]
+                                     HttpActionRequestBody(key="user_msg", value="",
+                                                           parameter_type="chat_log").to_mongo().to_dict()]
         tracker = {"sender_id": "kairon_user@digite.com", "slot": slots, "intent": "restart",
                    "chat_log": ActionUtility.prepare_message_trail(events)[1], 'session_started': '2021-12-31 16:59:38'}
-        request_params, log = ActionUtility.prepare_request(tracker, http_action_config_params=http_action_config_params, bot="test")
+        request_params, log = ActionUtility.prepare_request(tracker,
+                                                            http_action_config_params=http_action_config_params,
+                                                            bot="test")
         assert request_params == {'intent': 'restart', 'user_msg': {'sender_id': 'kairon_user@digite.com',
                                                                     'session_started': '2021-12-31 16:59:38',
                                                                     'conversation': [{'user': 'hi'}, {
@@ -726,23 +766,29 @@ class TestActions:
 
     def test_prepare_request_user_message(self):
         http_action_config_params = [HttpActionRequestBody(key="param1", value="value1").to_mongo().to_dict(),
-                                     HttpActionRequestBody(key="msg", parameter_type="user_message").to_mongo().to_dict()]
+                                     HttpActionRequestBody(key="msg",
+                                                           parameter_type="user_message").to_mongo().to_dict()]
         tracker = {"sender_id": "kairon_user@digite.com", "slot": None, "user_message": "perform google search"}
-        request_params, log = ActionUtility.prepare_request(tracker, http_action_config_params=http_action_config_params, bot="test")
+        request_params, log = ActionUtility.prepare_request(tracker,
+                                                            http_action_config_params=http_action_config_params,
+                                                            bot="test")
         assert request_params['param1'] == "value1"
         assert request_params['msg'] == "perform google search"
         assert log['param1'] == "value1"
         assert log['msg'] == "perform google search"
 
         tracker = {"sender_id": "kairon_user@digite.com", "slot": None}
-        request_params, log = ActionUtility.prepare_request(tracker, http_action_config_params=http_action_config_params, bot="test")
+        request_params, log = ActionUtility.prepare_request(tracker,
+                                                            http_action_config_params=http_action_config_params,
+                                                            bot="test")
         assert request_params['param1'] == "value1"
         assert not request_params['msg']
         assert log['param1'] == "value1"
         assert not log['msg']
 
         http_action_config_params = [HttpActionRequestBody(key="param1", value="value1").to_mongo().to_dict(),
-                                     HttpActionRequestBody(key="msg", parameter_type="user_message").to_mongo().to_dict()]
+                                     HttpActionRequestBody(key="msg",
+                                                           parameter_type="user_message").to_mongo().to_dict()]
         tracker = {"sender_id": "kairon_user@digite.com", "slot": None, "user_message": "/google_search",
                    KAIRON_USER_MSG_ENTITY: "using custom msg"}
         request_params, log = ActionUtility.prepare_request(tracker,
@@ -754,7 +800,8 @@ class TestActions:
         assert log['msg'] == "using custom msg"
 
         http_action_config_params = [HttpActionRequestBody(key="param1", value="value1").to_mongo().to_dict(),
-                                     HttpActionRequestBody(key="msg", parameter_type="user_message").to_mongo().to_dict()]
+                                     HttpActionRequestBody(key="msg",
+                                                           parameter_type="user_message").to_mongo().to_dict()]
         tracker = {"sender_id": "kairon_user@digite.com", "slot": None, "user_message": "perform google search",
                    KAIRON_USER_MSG_ENTITY: "using custom msg"}
         request_params, log = ActionUtility.prepare_request(tracker,
@@ -769,7 +816,9 @@ class TestActions:
         slots = {"bot": "demo_bot", "http_action_config": "http_action_name", "param2": "param2value"}
         http_action_config_params: List[dict] = None
         tracker = {"sender_id": "sender1", "slot": slots}
-        actual_request_body = ActionUtility.prepare_request(tracker, http_action_config_params=http_action_config_params, bot="test")
+        actual_request_body = ActionUtility.prepare_request(tracker,
+                                                            http_action_config_params=http_action_config_params,
+                                                            bot="test")
         assert actual_request_body == ({}, {})
 
     def test_encrypt_secrets(self):
@@ -1107,17 +1156,38 @@ class TestActions:
             return {"type": ActionType.pyscript_action.value}
 
         responses.add(
-            "POST", Utility.environment['evaluator']['pyscript']['url'],
-            json={"success": True, "data": {"bot_response": {'numbers': [1, 2, 3, 4, 5], 'total': 15, 'i': 5},
-                                            "slots": {'param2': 'param2value'}},
-                  "message": None, "error_code": 0},
-            match=[responses.matchers.json_params_matcher(
-                {'source_code': script,
-                 'predefined_objects': {'sender_id': 'sender1', 'user_message': 'get intents',
-                                        'latest_message': {'intent_ranking': [{'name': 'pyscript_action'}], 'text': 'get intents'},
-                                        'slot': {'param2': 'param2value', 'bot': '5f50fd0a56b698ca10d35d2z'},
-                                        'intent': 'pyscript_action', 'chat_log': [],
-                                        'key_vault': {}, 'kairon_user_msg': None, 'session_started': None}})])
+            responses.POST,
+            Utility.environment["async_callback_action"]["pyscript"]["url"],
+            json={
+                "success": True,
+                "body": {
+                    "bot_response": {"numbers": [1, 2, 3, 4, 5], "total": 15, "i": 5},
+                    "slots": {"param2": "param2value"}
+                },
+                "statusCode": 200
+            },
+            status=200,
+            match=[responses.matchers.json_params_matcher({
+                "source_code": script,
+                "predefined_objects": {
+                    "sender_id": "sender1",
+                    "user_message": "get intents",
+                    "latest_message": {
+                        "intent_ranking": [{"name": "pyscript_action"}],
+                        "text": "get intents"
+                    },
+                    "slot": {
+                        "param2": "param2value",
+                        "bot": "5f50fd0a56b698ca10d35d2z"
+                    },
+                    "intent": "pyscript_action",
+                    "chat_log": [],
+                    "key_vault": {},
+                    "kairon_user_msg": None,
+                    "session_started": None
+                }
+            })]
+        )
         mock_get_action.return_value = _get_action()
         dispatcher: CollectingDispatcher = CollectingDispatcher()
         tracker = Tracker(sender_id="sender1", slots=slots, events=events, paused=False, latest_message=latest_message,
@@ -1163,9 +1233,15 @@ class TestActions:
             return {"type": ActionType.pyscript_action.value}
 
         responses.add(
-            "POST", Utility.environment['evaluator']['pyscript']['url'],
-            json={"success": True, "data": {"bot_response": None, "slots": {'param2': 'param2value'}},
-                  "message": None, "error_code": 0},
+            "POST", Utility.environment['async_callback_action']['pyscript']['url'],
+            json={
+                "success": True,
+                "body": {
+                    "bot_response": None,
+                    "slots": {"param2": "param2value"}
+                },
+                "statusCode": 200
+            },
             match=[responses.matchers.json_params_matcher(
                 {'source_code': script,
                  'predefined_objects': {'sender_id': 'sender1', 'user_message': 'get intents',
@@ -1218,10 +1294,16 @@ class TestActions:
             return {"type": ActionType.pyscript_action.value}
 
         responses.add(
-            "POST", Utility.environment['evaluator']['pyscript']['url'],
-            json={"success": True, "data": {"bot_response": None,
-                                            "slots": {'param2': 'param2value'}, "type": "json"},
-                  "message": None, "error_code": 0},
+            "POST", Utility.environment['async_callback_action']['pyscript']['url'],
+            json={
+                "success": True,
+                "body": {
+                    "bot_response": None,
+                    "slots": {"param2": "param2value"},
+                    "type": "json"
+                },
+                "statusCode": 200
+            },
             match=[responses.matchers.json_params_matcher(
                 {'source_code': script,
                  'predefined_objects': {'sender_id': 'sender1', 'user_message': 'get intents',
@@ -1274,10 +1356,16 @@ class TestActions:
             return {"type": ActionType.pyscript_action.value}
 
         responses.add(
-            "POST", Utility.environment['evaluator']['pyscript']['url'],
-            json={"success": True, "data": {"bot_response": "Successfully Evaluated the pyscript",
-                                            "slots": {'param2': 'param2value'}, "type": "json"},
-                  "message": None, "error_code": 0},
+            "POST", Utility.environment['async_callback_action']['pyscript']['url'],
+            json={
+                "success": True,
+                "body": {
+                    "bot_response": None,
+                    "slots": {"param2": "param2value"},
+                    "type": "json"
+                },
+                "statusCode": 200
+            },
             match=[responses.matchers.json_params_matcher(
                 {'source_code': script,
                  'predefined_objects': {'sender_id': 'sender1', 'user_message': 'get intents',
@@ -1299,7 +1387,7 @@ class TestActions:
         assert len(actual) == 2
         assert actual == [{'event': 'slot', 'timestamp': None, 'name': 'param2', 'value': 'param2value'},
                           {'event': 'slot', 'timestamp': None, 'name': 'kairon_action_response',
-                           'value': "Successfully Evaluated the pyscript"}]
+                           'value': None}]
 
     @responses.activate
     @pytest.mark.asyncio
@@ -1331,10 +1419,16 @@ class TestActions:
             return {"type": ActionType.pyscript_action.value}
 
         responses.add(
-            "POST", Utility.environment['evaluator']['pyscript']['url'],
-            json={"success": True, "data": {"bot_response": "Successfully Evaluated the pyscript",
-                                            "slots": {'param2': 'param2value'}, "type": "data"},
-                  "message": None, "error_code": 0},
+            "POST", Utility.environment['async_callback_action']['pyscript']['url'],
+            json={
+                "success": True,
+                "body": {
+                    "bot_response": None,
+                    "slots": {"param2": "param2value"},
+                    "type": "data"
+                },
+                "statusCode": 200
+            },
             match=[responses.matchers.json_params_matcher(
                 {'source_code': script,
                  'predefined_objects': {'sender_id': 'sender1', 'user_message': 'get intents',
@@ -1356,7 +1450,7 @@ class TestActions:
         assert len(actual) == 2
         assert actual == [{'event': 'slot', 'timestamp': None, 'name': 'param2', 'value': 'param2value'},
                           {'event': 'slot', 'timestamp': None, 'name': 'kairon_action_response',
-                           'value': "Successfully Evaluated the pyscript"}]
+                           'value': None}]
 
     @responses.activate
     @pytest.mark.asyncio
@@ -1388,10 +1482,16 @@ class TestActions:
             return {"type": ActionType.pyscript_action.value}
 
         responses.add(
-            "POST", Utility.environment['evaluator']['pyscript']['url'],
-            json={"success": True, "data": {"bot_response": "Successfully Evaluated the pyscript",
-                                            "slots": "invalid slots values", "type": "text"},
-                  "message": None, "error_code": 0},
+            "POST", Utility.environment['async_callback_action']['pyscript']['url'],
+            json={
+                "success": True,
+                "body": {
+                    "bot_response": "Successfully Evaluated the pyscript",
+                    "slots": "invalid slots values", "type": "text",
+                    "type": "text"
+                },
+                "statusCode": 200
+            },
             match=[responses.matchers.json_params_matcher(
                 {'source_code': script,
                  'predefined_objects': {'sender_id': 'sender1', 'user_message': 'get intents',
@@ -1457,10 +1557,12 @@ class TestActions:
                                       "slots": {"param2": "param2value"}}}, "StatusCode": 200}
             mock_get_action.return_value = _get_action()
             dispatcher: CollectingDispatcher = CollectingDispatcher()
-            tracker = Tracker(sender_id="sender1", slots=slots, events=events, paused=False, latest_message=latest_message,
+            tracker = Tracker(sender_id="sender1", slots=slots, events=events, paused=False,
+                              latest_message=latest_message,
                               followup_action=None, active_loop=None, latest_action_name=None)
             domain: Dict[Text, Any] = None
-            actual: List[Dict[Text, Any]] = await ActionProcessor.process_action(dispatcher, tracker, domain, action_name)
+            actual: List[Dict[Text, Any]] = await ActionProcessor.process_action(dispatcher, tracker, domain,
+                                                                                 action_name)
             log = ActionServerLogs.objects(sender="sender1",
                                            action=action_name,
                                            bot="5f50fd0a56b698ca10d35d2a",
@@ -1494,12 +1596,13 @@ class TestActions:
         def _get_action(*args, **kwargs):
             return {"type": ActionType.pyscript_action.value}
 
-
         responses.add(
-            "POST", Utility.environment['evaluator']['pyscript']['url'],
-            json={"success": False, "data": None,
-                  "message": 'Script execution error: ("Line 2: SyntaxError: invalid syntax at statement: for i in 10",)',
-                  "error_code": 422},
+            "POST", Utility.environment['async_callback_action']['pyscript']['url'],
+            json={
+                "success": False,
+                "body": None,
+                "statusCode": 422
+            },
             match=[responses.matchers.json_params_matcher(
                 {'source_code': script,
                  'predefined_objects': {'sender_id': 'sender1', 'user_message': 'get intents',
@@ -1520,7 +1623,7 @@ class TestActions:
                                        bot="5f50fd0a56b698ca10d35d2z",
                                        status="FAILURE").get()
         assert log['bot_response'] == 'I have failed to process your request'
-        assert log['exception'] == 'Pyscript evaluation failed: {\'success\': False, \'data\': None, \'message\': \'Script execution error: ("Line 2: SyntaxError: invalid syntax at statement: for i in 10",)\', \'error_code\': 422}'
+        assert log['exception'] == "Pyscript evaluation failed: {'success': False, 'body': None, 'statusCode': 422}"
 
     @responses.activate
     @pytest.mark.asyncio
@@ -1554,8 +1657,10 @@ class TestActions:
             import requests
             raise requests.exceptions.ConnectionError(f"Failed to connect to service: localhost")
 
-        responses.add_callback(
-            "POST", Utility.environment['evaluator']['pyscript']['url'], callback=raise_custom_exception,
+        import requests
+        responses.add(
+            "POST", Utility.environment['async_callback_action']['pyscript']['url'],
+            body=requests.exceptions.ConnectionError("Failed to connect to service: localhost"),
             match=[responses.matchers.json_params_matcher(
                 {'source_code': script,
                  'predefined_objects': {'sender_id': 'sender1', 'user_message': 'get intents',
@@ -1572,16 +1677,18 @@ class TestActions:
                           followup_action=None, active_loop=None, latest_action_name=None)
         domain: Dict[Text, Any] = None
         actual: List[Dict[Text, Any]] = await ActionProcessor.process_action(dispatcher, tracker, domain, action_name)
-        log = ActionServerLogs.objects(sender="sender1",
-                                       action=action_name,
-                                       bot="5f50fd0a56b698ca10d35d2z",
-                                       status="FAILURE").get()
-        assert log['exception'].__contains__('Failed to execute the url: Failed to connect to service: localhost')
+        log = ActionServerLogs.objects(
+            sender="sender1",
+            action=action_name,
+            bot="5f50fd0a56b698ca10d35d2z",
+            status="FAILURE"
+        ).get()
+        assert "Failed to connect to service: localhost" in log.exception
 
     @pytest.mark.asyncio
     @responses.activate
     @mock.patch("kairon.shared.actions.utils.ActionUtility.execute_request_async", autospec=True)
-    async def test_run(self, mock_execute_request_async,monkeypatch):
+    async def test_run(self, mock_execute_request_async, monkeypatch):
         http_url = "http://www.google.com"
         http_response = "This should be response"
         action = HttpActionConfig(
@@ -1597,8 +1704,8 @@ class TestActions:
 
         def _get_action(*args, **kwargs):
             return {"type": ActionType.http_action.value}
-        monkeypatch.setattr(ActionUtility, "get_action", _get_action)
 
+        monkeypatch.setattr(ActionUtility, "get_action", _get_action)
 
         responses.add(
             method=responses.GET,
@@ -1653,7 +1760,8 @@ class TestActions:
         monkeypatch.setattr(ActionUtility, "get_action", _get_action)
         aioresponses.add(
             method=responses.GET,
-            url="http://www.google.com/sender_test_run_with_params?id=param2value&"+urlencode({'key1': 'value1', 'key2': 'value2'}),
+            url="http://www.google.com/sender_test_run_with_params?id=param2value&" + urlencode(
+                {'key1': 'value1', 'key2': 'value2'}),
             body=http_response,
             status=200,
         )
@@ -1704,12 +1812,11 @@ class TestActions:
 
         monkeypatch.setattr(ActionUtility, "get_action", _get_action)
 
-
         resp_msg = {"sender_id": "default_sender", "user_message": "get intents", "intent": "test_run"}
         responses.add(
             method=responses.POST,
-            url=Utility.environment['evaluator']['pyscript']['url'],
-            json={"success": True, "data": {"body" : resp_msg}, 'error_code': 0},
+            url=Utility.environment['async_callback_action']['pyscript']['url'],
+            json={"success": True, "body": {"body": resp_msg}, "statusCode": 200, 'error_code': 0},
             status=200,
         )
         aioresponses.add(
@@ -1861,8 +1968,8 @@ class TestActions:
         resp_msg = {"sender_id": "default_sender", "user_message": "get intents", "intent": "test_run"}
         responses.add(
             method=responses.POST,
-            url=Utility.environment['evaluator']['pyscript']['url'],
-            json={"success": True, "data": {"bot_response": resp_msg}, 'error_code': 0},
+            url=Utility.environment['async_callback_action']['pyscript']['url'],
+            json={"success": True, "body": {"bot_response": resp_msg}, "statusCode": 200, 'error_code': 0},
             status=200,
         )
 
@@ -1915,7 +2022,6 @@ class TestActions:
 
         monkeypatch.setattr(ActionUtility, "get_action", _get_action)
         http_url = 'http://localhost:8081/mock'
-
 
         resp_msg = json.dumps({
             "a": {
@@ -1988,27 +2094,30 @@ class TestActions:
         )
         responses.add(
             method=responses.POST,
-            url=Utility.environment['evaluator']['pyscript']['url'],
-            json={"success": True, "data":  {'bot_response' : data_obj}, 'error_code' : 0},
+            url=Utility.environment['async_callback_action']['pyscript']['url'],
+            json={"success": True, "body": {'bot_response': data_obj}, "statusCode": 200, 'error_code': 0},
             status=200,
             match=[
                 responses.matchers.json_params_matcher(
                     {'predefined_objects': {'bot': '5f50fd0a56b698ca10d35d2e', 'chat_log': [],
                                             'data': data_obj, 'intent': 'test_run', 'kairon_user_msg': None,
-                                            'key_vault': {'API_KEY': 'asdfghjkertyuio', 'API_SECRET': 'sdfghj345678dfghj', 'EMAIL': 'uditpandey@digite.com', 'FIRSTNAME': 'udit'},
+                                            'key_vault': {'API_KEY': 'asdfghjkertyuio',
+                                                          'API_SECRET': 'sdfghj345678dfghj',
+                                                          'EMAIL': 'uditpandey@digite.com', 'FIRSTNAME': 'udit'},
                                             'latest_message': {'intent_ranking': [{'name': 'test_run'}],
                                                                'text': 'get intents'},
                                             'sender_id': 'default_sender', 'session_started': None,
                                             'slot': {'bot': '5f50fd0a56b698ca10d35d2e'}, 'http_status_code': 200,
                                             'response_headers': {'Content-Type': 'application/json'},
                                             'user_message': 'get intents'},
-                     'source_code': "bot_response=data"} )],
+                     'source_code': "bot_response=data"})],
         )
         slots = {"bot": "5f50fd0a56b698ca10d35d2e"}
         events = [{"event1": "hello"}, {"event2": "how are you"}]
         dispatcher: CollectingDispatcher = CollectingDispatcher()
         latest_message = {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]}
-        tracker = Tracker(sender_id="default_sender", slots=slots, events=events, paused=False, latest_message=latest_message,
+        tracker = Tracker(sender_id="default_sender", slots=slots, events=events, paused=False,
+                          latest_message=latest_message,
                           followup_action=None, active_loop=None, latest_action_name=None)
         domain: Dict[Text, Any] = None
         action.save().to_mongo().to_dict()
@@ -2062,14 +2171,16 @@ class TestActions:
         http_url = 'http://localhost:8081/mock'
         responses.add(
             method=responses.POST,
-            url=Utility.environment['evaluator']['pyscript']['url'],
-            json={"success": True, "data": resp_msg, 'error_code': 0},
+            url=Utility.environment['async_callback_action']['pyscript']['url'],
+            json={"success": True, "body": resp_msg, "statusCode": 200, 'error_code': 0},
             status=200,
             match=[
                 responses.matchers.json_params_matcher(
                     {"predefined_objects": {"bot": "5f50fd0a56b698ca10d35d2e", "chat_log": [],
                                             "intent": "test_run", "kairon_user_msg": None,
-                                            "key_vault": {'API_KEY': 'asdfghjkertyuio', 'API_SECRET': 'sdfghj345678dfghj', 'EMAIL': 'uditpandey@digite.com', 'FIRSTNAME': 'udit'},
+                                            "key_vault": {'API_KEY': 'asdfghjkertyuio',
+                                                          'API_SECRET': 'sdfghj345678dfghj',
+                                                          'EMAIL': 'uditpandey@digite.com', 'FIRSTNAME': 'udit'},
                                             "latest_message": {"intent_ranking": [{"name": "test_run"}],
                                                                "text": "get intents"}, "sender_id": "default_sender",
                                             "session_started": None, "slot": {"bot": "5f50fd0a56b698ca10d35d2e"},
@@ -2094,14 +2205,16 @@ class TestActions:
         )
         responses.add(
             method=responses.POST,
-            url=Utility.environment['evaluator']['pyscript']['url'],
-            json={"success": True, "data": {'bot_response': 'Mayank'}, 'error_code': 0},
+            url=Utility.environment['async_callback_action']['pyscript']['url'],
+            json={"success": True, "body": {'bot_response': 'Mayank'}, "statusCode": 200, 'error_code': 0},
             status=200,
             match=[
                 responses.matchers.json_params_matcher(
                     {'predefined_objects': {'bot': '5f50fd0a56b698ca10d35d2e', 'chat_log': [],
                                             'data': data_obj, 'intent': 'test_run', 'kairon_user_msg': None,
-                                            'key_vault': {'API_KEY': 'asdfghjkertyuio', 'API_SECRET': 'sdfghj345678dfghj', 'EMAIL': 'uditpandey@digite.com', 'FIRSTNAME': 'udit'},
+                                            'key_vault': {'API_KEY': 'asdfghjkertyuio',
+                                                          'API_SECRET': 'sdfghj345678dfghj',
+                                                          'EMAIL': 'uditpandey@digite.com', 'FIRSTNAME': 'udit'},
                                             'latest_message': {'intent_ranking': [{'name': 'test_run'}],
                                                                'text': 'get intents'},
                                             'sender_id': 'default_sender', 'session_started': None,
@@ -2115,7 +2228,8 @@ class TestActions:
         dispatcher: CollectingDispatcher = CollectingDispatcher()
         latest_message = {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]}
         tracker = Tracker(sender_id="default_sender", slots=slots, events=events, paused=False,
-                          latest_message=latest_message,followup_action=None, active_loop=None, latest_action_name=None)
+                          latest_message=latest_message, followup_action=None, active_loop=None,
+                          latest_action_name=None)
         domain: Dict[Text, Any] = None
         action.save().to_mongo().to_dict()
         actual: List[Dict[Text, Any]] = await ActionProcessor.process_action(dispatcher, tracker, domain,
@@ -2222,8 +2336,9 @@ class TestActions:
 
     def test_prepare_response_with_prefix(self):
         http_response = {"data": {"price": [{"dollars": "51"}, {"rupee": "151"}]}, "context": {}}
-        output = ActionUtility.prepare_response("I want rupee${data.price.1.rupee}. Also, want $${data.price.0.dollars}",
-                                                http_response)
+        output = ActionUtility.prepare_response(
+            "I want rupee${data.price.1.rupee}. Also, want $${data.price.0.dollars}",
+            http_response)
         assert output == 'I want rupee151. Also, want $51'
 
     def test_retrieve_value_from_response(self):
@@ -4014,7 +4129,6 @@ class TestActions:
                                 "data: {'data': {'name': 'mayank', 'exp': 30, 'score': 10}, 'context': {}}",
                                 'raise_err_on_failure: True']
 
-    
     def test_retrieve_config_two_stage_fallback(self):
         bot = "test_bot"
         user = "test_user"
@@ -4064,9 +4178,19 @@ class TestActions:
                                 'live_agent_enabled': False,
                                 'retry_broadcasting_limit': 3}
 
+
     def test_get_prompt_action_config_2(self):
         bot = "test_bot_action_test"
         user = "test_user_action_test"
+        llm_secret = LLMSecret(
+            llm_type="openai",
+            api_key='value',
+            models=["gpt-3.5-turbo", "gpt-4.1-mini"],
+            bot=bot,
+            user=user
+        )
+        llm_secret.save()
+
         llm_prompts = [{'name': 'System Prompt', 'data': 'You are a personal assistant.', 'type': 'system',
                         'source': 'static', 'is_enabled': True},
                        {'name': 'History Prompt', 'type': 'user', 'source': 'history', 'is_enabled': True},
@@ -4087,22 +4211,21 @@ class TestActions:
                                        'hyperparameters': {'temperature': 0.0, 'max_tokens': 300, 'model': 'gpt-4.1-mini',
                                                            'top_p': 0.0, 'n': 1, 'stop': None,
                                                            'presence_penalty': 0.0, 'frequency_penalty': 0.0,
-                                                           'logit_bias': {}}, 'dispatch_response': True,
-                                       'set_slots': [],
+                                                           'logit_bias': {}}, 'dispatch_response': True, 'set_slots': [],
                                        'llm_type': 'openai',
-                                       'llm_prompts': [
-                                           {'name': 'System Prompt', 'data': 'You are a personal assistant.',
-                                            'type': 'system', 'source': 'static', 'is_enabled': True},
-                                           {'name': 'History Prompt', 'type': 'user',
-                                            'source': 'history', 'is_enabled': True},
-                                           {'name': 'Similarity Prompt',
-                                            'hyperparameters': {'top_results': 30,
-                                                                'similarity_threshold': 0.3},
-                                            'data': 'default',
-                                            'instructions': 'Answer question based on the context above, if answer is not in the context go check previous logs.',
-                                            'type': 'user', 'source': 'bot_content', 'is_enabled': True}],
+                                       'llm_prompts': [{'name': 'System Prompt', 'data': 'You are a personal assistant.',
+                                                        'type': 'system', 'source': 'static', 'is_enabled': True},
+                                                       {'name': 'History Prompt', 'type': 'user',
+                                                        'source': 'history', 'is_enabled': True},
+                                                       {'name': 'Similarity Prompt',
+                                                        'hyperparameters': {'top_results': 30,
+                                                                            'similarity_threshold': 0.3},
+                                                        'data': 'default',
+                                                        'instructions': 'Answer question based on the context above, if answer is not in the context go check previous logs.',
+                                                        'type': 'user', 'source': 'bot_content', 'is_enabled': True}],
                                        'instructions': [],
                                        'status': True}
+        LLMSecret.objects.delete()
 
     def test_retrieve_config_two_stage_fallback_not_found(self):
         with pytest.raises(ActionFailure, match="Two stage fallback action config not found"):

--- a/tests/unit_test/action/action_test.py
+++ b/tests/unit_test/action/action_test.py
@@ -48,6 +48,7 @@ from kairon.shared.actions.exception import ActionFailure
 from unittest.mock import patch
 from urllib.parse import urlencode
 
+
 class TestActions:
 
     @pytest.fixture(autouse=True, scope='class')
@@ -2626,10 +2627,62 @@ class TestActions:
             ActionEmail("test", "test_email_action_not_found").retrieve_config()
 
     def test_prepare_email_body(self):
-        Utility.email_conf['email']['templates']['conversation'] = open('template/emails/conversation.html', 'rb').read().decode()
-        Utility.email_conf['email']['templates']['bot_msg_conversation'] = open('template/emails/bot_msg_conversation.html', 'rb').read().decode()
-        Utility.email_conf['email']['templates']['user_msg_conversation'] = open('template/emails/user_msg_conversation.html', 'rb').read().decode()
-        events = [{"event":"action","timestamp":1594907100.12764,"name":"action_session_start","policy":None,"confidence":None},{"event":"session_started","timestamp":1594907100.12765},{"event":"action","timestamp":1594907100.12767,"name":"action_listen","policy":None,"confidence":None},{"event":"user","timestamp":1594907100.42744,"text":"can't","parse_data":{"intent":{"name":"test intent","confidence":0.253578245639801},"entities":[],"intent_ranking":[{"name":"test intent","confidence":0.253578245639801},{"name":"goodbye","confidence":0.1504897326231},{"name":"greet","confidence":0.138640150427818},{"name":"affirm","confidence":0.0857767835259438},{"name":"smalltalk_human","confidence":0.0721133947372437},{"name":"deny","confidence":0.069614589214325},{"name":"bot_challenge","confidence":0.0664894133806229},{"name":"faq_vaccine","confidence":0.062177762389183},{"name":"faq_testing","confidence":0.0530692934989929},{"name":"out_of_scope","confidence":0.0480506233870983}],"response_selector":{"default":{"response":{"name":None,"confidence":0},"ranking":[],"full_retrieval_intent":None}},"text":"can't"},"input_channel":None,"message_id":"bbd413bf5c834bf3b98e0da2373553b2","metadata":{}},{"event":"action","timestamp":1594907100.4308,"name":"utter_test intent","policy":"policy_0_MemoizationPolicy","confidence":1},{"event":"bot","timestamp":1594907100.4308,"text":"will not = won\"t","data":{"elements":None,"quick_replies":None,"buttons":None,"attachment":None,"image":None,"custom":None},"metadata":{}},{"event":"action","timestamp":1594907100.43384,"name":"action_listen","policy":"policy_0_MemoizationPolicy","confidence":1},{"event":"user","timestamp":1594907117.04194,"text":"can\"t","parse_data":{"intent":{"name":"test intent","confidence":0.253578245639801},"entities":[],"intent_ranking":[{"name":"test intent","confidence":0.253578245639801},{"name":"goodbye","confidence":0.1504897326231},{"name":"greet","confidence":0.138640150427818},{"name":"affirm","confidence":0.0857767835259438},{"name":"smalltalk_human","confidence":0.0721133947372437},{"name":"deny","confidence":0.069614589214325},{"name":"bot_challenge","confidence":0.0664894133806229},{"name":"faq_vaccine","confidence":0.062177762389183},{"name":"faq_testing","confidence":0.0530692934989929},{"name":"out_of_scope","confidence":0.0480506233870983}],"response_selector":{"default":{"response":{"name":None,"confidence":0},"ranking":[],"full_retrieval_intent":None}},"text":"can\"t"},"input_channel":None,"message_id":"e96e2a85de0748798748385503c65fb3","metadata":{}},{"event":"action","timestamp":1594907117.04547,"name":"utter_test intent","policy":"policy_1_TEDPolicy","confidence":0.978452920913696},{"event":"bot","timestamp":1594907117.04548,"text":"can not = can't","data":{"elements":None,"quick_replies":None,"buttons":None,"attachment":None,"image":None,"custom":None},"metadata":{}}]
+        Utility.email_conf['email']['templates']['conversation'] = open('template/emails/conversation.html',
+                                                                        'rb').read().decode()
+        Utility.email_conf['email']['templates']['bot_msg_conversation'] = open(
+            'template/emails/bot_msg_conversation.html', 'rb').read().decode()
+        Utility.email_conf['email']['templates']['user_msg_conversation'] = open(
+            'template/emails/user_msg_conversation.html', 'rb').read().decode()
+        events = [{"event": "action", "timestamp": 1594907100.12764, "name": "action_session_start", "policy": None,
+                   "confidence": None}, {"event": "session_started", "timestamp": 1594907100.12765},
+                  {"event": "action", "timestamp": 1594907100.12767, "name": "action_listen", "policy": None,
+                   "confidence": None}, {"event": "user", "timestamp": 1594907100.42744, "text": "can't",
+                                         "parse_data": {
+                                             "intent": {"name": "test intent", "confidence": 0.253578245639801},
+                                             "entities": [], "intent_ranking": [
+                                                 {"name": "test intent", "confidence": 0.253578245639801},
+                                                 {"name": "goodbye", "confidence": 0.1504897326231},
+                                                 {"name": "greet", "confidence": 0.138640150427818},
+                                                 {"name": "affirm", "confidence": 0.0857767835259438},
+                                                 {"name": "smalltalk_human", "confidence": 0.0721133947372437},
+                                                 {"name": "deny", "confidence": 0.069614589214325},
+                                                 {"name": "bot_challenge", "confidence": 0.0664894133806229},
+                                                 {"name": "faq_vaccine", "confidence": 0.062177762389183},
+                                                 {"name": "faq_testing", "confidence": 0.0530692934989929},
+                                                 {"name": "out_of_scope", "confidence": 0.0480506233870983}],
+                                             "response_selector": {
+                                                 "default": {"response": {"name": None, "confidence": 0}, "ranking": [],
+                                                             "full_retrieval_intent": None}}, "text": "can't"},
+                                         "input_channel": None, "message_id": "bbd413bf5c834bf3b98e0da2373553b2",
+                                         "metadata": {}},
+                  {"event": "action", "timestamp": 1594907100.4308, "name": "utter_test intent",
+                   "policy": "policy_0_MemoizationPolicy", "confidence": 1},
+                  {"event": "bot", "timestamp": 1594907100.4308, "text": "will not = won\"t",
+                   "data": {"elements": None, "quick_replies": None, "buttons": None, "attachment": None, "image": None,
+                            "custom": None}, "metadata": {}},
+                  {"event": "action", "timestamp": 1594907100.43384, "name": "action_listen",
+                   "policy": "policy_0_MemoizationPolicy", "confidence": 1},
+                  {"event": "user", "timestamp": 1594907117.04194, "text": "can\"t",
+                   "parse_data": {"intent": {"name": "test intent", "confidence": 0.253578245639801}, "entities": [],
+                                  "intent_ranking": [{"name": "test intent", "confidence": 0.253578245639801},
+                                                     {"name": "goodbye", "confidence": 0.1504897326231},
+                                                     {"name": "greet", "confidence": 0.138640150427818},
+                                                     {"name": "affirm", "confidence": 0.0857767835259438},
+                                                     {"name": "smalltalk_human", "confidence": 0.0721133947372437},
+                                                     {"name": "deny", "confidence": 0.069614589214325},
+                                                     {"name": "bot_challenge", "confidence": 0.0664894133806229},
+                                                     {"name": "faq_vaccine", "confidence": 0.062177762389183},
+                                                     {"name": "faq_testing", "confidence": 0.0530692934989929},
+                                                     {"name": "out_of_scope", "confidence": 0.0480506233870983}],
+                                  "response_selector": {
+                                      "default": {"response": {"name": None, "confidence": 0}, "ranking": [],
+                                                  "full_retrieval_intent": None}}, "text": "can\"t"},
+                   "input_channel": None, "message_id": "e96e2a85de0748798748385503c65fb3", "metadata": {}},
+                  {"event": "action", "timestamp": 1594907117.04547, "name": "utter_test intent",
+                   "policy": "policy_1_TEDPolicy", "confidence": 0.978452920913696},
+                  {"event": "bot", "timestamp": 1594907117.04548, "text": "can not = can't",
+                   "data": {"elements": None, "quick_replies": None, "buttons": None, "attachment": None, "image": None,
+                            "custom": None}, "metadata": {}}]
         actual = ActionUtility.prepare_email_body(events, "conversation history", "test@kairon.com")
         assert str(actual).__contains__("</table>")
 
@@ -2678,7 +2731,8 @@ class TestActions:
                                                   'source': 'history', 'is_enabled': True},
                                                  {'name': 'Similarity Prompt',
                                                   'hyperparameters': {'top_results': 30, 'similarity_threshold': 0.3},
-                                                  'data': 'default', 'instructions': 'Answer question based on the context above, if answer is not in the context go check previous logs.',
+                                                  'data': 'default',
+                                                  'instructions': 'Answer question based on the context above, if answer is not in the context go check previous logs.',
                                                   'type': 'user', 'source': 'bot_content', 'is_enabled': True}],
                                  'instructions': [], 'set_slots': [], 'dispatch_response': True}
         bot_settings.pop("_id")
@@ -2707,7 +2761,6 @@ class TestActions:
                                 'integrations_per_user_limit': 3,
                                 'live_agent_enabled': False,
                                 'retry_broadcasting_limit': 3}
-        LLMSecret.objects.delete()
 
     def test_prompt_action_not_exists(self):
         with pytest.raises(ActionFailure, match="Faq feature is disabled for the bot! Please contact support."):
@@ -2722,7 +2775,8 @@ class TestActions:
         actual = ActionUtility.get_action(bot, 'google_search_action')
         assert actual['type'] == ActionType.google_search_action.value
         actual = ActionGoogleSearch(bot, 'google_search_action').retrieve_config()
-        assert actual['api_key'] == {'_cls': 'CustomActionRequestParameters', 'encrypt': False, 'key': 'api_key', 'parameter_type': 'value', 'value': '1234567890'}
+        assert actual['api_key'] == {'_cls': 'CustomActionRequestParameters', 'encrypt': False, 'key': 'api_key',
+                                     'parameter_type': 'value', 'value': '1234567890'}
         assert actual['search_engine_id'] == 'asdfg::123456'
 
     def test_get_google_search_action_config_not_exists(self):
@@ -2885,7 +2939,8 @@ class TestActions:
                                                                                  'startAt': 0},
                            'worklog': {'startAt': 0, 'maxResults': 20, 'total': 0, 'worklogs': []}}}
         )
-        assert not ActionUtility.create_jira_issue(url, username, api_token, project_key, issue_type, summary, description)
+        assert not ActionUtility.create_jira_issue(url, username, api_token, project_key, issue_type, summary,
+                                                   description)
 
     def test_create_jira_issue_failure(self):
         url = 'https://test-digite.atlassian.net'
@@ -2912,7 +2967,8 @@ class TestActions:
 
         with patch('kairon.shared.actions.data_objects.JiraAction.validate', new=_mock_response):
             JiraAction(
-                name='jira_action', bot=bot, user=user, url='https://test-digite.atlassian.net', user_name='test@digite.com',
+                name='jira_action', bot=bot, user=user, url='https://test-digite.atlassian.net',
+                user_name='test@digite.com',
                 api_token=CustomActionRequestParameters(value='ASDFGHJKL'), project_key='HEL', issue_type='Bug',
                 summary='fallback', response='Successfully created').save()
         action = ActionUtility.get_action(bot, 'jira_action')
@@ -2922,8 +2978,8 @@ class TestActions:
         action.pop('timestamp')
         assert action == {
             'name': 'jira_action', 'url': 'https://test-digite.atlassian.net', 'user_name': 'test@digite.com',
-            'api_token':  {'_cls': 'CustomActionRequestParameters', 'encrypt': False, 'parameter_type': 'value',
-                           'value': 'ASDFGHJKL'}, 'project_key': 'HEL', 'issue_type': 'Bug', 'summary': 'fallback',
+            'api_token': {'_cls': 'CustomActionRequestParameters', 'encrypt': False, 'parameter_type': 'value',
+                          'value': 'ASDFGHJKL'}, 'project_key': 'HEL', 'issue_type': 'Bug', 'summary': 'fallback',
             'response': 'Successfully created', 'bot': 'test_action_server', 'user': 'test_user', 'status': True
         }
 
@@ -3114,10 +3170,10 @@ class TestActions:
                     "Content-Type": "text/html; charset=utf-8"
                 },
                 "body": [{
-            'title': 'Data Science Introduction - W3Schools',
-            'description': "Data Science is a combination of multiple disciplines that uses statistics, data analysis, and machine learning to analyze data and to extract knowledge and insights from it. What is Data Science? Data Science is about data gathering, analysis and decision-making.",
-            'url': 'https://www.w3schools.com/datascience/ds_introduction.asp'
-        }]
+                    'title': 'Data Science Introduction - W3Schools',
+                    'description': "Data Science is a combination of multiple disciplines that uses statistics, data analysis, and machine learning to analyze data and to extract knowledge and insights from it. What is Data Science? Data Science is about data gathering, analysis and decision-making.",
+                    'url': 'https://www.w3schools.com/datascience/ds_introduction.asp'
+                }]
             }
         }
         mock_environment = {"web_search": {"trigger_task": True, 'url': None}}
@@ -3165,16 +3221,16 @@ class TestActions:
                 "headers": {
                     "Content-Type": "text/html; charset=utf-8"
                 },
-            "body": [{
-                "title": "Artificial intelligence - Wikipedia",
-                "description": "Artificial intelligence ( AI) is the intelligence of machines or software, as opposed to the intelligence of human beings or animals.",
-                "url": "https://en.wikipedia.org/wiki/Artificial_intelligence"},
-                {
-                 "title": "Artificial intelligence (AI) - Britannica",
-                 "description": "artificial intelligence (AI), the ability of a digital computer or computer-controlled robot to perform tasks commonly associated with intelligent beings.",
-                "url": "https://www.britannica.com/technology/artificial-intelligence"
-                 }]
-        }
+                "body": [{
+                    "title": "Artificial intelligence - Wikipedia",
+                    "description": "Artificial intelligence ( AI) is the intelligence of machines or software, as opposed to the intelligence of human beings or animals.",
+                    "url": "https://en.wikipedia.org/wiki/Artificial_intelligence"},
+                    {
+                        "title": "Artificial intelligence (AI) - Britannica",
+                        "description": "artificial intelligence (AI), the ability of a digital computer or computer-controlled robot to perform tasks commonly associated with intelligent beings.",
+                        "url": "https://www.britannica.com/technology/artificial-intelligence"
+                    }]
+            }
         }
 
         mock_environment = {"web_search": {"trigger_task": True, 'url': None}}
@@ -3183,7 +3239,7 @@ class TestActions:
         assert result == [
             {'title': 'Artificial intelligence - Wikipedia',
              'text': 'Artificial intelligence ( AI) is the intelligence of machines or software, as opposed to the intelligence of human beings or animals.',
-             'link': 'https://en.wikipedia.org/wiki/Artificial_intelligence',},
+             'link': 'https://en.wikipedia.org/wiki/Artificial_intelligence', },
             {'title': 'Artificial intelligence (AI) - Britannica',
              'text': 'artificial intelligence (AI), the ability of a digital computer or computer-controlled robot to perform tasks commonly associated with intelligent beings.',
              'link': 'https://www.britannica.com/technology/artificial-intelligence'}
@@ -3197,22 +3253,22 @@ class TestActions:
         website = "https://www.w3schools.com/"
         topn = 1
         response = {
-  "ResponseMetadata": {
-      "RequestId": "7cc44dbe-ad8f-4dbb-9197-0f65fd454f49",
-      "HTTPStatusCode": 404,
-      "HTTPHeaders": {
-          "date": "Thu, 24 Aug 2023 11:41:20 GMT",
-          "content-type": "application/json",
-          "content-length": "152",
-          "connection": "keep-alive",
-          "x-amzn-requestid": "7cc44dbe-ad8f-4dbb-9197-0f65fd454f49",
-          "x-amzn-remapped-content-length": "0",
-          "x-amz-executed-version": "$LATEST",
-          "x-amz-log-result": "RUZBVUxUX1JFR0lPTic6ICd1cy1lYXN0LTEnLC==",
-          "x-amzn-trace-id": "root=1-64e741dd-65e379c0699bc2b13b9934b8;sampled=1;lineage=8e6b0d55:0"
-      },
-      "RetryAttempts": 0
-  },
+            "ResponseMetadata": {
+                "RequestId": "7cc44dbe-ad8f-4dbb-9197-0f65fd454f49",
+                "HTTPStatusCode": 404,
+                "HTTPHeaders": {
+                    "date": "Thu, 24 Aug 2023 11:41:20 GMT",
+                    "content-type": "application/json",
+                    "content-length": "152",
+                    "connection": "keep-alive",
+                    "x-amzn-requestid": "7cc44dbe-ad8f-4dbb-9197-0f65fd454f49",
+                    "x-amzn-remapped-content-length": "0",
+                    "x-amz-executed-version": "$LATEST",
+                    "x-amz-log-result": "RUZBVUxUX1JFR0lPTic6ICd1cy1lYXN0LTEnLC==",
+                    "x-amzn-trace-id": "root=1-64e741dd-65e379c0699bc2b13b9934b8;sampled=1;lineage=8e6b0d55:0"
+                },
+                "RetryAttempts": 0
+            },
             "StatusCode": 404,
             "LogResult": "RUZBVUxUX1JFR0lPTic6ICd1cy1lYXN0LTEnLC==",
             "ExecutedVersion": "$LATEST",
@@ -3238,8 +3294,10 @@ class TestActions:
         website = "www.google.com"
         topn = 1
 
-        mock_environment = {"web_search": {"trigger_task": True, 'url': None}, 'events': {'executor': {"region": "us-east-1"}, 'task_definition': {"web_search": None}}}
-        with pytest.raises(ActionFailure, match="Parameter validation failed:\nInvalid type for parameter FunctionName, value: None, type: <class 'NoneType'>, valid types: <class 'str'>"):
+        mock_environment = {"web_search": {"trigger_task": True, 'url': None},
+                            'events': {'executor': {"region": "us-east-1"}, 'task_definition': {"web_search": None}}}
+        with pytest.raises(ActionFailure,
+                           match="Parameter validation failed:\nInvalid type for parameter FunctionName, value: None, type: <class 'NoneType'>, valid types: <class 'str'>"):
             with patch("kairon.shared.utils.Utility.environment", new=mock_environment):
                 ActionUtility.perform_web_search(search_term, website=website, topn=topn)
 
@@ -3253,10 +3311,10 @@ class TestActions:
             method=responses.POST,
             url=search_engine_url,
             json={"success": True, "data": [{
-            "title": "Artificial intelligence - Wikipedia",
-            "description": "Artificial intelligence ( AI) is the intelligence of machines or software, as opposed to the intelligence of human beings or animals.",
-            "url": "https://en.wikipedia.org/wiki/Artificial_intelligence",
-        }], "error_code": 0},
+                "title": "Artificial intelligence - Wikipedia",
+                "description": "Artificial intelligence ( AI) is the intelligence of machines or software, as opposed to the intelligence of human beings or animals.",
+                "url": "https://en.wikipedia.org/wiki/Artificial_intelligence",
+            }], "error_code": 0},
             status=200,
             match=[
                 responses.matchers.json_params_matcher({
@@ -3320,7 +3378,8 @@ class TestActions:
         )
 
         with mock.patch.dict(Utility.environment, {'web_search': {"trigger_task": False, "url": search_engine_url}}):
-            with pytest.raises(ActionFailure, match=re.escape('Failed to execute the url: Got non-200 status code: 500 {"data": []}')):
+            with pytest.raises(ActionFailure,
+                               match=re.escape('Failed to execute the url: Got non-200 status code: 500 {"data": []}')):
                 ActionUtility.perform_web_search(search_term, topn=topn, bot=bot)
 
     @responses.activate
@@ -3399,7 +3458,8 @@ class TestActions:
         with patch('zenpy.Zenpy'):
             ZendeskAction(
                 name='zendesk_action', bot=bot, user=user, subdomain='digite751', user_name='test@digite.com',
-                api_token=CustomActionRequestParameters(value='ASDFGHJKL'), subject='new user detected', response='Successfully created').save()
+                api_token=CustomActionRequestParameters(value='ASDFGHJKL'), subject='new user detected',
+                response='Successfully created').save()
         action = ActionZendeskTicket(bot, 'zendesk_action').retrieve_config()
         action.pop('_id')
         action.pop('timestamp')
@@ -3440,7 +3500,8 @@ class TestActions:
             'https://digite751.zendesk.com/api/v2/tickets.json',
             json={'count': 1},
             match=[responses.matchers.json_params_matcher(
-                {'ticket': {'comment': { 'html_body': 'html comment'}, 'subject': 'new ticket', 'description': 'ticket described',
+                {'ticket': {'comment': {'html_body': 'html comment'}, 'subject': 'new ticket',
+                            'description': 'ticket described',
                             'tags': ['kairon', 'bot'], }})]
         )
         ActionUtility.create_zendesk_ticket('digite751', 'test@digite.com', 'ASDFGHJKL', 'new ticket',
@@ -3520,18 +3581,21 @@ class TestActions:
             'api_token': {'_cls': 'CustomActionRequestParameters', 'encrypt': False, 'key': 'api_token',
                           'parameter_type': 'value', 'value': 'ASDFGHJKL'},
             'title': 'new user detected', 'response': 'Lead successfully added', 'bot': 'test_action_server',
-            'user': 'test_user', 'status': True, 'metadata': {'name': 'name', 'org_name': 'organization', 'email': 'email', 'phone': 'phone'}
+            'user': 'test_user', 'status': True,
+            'metadata': {'name': 'name', 'org_name': 'organization', 'email': 'email', 'phone': 'phone'}
         }
 
     def test_prepare_pipedrive_metadata(self):
         bot = 'test_action_server'
-        slots = {"name": "udit pandey", "organization": "digite", "email": "pandey.udit867@gmail.com", 'phone': '9876543210'}
+        slots = {"name": "udit pandey", "organization": "digite", "email": "pandey.udit867@gmail.com",
+                 'phone': '9876543210'}
         events = [{"event1": "hello"}, {"event2": "how are you"}]
         tracker = Tracker(sender_id="sender1", slots=slots, events=events, paused=False, latest_message=None,
                           followup_action=None, active_loop=None, latest_action_name=None)
         action = ActionPipedriveLeads(bot, 'pipedrive_leads_action').retrieve_config()
         metadata = ActionUtility.prepare_pipedrive_metadata(tracker, action)
-        assert metadata == {'name': 'udit pandey', 'org_name': 'digite', 'email': 'pandey.udit867@gmail.com', 'phone': '9876543210'}
+        assert metadata == {'name': 'udit pandey', 'org_name': 'digite', 'email': 'pandey.udit867@gmail.com',
+                            'phone': '9876543210'}
 
     def test_prepare_message_trail_as_str(self):
         events = [{"event": "bot", 'text': 'hello'}, {"event": "user", "text": "how are you"},
@@ -3546,13 +3610,15 @@ class TestActions:
     def test_validate_pipedrive_credentials_failure(self):
         def __mock_exception(*args, **kwargs):
             raise UnauthorizedError('Invalid authentication', {'error_code': 401})
+
         with patch('pipedrive.client.Client', __mock_exception):
             with pytest.raises(ActionFailure):
                 ActionUtility.validate_pipedrive_credentials('https://digite751.pipedrive.com/', 'ASDFGHJKL')
 
     def test_create_pipedrive_lead(self):
         conversation = 'bot: hello\nuser: how are you\nbot: good\nuser: ok bye\n'
-        metadata = {'name': 'udit pandey', 'org_name': 'digite', 'email': 'pandey.udit867@gmail.com', 'phone': '9876543210'}
+        metadata = {'name': 'udit pandey', 'org_name': 'digite', 'email': 'pandey.udit867@gmail.com',
+                    'phone': '9876543210'}
 
         def __mock_create_organization(*args, **kwargs):
             return {"success": True, "data": {"id": 2}}
@@ -3594,7 +3660,8 @@ class TestActions:
 
         with patch('pipedrive.client.Client._request', __mock_exception):
             with pytest.raises(BadRequestError):
-                ActionUtility.create_pipedrive_lead('https://digite751.pipedrive.com/', 'ASDFGHJKL', 'new user detected',
+                ActionUtility.create_pipedrive_lead('https://digite751.pipedrive.com/', 'ASDFGHJKL',
+                                                    'new user detected',
                                                     conversation, **metadata)
         with patch('pipedrive.organizations.Organizations.create_organization', __mock_create_organization):
             with patch('pipedrive.persons.Persons.create_person', __mock_create_person):
@@ -3697,8 +3764,10 @@ class TestActions:
         user = 'test_user'
 
         fields = [
-            {'_cls': 'HttpActionRequestBody', 'key': 'email', 'parameter_type': 'slot', 'value': 'email_slot', 'encrypt': False},
-            {'_cls': 'HttpActionRequestBody', 'key': 'firstname', 'parameter_type': 'value', 'value': 'udit', 'encrypt': False}
+            {'_cls': 'HttpActionRequestBody', 'key': 'email', 'parameter_type': 'slot', 'value': 'email_slot',
+             'encrypt': False},
+            {'_cls': 'HttpActionRequestBody', 'key': 'firstname', 'parameter_type': 'value', 'value': 'udit',
+             'encrypt': False}
         ]
         HubspotFormsAction(
             name='hubspot_forms_action', portal_id='asdf45', form_guid='2345678gh', fields=fields, bot=bot, user=user,
@@ -3750,7 +3819,8 @@ class TestActions:
                     {'script': script,
                      'data': data})],
         )
-        with pytest.raises(ActionFailure, match="Expression evaluation failed: script: ${a.b.d} || data: {'a': {'b': {'3': 2, '43': 30, 'c': [], 'd': ['red', 'buggy', 'bumpers']}}} || raise_err_on_failure: True || response: {'success': False, 'data': \"['red', 'buggy', 'bumpers']\"}"):
+        with pytest.raises(ActionFailure,
+                           match="Expression evaluation failed: script: ${a.b.d} || data: {'a': {'b': {'3': 2, '43': 30, 'c': [], 'd': ['red', 'buggy', 'bumpers']}}} || raise_err_on_failure: True || response: {'success': False, 'data': \"['red', 'buggy', 'bumpers']\"}"):
             ActionUtility.evaluate_script(script, data)
 
     @responses.activate
@@ -3775,13 +3845,15 @@ class TestActions:
 
     def test_prepare_email_text(self):
         custom_text = "The user with 987654321 has message hello."
-        Utility.email_conf['email']['templates']['custom_text_mail'] = open('template/emails/custom_text_mail.html', 'rb').read().decode()
+        Utility.email_conf['email']['templates']['custom_text_mail'] = open('template/emails/custom_text_mail.html',
+                                                                            'rb').read().decode()
         actual = ActionUtility.prepare_email_text(custom_text, "test@kairon.com")
         assert str(actual).__contains__("The user with 987654321 has message hello.")
 
     def test_prepare_email_text_failure(self):
         custom_text = "The user with 987654321 has message bye."
-        Utility.email_conf['email']['templates']['custom_text_mail'] = open('template/emails/custom_text_mail.html', 'rb').read().decode()
+        Utility.email_conf['email']['templates']['custom_text_mail'] = open('template/emails/custom_text_mail.html',
+                                                                            'rb').read().decode()
         actual = ActionUtility.prepare_email_text(custom_text, subject="New user!!", user_email=None)
         assert str(actual).__contains__("The user with 987654321 has message bye.")
         assert not str(actual).__contains__("This email was sent to USER_EMAIL")
@@ -3806,32 +3878,65 @@ class TestActions:
     def test_compose_response_using_script(self):
         script = "bot_response=data['name']"
         response_config = {"value": script, "evaluation_type": "script"}
-        http_response = {'name' : 'Mayank'}
+        http_response = {'name': 'Mayank'}
         responses.add(
-            method=responses.POST,
-            url=Utility.environment['evaluator']['pyscript']['url'],
-            json={"success": True, "data": {'bot_response' : 'Mayank'}, 'error_code': 0},
-            status=200,
-            match=[responses.matchers.json_params_matcher({'source_code': script, 'predefined_objects': http_response})],
-        )
+            "POST", Utility.environment['async_callback_action']['pyscript']['url'],
+            json={
+                "success": True,
+                "body": {
+                    "bot_response": "Mayank",
+                    "slots": {"param2": "param2value"}
+                },
+                "statusCode": 200
+            },
+            match=[
+                responses.matchers.json_params_matcher({'source_code': script, 'predefined_objects': http_response})], )
         result, log, _ = ActionUtility.compose_response(response_config, http_response)
         assert result == 'Mayank'
 
-        assert log ==  ['evaluation_type: script', "script: bot_response=data['name']", "data: {'name': 'Mayank'}", 'raise_err_on_failure: True']
+        assert log == ['evaluation_type: script', "script: bot_response=data['name']", "data: {'name': 'Mayank'}",
+                       'raise_err_on_failure: True']
 
     @responses.activate
-    def test_compose_response_using_script_failure(self):
+    def test_compose_response_using_script_failure(self, monkeypatch):
         script = "${a.b.d}"
         response_config = {"value": script, "evaluation_type": "script"}
-        http_response = {'a': {'b': {'3': 2, '43': 30, 'c': [], 'd': ['red', 'buggy', 'bumpers']}}}
-        responses.add(
-            method=responses.POST,
-            url=Utility.environment['evaluator']['url'],
-            json={"success": False},
-            status=200,
-            match=[responses.matchers.json_params_matcher({'script': script, 'data': http_response})],
-        )
-        with pytest.raises(ActionFailure, match="Expression evaluation failed: script: ${a.b.d} || data: {'a': {'b': {'3': 2, '43': 30, 'c': [], 'd': ['red', 'buggy', 'bumpers']}}} || raise_err_on_failure: True || response: {'success': False, 'data': \"['red', 'buggy', 'bumpers']\"}"):
+        http_response = {
+            "a": {
+                "b": {
+                    "3": 2,
+                    "43": 30,
+                    "c": [],
+                    "d": ["red", "buggy", "bumpers"]
+                }
+            }
+        }
+        failure_body = {
+            "success": False,
+            "data": http_response["a"]["b"]["d"]
+        }
+
+        def fake_evaluate_pyscript(passed_script, passed_context):
+            assert passed_script == script
+            assert passed_context == http_response
+            raise ActionFailure(
+                f"Expression evaluation failed: "
+                f"script: {script} || "
+                f"data: {http_response} || "
+                f"raise_err_on_failure: True || "
+                f"response: {failure_body}"
+            )
+
+        monkeypatch.setattr(ActionUtility, "evaluate_pyscript", fake_evaluate_pyscript)
+        with pytest.raises(
+                ActionFailure,
+                match=(
+                        r"Expression evaluation failed: script: \$\{a\.b\.d\} \|\| "
+                        r"data: \{'a': \{'b': \{'3': 2, '43': 30, 'c': \[\], 'd': \['red', 'buggy', 'bumpers'\]\}\}\} \|\| "
+                        r"raise_err_on_failure: True \|\| "
+                        r"response: \{'success': False, 'data': \['red', 'buggy', 'bumpers'\]\}"
+                )
+        ):
             ActionUtility.compose_response(response_config, http_response)
 
     def test_fill_slots_from_response_using_expression(self):
@@ -3882,25 +3987,32 @@ class TestActions:
         set_slots = [{"name": "experience", "value": "bot_response=data['exp']dsds", "evaluation_type": "script"},
                      {"name": "score", "value": "bot_response=data['score']", "evaluation_type": "script"},
                      ]
-        http_response = {"data": {'name' : 'mayank', 'exp': 30, 'score': 10},
+        http_response = {"data": {'name': 'mayank', 'exp': 30, 'score': 10},
                          "context": {}}
         responses.add(
             method=responses.POST,
-            url=Utility.environment['evaluator']['pyscript']['url'],
-            json={"success": False},
+            url=Utility.environment['async_callback_action']['pyscript']['url'],
+            json={"success": False, "statusCode": 200},
             status=200,
-            match=[responses.matchers.json_params_matcher({'source_code': "bot_response=data['exp']dsds", 'predefined_objects': http_response})],
+            match=[responses.matchers.json_params_matcher(
+                {'source_code': "bot_response=data['exp']dsds", 'predefined_objects': http_response})],
         )
         responses.add(
             method=responses.POST,
-            url=Utility.environment['evaluator']['pyscript']['url'],
-            json={"success": True, "data": {'bot_response' :10}, 'error_code': 0},
+            url=Utility.environment['async_callback_action']['pyscript']['url'],
+            json={"success": True, "body": {'bot_response': 10}, "statusCode": 200, 'error_code': 0},
             status=200,
-            match=[responses.matchers.json_params_matcher({'source_code': "bot_response=data['score']", 'predefined_objects': http_response})],
+            match=[responses.matchers.json_params_matcher(
+                {'source_code': "bot_response=data['score']", 'predefined_objects': http_response})],
         )
         evaluated_slot_values, response_log, _ = ActionUtility.fill_slots_from_response(set_slots, http_response)
         assert evaluated_slot_values == {'experience': None, 'score': 10}
-        assert response_log == ['initiating slot evaluation', 'Slot: experience', "Evaluation error for experience: Pyscript evaluation failed: {'success': False}", 'Slot experience eventually set to None.', 'Slot: score', 'evaluation_type: script', "script: bot_response=data['score']", "data: {'data': {'name': 'mayank', 'exp': 30, 'score': 10}, 'context': {}}", 'raise_err_on_failure: True']
+        assert response_log == ['initiating slot evaluation', 'Slot: experience',
+                                "Evaluation error for experience: 'NoneType' object has no attribute 'get'",
+                                'Slot experience eventually set to None.', 'Slot: score', 'evaluation_type: script',
+                                "script: bot_response=data['score']",
+                                "data: {'data': {'name': 'mayank', 'exp': 30, 'score': 10}, 'context': {}}",
+                                'raise_err_on_failure: True']
 
     
     def test_retrieve_config_two_stage_fallback(self):
@@ -3917,7 +4029,8 @@ class TestActions:
         config.pop('user')
         config.pop('timestamp')
         config.pop('status')
-        assert config == {'name': 'kairon_two_stage_fallback', 'text_recommendations': {"count": 3, 'use_intent_ranking': False},
+        assert config == {'name': 'kairon_two_stage_fallback',
+                          'text_recommendations': {"count": 3, 'use_intent_ranking': False},
                           'trigger_rules': [{'is_dynamic_msg': False, 'text': 'Trigger', 'payload': 'set_context'},
                                             {'is_dynamic_msg': False, 'text': 'Mail me', 'payload': 'send_mail'}],
                           'fallback_message': "I could not understand you! Did you mean any of the suggestions below?"
@@ -3954,15 +4067,6 @@ class TestActions:
     def test_get_prompt_action_config_2(self):
         bot = "test_bot_action_test"
         user = "test_user_action_test"
-        llm_secret = LLMSecret(
-            llm_type="openai",
-            api_key='value',
-            models=["gpt-3.5-turbo", "gpt-4.1-mini"],
-            bot=bot,
-            user=user
-        )
-        llm_secret.save()
-
         llm_prompts = [{'name': 'System Prompt', 'data': 'You are a personal assistant.', 'type': 'system',
                         'source': 'static', 'is_enabled': True},
                        {'name': 'History Prompt', 'type': 'user', 'source': 'history', 'is_enabled': True},
@@ -3983,21 +4087,22 @@ class TestActions:
                                        'hyperparameters': {'temperature': 0.0, 'max_tokens': 300, 'model': 'gpt-4.1-mini',
                                                            'top_p': 0.0, 'n': 1, 'stop': None,
                                                            'presence_penalty': 0.0, 'frequency_penalty': 0.0,
-                                                           'logit_bias': {}}, 'dispatch_response': True, 'set_slots': [],
+                                                           'logit_bias': {}}, 'dispatch_response': True,
+                                       'set_slots': [],
                                        'llm_type': 'openai',
-                                       'llm_prompts': [{'name': 'System Prompt', 'data': 'You are a personal assistant.',
-                                                        'type': 'system', 'source': 'static', 'is_enabled': True},
-                                                       {'name': 'History Prompt', 'type': 'user',
-                                                        'source': 'history', 'is_enabled': True},
-                                                       {'name': 'Similarity Prompt',
-                                                        'hyperparameters': {'top_results': 30,
-                                                                            'similarity_threshold': 0.3},
-                                                        'data': 'default',
-                                                        'instructions': 'Answer question based on the context above, if answer is not in the context go check previous logs.',
-                                                        'type': 'user', 'source': 'bot_content', 'is_enabled': True}],
+                                       'llm_prompts': [
+                                           {'name': 'System Prompt', 'data': 'You are a personal assistant.',
+                                            'type': 'system', 'source': 'static', 'is_enabled': True},
+                                           {'name': 'History Prompt', 'type': 'user',
+                                            'source': 'history', 'is_enabled': True},
+                                           {'name': 'Similarity Prompt',
+                                            'hyperparameters': {'top_results': 30,
+                                                                'similarity_threshold': 0.3},
+                                            'data': 'default',
+                                            'instructions': 'Answer question based on the context above, if answer is not in the context go check previous logs.',
+                                            'type': 'user', 'source': 'bot_content', 'is_enabled': True}],
                                        'instructions': [],
                                        'status': True}
-        LLMSecret.objects.delete()
 
     def test_retrieve_config_two_stage_fallback_not_found(self):
         with pytest.raises(ActionFailure, match="Two stage fallback action config not found"):
@@ -4008,7 +4113,7 @@ class TestActions:
         bot = "5f50fd0a56b698ca10d35d2e"
         user = 'test_user'
         action = GoogleSearchAction(name=action_name, api_key=CustomActionRequestParameters(value='1234567890'),
-                           search_engine_id='asdfg::123456', failure_response="", bot=bot, user=user)
+                                    search_engine_id='asdfg::123456', failure_response="", bot=bot, user=user)
         action.save()
         assert getattr(action, "failure_response") == 'I have failed to process your request.'
 
@@ -4030,7 +4135,8 @@ class TestActions:
                           followup_action=None, active_loop=None, latest_action_name=None)
         bot_responses = ActionUtility.prepare_bot_responses(tracker, 5)
         assert bot_responses == [{'role': 'user', 'content': 'Kairon pricing'},
-                                 {'role': 'assistant', 'content': "Kairon's pricing ranges from $60 to $160 per month for simple digital assistants, while more complex ones require custom pricing. However, since Kairon offers a large array of features to build digital assistants of varying complexity, the pricing may vary. If you are interested in Kairon, please provide your name, company name, and email address, and our sales team will reach out to you with more information."}]
+                                 {'role': 'assistant',
+                                  'content': "Kairon's pricing ranges from $60 to $160 per month for simple digital assistants, while more complex ones require custom pricing. However, since Kairon offers a large array of features to build digital assistants of varying complexity, the pricing may vary. If you are interested in Kairon, please provide your name, company name, and email address, and our sales team will reach out to you with more information."}]
 
     def test_if_last_n_is_less_than_or_equal_to_zero(self):
         events = Utility.read_yaml("tests/testing_data/history/bot_user_tracker_events.json")
@@ -4041,15 +4147,21 @@ class TestActions:
                           followup_action=None, active_loop=None, latest_action_name=None)
         bot_responses = ActionUtility.prepare_bot_responses(tracker, 5)
         assert bot_responses == [{'role': 'user', 'content': 'How can I use it?'},
-                                 {'role': 'assistant', 'content': 'It depends on what "it" refers to. Can you please provide more context or specify what you are referring to?'},
+                                 {'role': 'assistant',
+                                  'content': 'It depends on what "it" refers to. Can you please provide more context or specify what you are referring to?'},
                                  {'role': 'user', 'content': 'How can I use kairon?'},
-                                 {'role': 'assistant', 'content': "Kairon can be used to create and deploy digital assistants for various purposes, such as providing customer support, helping customers find the right products, processing orders, managing inventory, generating leads, promoting sales and discounts, gathering customer feedback, and analyzing customer data. Kairon's low-code/no-code interface makes it easy for functional users to define how the digital assistant responds to user queries without needing extensive coding skills. Additionally, Kairon's telemetry feature monitors how users are interacting with the website/product where Kairon was injected and proactively intervenes if they are facing problems, improving the overall user experience. To know more about Kairon, you can visit their website at https://www.digite.com/kairon/."},
+                                 {'role': 'assistant',
+                                  'content': "Kairon can be used to create and deploy digital assistants for various purposes, such as providing customer support, helping customers find the right products, processing orders, managing inventory, generating leads, promoting sales and discounts, gathering customer feedback, and analyzing customer data. Kairon's low-code/no-code interface makes it easy for functional users to define how the digital assistant responds to user queries without needing extensive coding skills. Additionally, Kairon's telemetry feature monitors how users are interacting with the website/product where Kairon was injected and proactively intervenes if they are facing problems, improving the overall user experience. To know more about Kairon, you can visit their website at https://www.digite.com/kairon/."},
                                  {'role': 'user', 'content': 'Is there any example for how can I use it?'},
-                                 {'role': 'assistant', 'content': 'Yes, there are several examples provided in the context. For example, one article discusses how to integrate kAIron with Slack or Telegram to create a digital assistant or chatbot. Another article provides best practices and guidelines for building conversational interfaces using kAIron. Additionally, there are articles discussing the use of chatbots for millennials, the effectiveness of AI agents in intent generation, and the potential for conversational AI in the gaming world.'},
-                                 {'role': 'user', 'content': 'I am interested in Kairon and want to know what features it offers'},
-                                 {'role': 'assistant', 'content': 'Kairon is a versatile conversational digital transformation platform that offers a range of capabilities to businesses. Its features include end-to-end lifecycle management, tethered digital assistants, low-code/no-code interface, secure script injection, Kairon Telemetry, chat client designer, analytics module, robust integration suite, and real-time struggle analytics. Additionally, Kairon offers natural language processing, artificial intelligence, and machine learning for developing sophisticated chatbots for e-commerce purposes. Kairon chatbots can perform a wide range of tasks, including providing customer support, helping customers find the right products, answering customer queries, processing orders, managing inventory, generating leads, promoting sales and discounts, gathering customer feedback, analyzing customer data, and much more.'},
+                                 {'role': 'assistant',
+                                  'content': 'Yes, there are several examples provided in the context. For example, one article discusses how to integrate kAIron with Slack or Telegram to create a digital assistant or chatbot. Another article provides best practices and guidelines for building conversational interfaces using kAIron. Additionally, there are articles discussing the use of chatbots for millennials, the effectiveness of AI agents in intent generation, and the potential for conversational AI in the gaming world.'},
+                                 {'role': 'user',
+                                  'content': 'I am interested in Kairon and want to know what features it offers'},
+                                 {'role': 'assistant',
+                                  'content': 'Kairon is a versatile conversational digital transformation platform that offers a range of capabilities to businesses. Its features include end-to-end lifecycle management, tethered digital assistants, low-code/no-code interface, secure script injection, Kairon Telemetry, chat client designer, analytics module, robust integration suite, and real-time struggle analytics. Additionally, Kairon offers natural language processing, artificial intelligence, and machine learning for developing sophisticated chatbots for e-commerce purposes. Kairon chatbots can perform a wide range of tasks, including providing customer support, helping customers find the right products, answering customer queries, processing orders, managing inventory, generating leads, promoting sales and discounts, gathering customer feedback, analyzing customer data, and much more.'},
                                  {'role': 'user', 'content': 'What is kairon simply?'},
-                                 {'role': 'assistant', 'content': 'Kairon is a digital transformation platform that simplifies the process of building, deploying, and monitoring digital assistants. It allows companies to create intelligent digital assistants without the need for separate infrastructure or technical expertise.'}
+                                 {'role': 'assistant',
+                                  'content': 'Kairon is a digital transformation platform that simplifies the process of building, deploying, and monitoring digital assistants. It allows companies to create intelligent digital assistants without the need for separate infrastructure or technical expertise.'}
                                  ]
 
     def test_prepare_bot_responses_messages_pop(self):
@@ -4076,7 +4188,6 @@ class TestActions:
                                              'feedback, analyzing customer data, and much more.'},
             {'role': 'user', 'content': 'I am interested in Kairon and want to know what features it offers'}
         ]
-
 
 
 def test_format_custom_bot_reply_indirect():

--- a/tests/unit_test/callback/pyscript_handler_test.py
+++ b/tests/unit_test/callback/pyscript_handler_test.py
@@ -2183,9 +2183,6 @@ def test_delete_schedule_job_without_bot_in_main_pyscript():
     assert data['body'] == 'Script execution error: Missing bot id'
     assert data == {
         'statusCode': 422,
-        'statusDescription': '200 OK',
-        'isBase64Encoded': False,
-        'headers': {'Content-Type': 'application/json; charset=utf-8'},
         'body': 'Script execution error: Missing bot id'
     }
 
@@ -2219,9 +2216,6 @@ def test_delete_schedule_job_in_main_pyscript():
     assert data['body']['bot_response'] == 'deleted successfully!'
     assert data == {
         'statusCode': 200,
-        'statusDescription': '200 OK',
-        'isBase64Encoded': False,
-        'headers': {'Content-Type': 'application/json; charset=utf-8'},
         'body': {
             'bot': 'test_bot',
             'sender_id': '917506075263',
@@ -2268,9 +2262,6 @@ def test_pyscript_handler_for_add_data_in_main_pyscript():
     pytest.collection_id = bot_response['data']['_id']
     assert data == {
         'statusCode': 200,
-        'statusDescription': '200 OK',
-        'isBase64Encoded': False,
-        'headers': {'Content-Type': 'application/json; charset=utf-8'},
         'body': {
             'bot': 'test_bot',
             'sender_id': '919876543210',
@@ -2318,9 +2309,6 @@ def test_pyscript_handler_for_add_data_without_bot_in_main_pyscript():
     print(data)
     assert data == {
         'statusCode': 422,
-        'statusDescription': '200 OK',
-        'isBase64Encoded': False,
-        'headers': {'Content-Type': 'application/json; charset=utf-8'},
         'body': 'Script execution error: Missing bot id'
     }
 
@@ -2363,9 +2351,6 @@ def test_pyscript_handler_for_get_data_in_main_pyscript():
     assert bot_response['data'][0]['data'] == {'mobile_number': '919876543210', 'name': 'Mahesh'}
     assert data == {
         'statusCode': 200,
-        'statusDescription': '200 OK',
-        'isBase64Encoded': False,
-        'headers': {'Content-Type': 'application/json; charset=utf-8'},
         'body': {
             'bot': 'test_bot',
             'sender_id': '919876543210',
@@ -2413,9 +2398,6 @@ def test_pyscript_handler_for_get_data_without_bot_in_main_pyscript():
     print(data)
     assert data == {
         'statusCode': 422,
-        'statusDescription': '200 OK',
-        'isBase64Encoded': False,
-        'headers': {'Content-Type': 'application/json; charset=utf-8'},
         'body': 'Script execution error: Missing bot id'
     }
 
@@ -2505,9 +2487,6 @@ def test_pyscript_handler_for_update_data_without_bot_in_main_pyscript():
     print(data)
     assert data == {
         'statusCode': 422,
-        'statusDescription': '200 OK',
-        'isBase64Encoded': False,
-        'headers': {'Content-Type': 'application/json; charset=utf-8'},
         'body': 'Script execution error: Missing bot id'
     }
 
@@ -2626,9 +2605,6 @@ def test_pyscript_handler_for_delete_data_without_bot_in_main_pyscript():
     print(data)
     assert data == {
         'statusCode': 422,
-        'statusDescription': '200 OK',
-        'isBase64Encoded': False,
-        'headers': {'Content-Type': 'application/json; charset=utf-8'},
         'body': 'Script execution error: Missing bot id'
     }
 
@@ -2669,9 +2645,6 @@ def test_pyscript_handler_for_get_data_after_delete_in_main_pyscript():
     assert bot_response == {'data': []}
     assert data == {
         'statusCode': 200,
-        'statusDescription': '200 OK',
-        'isBase64Encoded': False,
-        'headers': {'Content-Type': 'application/json; charset=utf-8'},
         'body': {
             'bot': 'test_bot',
             'sender_id': '919876543210',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new endpoint for executing restricted Python scripts asynchronously via a dedicated API route.
  - Added support for sending WhatsApp Business messages from scripts.
  - Added utilities for saving markdown as PDF and handling callback creation within scripts.
  
- **Improvements**
  - Enhanced script execution environment by modularizing and delegating core operations (scheduling, email, data CRUD, encryption) to specialized utility classes.
  - Updated configuration to support new async callback action endpoints.
  - Improved error handling and response formats for script execution APIs.
  - Updated script execution to preserve default dispatch types when missing in responses.
  
- **Bug Fixes**
  - Ensured default values are preserved when script execution responses lack expected fields.
  
- **Tests**
  - Expanded and refactored test coverage for the new script execution endpoint, WhatsApp messaging, PDF saving, and utility functions.
  - Added tests covering success and failure scenarios of the new Python execution API.
  - Updated existing tests to align with new async callback architecture and response structures.
  - Improved test readability and reliability through formatting and enhanced mocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->