### PR TITLE
Api to upload media to bsp

### DIFF
--- a/kairon/api/app/routers/bot/channels.py
+++ b/kairon/api/app/routers/bot/channels.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Security, Path
+from fastapi import APIRouter, Security, Path, Query
 from starlette.requests import Request
 
 from kairon import Utility
@@ -254,3 +254,14 @@ async def get_channel_metrics(
     Get Channel metrics (Failures/Successes).
     """
     return Response(data=MessageBroadcastProcessor.get_channel_metrics(channel_type, current_user.get_bot()))
+
+@router.get("/media/upload/{bsp_type}/{media_id}", response_model=Response)
+async def bsp_upload_media(
+    media_id: str = Path(description="Id of the document"),
+    access_token: str = Query(description="360Dialog access token"),
+    bsp_type: str = Path(description="Business service provider type", examples=[WhatsappBSPTypes.bsp_360dialog.value]),
+    current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS)
+):
+    provider = BusinessServiceProviderFactory.get_instance(bsp_type)(current_user.get_bot(), current_user.get_user())
+    external_media_id = await provider.upload_media(bsp_type, media_id, access_token)
+    return Response(data={"external_media_id": external_media_id})

--- a/kairon/shared/channels/whatsapp/bsp/dialog360.py
+++ b/kairon/shared/channels/whatsapp/bsp/dialog360.py
@@ -220,7 +220,7 @@ class BSP360Dialog(WhatsappBusinessServiceProviderBase):
             raise AppException(f"UserMediaData not found for media_id: {media_id}")
 
         try:
-            file_stream, filename, extension = await UserMedia.get_media_content_buffer(media_id)
+            file_stream, filename, _ = await UserMedia.get_media_content_buffer(media_id)
 
             if not file_stream:
                 raise AppException("File stream not found")

--- a/kairon/shared/channels/whatsapp/bsp/dialog360.py
+++ b/kairon/shared/channels/whatsapp/bsp/dialog360.py
@@ -1,6 +1,8 @@
 import ast
+import io
 from typing import Text, Dict
 
+import requests
 from loguru import logger
 from mongoengine import DoesNotExist
 
@@ -9,7 +11,9 @@ from kairon.exceptions import AppException
 from kairon.shared.account.activity_log import UserActivityLogger
 from kairon.shared.channels.whatsapp.bsp.base import WhatsappBusinessServiceProviderBase
 from kairon.shared.chat.processor import ChatDataProcessor
+from kairon.shared.chat.user_media import UserMedia
 from kairon.shared.constants import WhatsappBSPTypes, ChannelTypes, UserActivityType
+from kairon.shared.data.data_objects import UserMediaData
 
 
 class BSP360Dialog(WhatsappBusinessServiceProviderBase):
@@ -203,3 +207,67 @@ class BSP360Dialog(WhatsappBusinessServiceProviderBase):
                                             request_body=request_body, headers=headers, validate_status=True,
                                             err_msg="Failed to set webhook url: ")
         return resp.get("url")
+
+    @staticmethod
+    async def upload_media(bsp_type:str, media_id: str, access_token: str) -> str:
+        """
+        Uploads the PDF to 360dialog and returns the external media ID.
+        """
+
+        try:
+            media_doc = UserMediaData.objects.get(media_id=media_id)
+        except DoesNotExist:
+            raise AppException(f"UserMediaData not found for media_id: {media_id}")
+
+        try:
+            file_stream, filename, extension = await UserMedia.get_media_content_buffer(media_id)
+
+            if not file_stream:
+                raise AppException("File stream not found")
+
+            pdf_bytes = file_stream.read()
+
+            base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"]["waba_base_url"]
+            auth_header = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"]["auth_header"]
+
+            files = [
+                ('file', (filename, io.BytesIO(pdf_bytes), 'application/pdf'))
+            ]
+            headers = {
+                auth_header: access_token
+            }
+
+            payload = {'messaging_product': 'whatsapp'}
+
+            response = requests.post(f"{base_url}/media", headers=headers, data=payload, files=files)
+
+            if response.status_code != 200:
+                media_doc.external_upload_info = {
+                    "bsp": bsp_type,
+                    "external_media_id": "",
+                    "error": response.text
+                }
+                media_doc.save()
+                raise AppException(response.text)
+
+            external_media_id = response.json().get("id")
+
+            media_doc.external_upload_info = {
+                "bsp": bsp_type,
+                "external_media_id": external_media_id,
+                "error": ""
+            }
+            media_doc.save()
+
+            return external_media_id
+
+        except Exception as e:
+            media_doc.external_upload_info = {
+                "bsp": bsp_type,
+                "error": str(e)
+            }
+            media_doc.save()
+            raise e
+
+
+

--- a/kairon/shared/data/data_objects.py
+++ b/kairon/shared/data/data_objects.py
@@ -1084,6 +1084,7 @@ class UserMediaData(Auditlog):
     sender_id = StringField(required=True)
     bot = StringField(required=True)
     timestamp = DateTimeField(default=datetime.utcnow)
+    external_upload_info = DictField()
 
 
     meta = {"indexes": [{"fields": ["bot", ("bot", "sender_id"), "media_id"]}]}

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -1,3 +1,4 @@
+import io
 import os
 import re
 import shutil
@@ -71,7 +72,7 @@ from kairon.shared.data.data_objects import (
     ChatClientConfig,
     BotSettings,
     LLMSettings,
-    DemoRequestLogs,
+    DemoRequestLogs, UserMediaData,
 )
 from kairon.shared.data.model_processor import ModelProcessor
 from kairon.shared.data.processor import MongoProcessor
@@ -1911,6 +1912,163 @@ def test_default_values():
     ]
 
     assert sorted(actual["data"]["default_names"]) == sorted(expected_default_names)
+
+@pytest.mark.asyncio
+@responses.activate
+def test_bsp_upload_media_success(monkeypatch):
+    media_id = "0196c9efbf547b81a66ba2af7b72d5ba"
+    bsp_type = "360dialog"
+    access_token = "hL0V3EgIV7v1tsh9qlr9Oul5AK"
+    expected_external_media_id = "abc123"
+
+    UserMediaData(
+        media_id=media_id,
+        filename="Upload_Download Data.pdf",
+        extension=".pdf",
+        upload_status="completed",
+        upload_type="user_uploaded",
+        filesize=410484,
+        sender_id="himanshu.gupta@digite.com",
+        bot=pytest.bot,
+        timestamp=datetime.utcnow(),
+        media_url="https://upload-doc-poc.s3.amazonaws.com/user_media/682323a603ec3be7dcaa75bc/himanshu.gt_digite.com_0196c9efbf547b81a66ba2af7b72d5ba_Upload_Download Data.pdf",
+        output_filename="user_media/682323a603ec3be7dcaa75bc/himanshu.gupta_digite.com_0196c9efbf547b81a66ba2af7b72d5ba_Upload_Download Data.pdf",
+    ).save()
+
+    from kairon.shared.chat.user_media import UserMedia
+
+    async def mock_get_media_content_buffer(media_id_arg):
+        assert media_id_arg == media_id
+        return io.BytesIO(b"%PDF-1.4 mock content"), "Upload_Download Data.pdf", ".pdf"
+
+    monkeypatch.setattr(UserMedia, "get_media_content_buffer", mock_get_media_content_buffer)
+
+    responses.add(
+        responses.POST,
+        "https://waba-v2.360dialog.io/media",
+        json={"id": expected_external_media_id},
+        status=200,
+        content_type="application/json"
+    )
+
+    response = client.get(
+        f"/api/bot/{pytest.bot}/channels/media/upload/{bsp_type}/{media_id}?access_token={access_token}",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+
+    actual = response.json()
+    assert response.status_code == 200
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["data"]["external_media_id"] == expected_external_media_id
+    UserMediaData.objects().delete()
+
+@pytest.mark.asyncio
+def test_bsp_upload_media_media_id_not_found(monkeypatch):
+    media_id = "non_existing_media_id"
+    bsp_type = "360dialog"
+    access_token = "dummy_access_token"
+
+    response = client.get(
+        f"/api/bot/{pytest.bot}/channels/media/upload/{bsp_type}/{media_id}?access_token={access_token}",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["data"] is None
+    assert actual["error_code"] == 422
+    assert "UserMediaData not found for media_id: non_existing_media_id" in actual["message"]
+
+@pytest.mark.asyncio
+def test_bsp_upload_media_no_file_stream(monkeypatch):
+    media_id = "no_stream_media_id"
+    bsp_type = "360dialog"
+    access_token = "dummy_access_token"
+
+    UserMediaData(
+        media_id=media_id,
+        filename="no_stream.pdf",
+        extension=".pdf",
+        upload_status="completed",
+        upload_type="user_uploaded",
+        filesize=410484,
+        sender_id="test@digite.com",
+        bot=pytest.bot,
+        timestamp=datetime.utcnow(),
+        media_url="some_url",
+        output_filename="output_file.pdf",
+    ).save()
+
+    from kairon.shared.chat.user_media import UserMedia
+
+    async def mock_get_media_content_buffer(media_id_arg):
+        return None, "no_stream.pdf", ".pdf"
+
+    monkeypatch.setattr(UserMedia, "get_media_content_buffer", mock_get_media_content_buffer)
+
+    response = client.get(
+        f"/api/bot/{pytest.bot}/channels/media/upload/{bsp_type}/{media_id}?access_token={access_token}",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+
+    actual = response.json()
+    assert not actual["success"]
+    assert actual["data"] is None
+    assert actual["error_code"] == 422
+    assert "File stream not found" in actual["message"]
+    UserMediaData.objects().delete()
+
+
+@pytest.mark.asyncio
+@responses.activate
+def test_bsp_upload_media_360dialog_upload_failed(monkeypatch):
+    media_id = "upload_fail_media"
+    bsp_type = "360dialog"
+    access_token = "dummy_access_token"
+
+    UserMediaData(
+        media_id=media_id,
+        filename="upload_fail.pdf",
+        extension=".pdf",
+        upload_status="completed",
+        upload_type="user_uploaded",
+        filesize=410484,
+        sender_id="test@digite.com",
+        bot=pytest.bot,
+        timestamp=datetime.utcnow(),
+        media_url="some_url",
+        output_filename="output_file.pdf",
+    ).save()
+
+    from kairon.shared.chat.user_media import UserMedia
+
+    async def mock_get_media_content_buffer(media_id_arg):
+        return io.BytesIO(b"%PDF mock"), "upload_fail.pdf", ".pdf"
+
+    monkeypatch.setattr(UserMedia, "get_media_content_buffer", mock_get_media_content_buffer)
+
+    responses.add(
+        responses.POST,
+        "https://waba-v2.360dialog.io/media",
+        body="Failure Test Case Simulation",
+        status=400,
+        content_type="application/json"
+    )
+
+    response = client.get(
+        f"/api/bot/{pytest.bot}/channels/media/upload/{bsp_type}/{media_id}?access_token={access_token}",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+
+    actual = response.json()
+    print(actual)
+
+    assert not actual["success"]
+    assert actual["data"] is None
+    assert actual["error_code"] == 422
+    assert "Failure Test Case Simulation" in actual["message"]
+    UserMediaData.objects().delete()
 
 @pytest.mark.asyncio
 @responses.activate

--- a/tests/unit_test/channels/bsp_test.py
+++ b/tests/unit_test/channels/bsp_test.py
@@ -1,4 +1,6 @@
+import io
 import os
+from datetime import datetime
 from unittest import mock
 
 import pytest
@@ -11,9 +13,10 @@ from kairon.shared.channels.whatsapp.bsp.base import WhatsappBusinessServiceProv
 from kairon.shared.channels.whatsapp.bsp.dialog360 import BSP360Dialog
 from kairon.shared.channels.whatsapp.bsp.factory import BusinessServiceProviderFactory
 from kairon.shared.chat.processor import ChatDataProcessor
+from kairon.shared.chat.user_media import UserMedia
 from kairon.shared.constants import WhatsappBSPTypes, ChannelTypes
 from kairon.shared.data.audit.data_objects import AuditLogData
-from kairon.shared.data.data_objects import BotSettings
+from kairon.shared.data.data_objects import BotSettings, UserMediaData
 from kairon.shared.data.processor import MongoProcessor
 from kairon.shared.utils import Utility
 from mongomock import MongoClient
@@ -845,3 +848,94 @@ class TestBusinessServiceProvider:
 
         with pytest.raises(Exception):
             WhatsappBusinessServiceProviderBase.delete_template()
+
+    @pytest.mark.asyncio
+    @responses.activate
+    async def test_upload_media_success(self):
+        media_id = "0196c9efbf547b81a66ba2af7b72d5ba"
+        bsp_type = "360dialog"
+        access_token = "test-token"
+        expected_external_media_id = "abc123"
+
+        UserMediaData(
+            media_id=media_id,
+            filename="Upload_Download Data.pdf",
+            extension=".pdf",
+            upload_status="completed",
+            upload_type="user_uploaded",
+            filesize=410484,
+            sender_id="himanshu.gupta@digite.com",
+            bot="682323a603ec3be7dcaa75bc",
+            timestamp=datetime.utcnow(),
+            media_url="https://upload-doc-poc.s3.amazonaws.com/user_media/682323a603ec3be7dcaa75bc/himanshu.gt_digite.com_0196c9efbf547b81a66ba2af7b72d5ba_Upload_Download Data.pdf",
+            output_filename="user_media/682323a603ec3be7dcaa75bc/himanshu.gupta_digite.com_0196c9efbf547b81a66ba2af7b72d5ba_Upload_Download Data.pdf",
+        ).save()
+
+        async def mock_get_media_content_buffer(media_id_arg):
+            assert media_id_arg == media_id
+            return io.BytesIO(b"%PDF-1.4 mock content"), "Upload_Download Data.pdf", ".pdf"
+
+        UserMedia.get_media_content_buffer = mock_get_media_content_buffer
+
+        responses.add(
+            responses.POST,
+            "https://waba-v2.360dialog.io/media",
+            json={"id": expected_external_media_id},
+            status=200,
+            content_type="application/json"
+        )
+
+        external_media_id = await BSP360Dialog.upload_media(bsp_type, media_id, access_token)
+
+        assert external_media_id == expected_external_media_id
+
+        updated_doc = UserMediaData.objects.get(media_id=media_id)
+        assert updated_doc.external_upload_info == {
+            "bsp": bsp_type,
+            "external_media_id": expected_external_media_id,
+            "error": ""
+        }
+        UserMediaData.objects().delete()
+
+    @pytest.mark.asyncio
+    async def test_upload_media_media_not_found(self):
+        media_id = "non_existing_media_id"
+        bsp_type = "360dialog"
+        access_token = "test-token"
+
+        with pytest.raises(AppException) as exc_info:
+            await BSP360Dialog.upload_media(bsp_type, media_id, access_token)
+
+        assert str(exc_info.value) == f"UserMediaData not found for media_id: {media_id}"
+
+    @pytest.mark.asyncio
+    async def test_upload_media_file_stream_not_found(self):
+        media_id = "0196c9efbf547b81a66ba2af7b72d5ba"
+        bsp_type = "360dialog"
+        access_token = "test-token"
+
+        UserMediaData(
+            media_id=media_id,
+            filename="Upload_Download Data.pdf",
+            extension=".pdf",
+            upload_status="completed",
+            upload_type="user_uploaded",
+            filesize=410484,
+            sender_id="himanshu.gupta@digite.com",
+            bot="682323a603ec3be7dcaa75bc",
+            timestamp=datetime.utcnow(),
+            media_url="https://upload-doc-poc.s3.amazonaws.com/user_media/682323a603ec3be7dcaa75bc/himanshu.gt_digite.com_0196c9efbf547b81a66ba2af7b72d5ba_Upload_Download Data.pdf",
+            output_filename="user_media/682323a603ec3be7dcaa75bc/himanshu.gupta_digite.com_0196c9efbf547b81a66ba2af7b72d5ba_Upload_Download Data.pdf",
+        ).save()
+
+        async def mock_get_media_content_buffer(media_id_arg):
+            return None, None, None
+
+        UserMedia.get_media_content_buffer = mock_get_media_content_buffer
+
+        with pytest.raises(AppException) as exc_info:
+            await BSP360Dialog.upload_media(bsp_type, media_id, access_token)
+
+        assert str(exc_info.value) == "File stream not found"
+
+        UserMediaData.objects().delete()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new endpoint to upload media files to external business service providers, returning an external media ID upon success.

- **Bug Fixes**
  - Improved error handling for scenarios such as missing media files or upload failures.

- **Tests**
  - Added integration and unit tests covering successful uploads, missing media, missing file streams, and external upload failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->