### PR TITLE
mail channel dispatch optional

### DIFF
--- a/kairon/actions/definitions/email.py
+++ b/kairon/actions/definitions/email.py
@@ -54,6 +54,7 @@ class ActionEmail(ActionsBase):
         exception = None
         action_config = self.retrieve_config()
         bot_response = action_config.get("response")
+        dispatch_bot_response = action_config.get("dispatch_bot_response", True)
         smtp_password = action_config.get('smtp_password')
         smtp_userid = action_config.get('smtp_userid')
         custom_text = action_config.get('custom_text')
@@ -87,6 +88,8 @@ class ActionEmail(ActionsBase):
             bot_response = "I have failed to process your request"
             status = "FAILURE"
         finally:
+            if dispatch_bot_response:
+                dispatcher.utter_message(bot_response)
             ActionServerLogs(
                 type=ActionType.email_action.value,
                 intent=tracker.get_intent_of_latest_message(skip_fallback_intent=False),
@@ -98,7 +101,6 @@ class ActionEmail(ActionsBase):
                 status=status,
                 user_msg=tracker.latest_message.get('text')
             ).save()
-        dispatcher.utter_message(bot_response)
         return {KaironSystemSlots.kairon_action_response.value: bot_response}
 
     @staticmethod

--- a/kairon/shared/actions/data_objects.py
+++ b/kairon/shared/actions/data_objects.py
@@ -444,6 +444,7 @@ class EmailActionConfig(Auditlog):
     subject = StringField(required=True)
     to_email = EmbeddedDocumentField(CustomActionParameters)
     response = StringField(required=True)
+    dispatch_bot_response = BooleanField(default=True)
     custom_text = EmbeddedDocumentField(CustomActionRequestParameters)
     tls = BooleanField(default=False)
     bot = StringField(required=True)

--- a/kairon/shared/data/data_models.py
+++ b/kairon/shared/data/data_models.py
@@ -1001,6 +1001,7 @@ class EmailActionRequest(BaseModel):
     custom_text: CustomActionParameter = None
     to_email: CustomActionParameterModel
     response: str
+    dispatch_bot_response: bool = True
     tls: bool = False
 
 

--- a/kairon/shared/data/processor.py
+++ b/kairon/shared/data/processor.py
@@ -7149,6 +7149,7 @@ class MongoProcessor:
         email_action.subject = action["subject"]
         email_action.to_email = CustomActionParameters(**action['to_email']) if action.get('to_email') else None
         email_action.response = action["response"]
+        email_action.dispatch_bot_response = action["dispatch_bot_response"]
         email_action.tls = action["tls"]
         email_action.user = user
         email_action.timestamp = datetime.utcnow()

--- a/tests/integration_test/action_service_test.py
+++ b/tests/integration_test/action_service_test.py
@@ -6147,6 +6147,159 @@ def test_email_action_execution(mock_smtp, mock_action_config, mock_action):
 @mock.patch("kairon.shared.actions.utils.ActionUtility.get_action")
 @mock.patch("kairon.actions.definitions.email.ActionEmail.retrieve_config")
 @mock.patch("kairon.shared.utils.SMTP", autospec=True)
+def test_email_action_execution_dispaatch_false(mock_smtp, mock_action_config, mock_action):
+    Utility.email_conf['email']['templates']['conversation'] = open('template/emails/conversation.html',
+                                                                    'rb').read().decode()
+    Utility.email_conf['email']['templates']['bot_msg_conversation'] = open(
+        'template/emails/bot_msg_conversation.html', 'rb').read().decode()
+    Utility.email_conf['email']['templates']['user_msg_conversation'] = open(
+        'template/emails/user_msg_conversation.html', 'rb').read().decode()
+    Utility.email_conf['email']['templates']['button_template'] = open('template/emails/button.html',
+                                                                       'rb').read().decode()
+
+    action_name = "test_run_email_action"
+    action = Actions(name=action_name, type=ActionType.email_action.value, bot="bot", user="user")
+    action_config = EmailActionConfig(
+        action_name=action_name,
+        smtp_url="test.localhost",
+        smtp_port=293,
+        smtp_password=CustomActionRequestParameters(key='smtp_password', value="test"),
+        from_email=CustomActionRequestParameters(value="test@demo.com", parameter_type="value"),
+        to_email=CustomActionParameters(value=["test@test.com"], parameter_type="value"),
+        subject="test",
+        response="Email Triggered",
+        bot="bot",
+        user="user",
+        dispatch_bot_response=False
+    )
+
+    def _get_action(*arge, **kwargs):
+        return action.to_mongo().to_dict()
+
+    def _get_action_config(*arge, **kwargs):
+        return action_config.to_mongo().to_dict()
+
+    request_object = {
+        "next_action": action_name,
+        "tracker": {
+            "sender_id": "default",
+            "conversation_id": "default",
+            "slots": {"bot": "5f50fd0a56b698ca10d35d2e"},
+            "latest_message": {'text': 'get intents', 'intent_ranking': [{'name': 'test_run'}]},
+            "latest_event_time": 1537645578.314389,
+            "followup_action": "action_listen",
+            "paused": False,
+            "events": [
+                {"event": "action", "timestamp": 1594907100.12764, "name": "action_session_start", "policy": None,
+                 "confidence": None}, {"event": "session_started", "timestamp": 1594907100.12765},
+                {"event": "action", "timestamp": 1594907100.12767, "name": "action_listen", "policy": None,
+                 "confidence": None}, {"event": "user", "timestamp": 1594907100.42744, "text": "can't",
+                                       "parse_data": {
+                                           "intent": {"name": "test intent", "confidence": 0.253578245639801},
+                                           "entities": [], "intent_ranking": [
+                                               {"name": "test intent", "confidence": 0.253578245639801},
+                                               {"name": "goodbye", "confidence": 0.1504897326231},
+                                               {"name": "greet", "confidence": 0.138640150427818},
+                                               {"name": "affirm", "confidence": 0.0857767835259438},
+                                               {"name": "smalltalk_human", "confidence": 0.0721133947372437},
+                                               {"name": "deny", "confidence": 0.069614589214325},
+                                               {"name": "bot_challenge", "confidence": 0.0664894133806229},
+                                               {"name": "faq_vaccine", "confidence": 0.062177762389183},
+                                               {"name": "faq_testing", "confidence": 0.0530692934989929},
+                                               {"name": "out_of_scope", "confidence": 0.0480506233870983}],
+                                           "response_selector": {
+                                               "default": {"response": {"name": None, "confidence": 0},
+                                                           "ranking": [], "full_retrieval_intent": None}},
+                                           "text": "can't"}, "input_channel": None,
+                                       "message_id": "bbd413bf5c834bf3b98e0da2373553b2", "metadata": {}},
+                {"event": "action", "timestamp": 1594907100.4308, "name": "utter_test intent",
+                 "policy": "policy_0_MemoizationPolicy", "confidence": 1},
+                {"event": "bot", "timestamp": 1594907100.4308, "text": "will not = won\"t",
+                 "data": {"elements": None, "quick_replies": None, "buttons": None, "attachment": None,
+                          "image": None, "custom": None}, "metadata": {}},
+                {"event": "action", "timestamp": 1594907100.43384, "name": "action_listen",
+                 "policy": "policy_0_MemoizationPolicy", "confidence": 1},
+                {"event": "user", "timestamp": 1594907117.04194, "text": "can\"t",
+                 "parse_data": {"intent": {"name": "test intent", "confidence": 0.253578245639801}, "entities": [],
+                                "intent_ranking": [{"name": "test intent", "confidence": 0.253578245639801},
+                                                   {"name": "goodbye", "confidence": 0.1504897326231},
+                                                   {"name": "greet", "confidence": 0.138640150427818},
+                                                   {"name": "affirm", "confidence": 0.0857767835259438},
+                                                   {"name": "smalltalk_human", "confidence": 0.0721133947372437},
+                                                   {"name": "deny", "confidence": 0.069614589214325},
+                                                   {"name": "bot_challenge", "confidence": 0.0664894133806229},
+                                                   {"name": "faq_vaccine", "confidence": 0.062177762389183},
+                                                   {"name": "faq_testing", "confidence": 0.0530692934989929},
+                                                   {"name": "out_of_scope", "confidence": 0.0480506233870983}],
+                                "response_selector": {
+                                    "default": {"response": {"name": None, "confidence": 0}, "ranking": [],
+                                                "full_retrieval_intent": None}}, "text": "can\"t"},
+                 "input_channel": None, "message_id": "e96e2a85de0748798748385503c65fb3", "metadata": {}},
+                {"event": "action", "timestamp": 1594907117.04547, "name": "utter_test intent",
+                 "policy": "policy_1_TEDPolicy", "confidence": 0.978452920913696},
+                {"event": "bot", "timestamp": 1594907117.04548, "text": "can not = can't",
+                 "data": {"elements": None, "quick_replies": None, "buttons": None, "attachment": None,
+                          "image": None, "custom": None}, "metadata": {}}],
+            "latest_input_channel": "rest",
+            "active_loop": {},
+            "latest_action": {},
+        },
+        "domain": {
+            "config": {},
+            "session_config": {},
+            "intents": [],
+            "entities": [],
+            "slots": {"bot": "5f50fd0a56b698ca10d35d2e"},
+            "responses": {},
+            "actions": [],
+            "forms": {},
+            "e2e_actions": []
+        },
+        "version": "version"
+    }
+    mock_action.side_effect = _get_action
+    mock_action_config.side_effect = _get_action_config
+    response = client.post("/webhook", json=request_object)
+    response_json = response.json()
+    assert response.status_code == 200
+    assert len(response_json['events']) == 1
+    assert len(response_json['responses']) == 0
+    assert response_json['events'] == [
+        {'event': 'slot', 'timestamp': None, 'name': 'kairon_action_response',
+         'value': "Email Triggered"}]
+    logs = ActionServerLogs.objects(type=ActionType.email_action.value).order_by("-id").first()
+    assert logs.status == "SUCCESS"
+
+    name, args, kwargs = mock_smtp.method_calls.pop(0)
+    assert name == '().connect'
+    assert {} == kwargs
+
+    host, port = args
+    assert host == action_config.smtp_url
+    assert port == action_config.smtp_port
+    name, args, kwargs = mock_smtp.method_calls.pop(0)
+    assert name == '().login'
+    assert {} == kwargs
+
+    from_email, password = args
+    assert from_email == action_config.from_email.value
+    assert password == action_config.smtp_password.value
+
+    name, args, kwargs = mock_smtp.method_calls.pop(0)
+    assert name == '().sendmail'
+    assert {} == kwargs
+
+    assert args[0] == action_config.from_email.value
+    assert args[1] == ["test@test.com"]
+    assert str(args[2]).__contains__(action_config.subject)
+    assert str(args[2]).__contains__("Content-Type: text/html")
+    assert str(args[2]).__contains__("Subject: default test")
+
+
+
+@mock.patch("kairon.shared.actions.utils.ActionUtility.get_action")
+@mock.patch("kairon.actions.definitions.email.ActionEmail.retrieve_config")
+@mock.patch("kairon.shared.utils.SMTP", autospec=True)
 def test_email_action_execution_with_sender_email_from_slot(mock_smtp, mock_action_config, mock_action):
     Utility.email_conf['email']['templates']['conversation'] = open('template/emails/conversation.html',
                                                                     'rb').read().decode()

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -23308,6 +23308,7 @@ def test_list_email_actions():
             "action_name": "email_config",
             "smtp_url": "test.test.com",
             "smtp_port": 25,
+            'dispatch_bot_response': True,
             "smtp_password": {
                 "_cls": "CustomActionRequestParameters",
                 "key": "smtp_password",
@@ -23327,6 +23328,7 @@ def test_list_email_actions():
             "action_name": "email_config_with_slot",
             "smtp_url": "test.test.com",
             "smtp_port": 25,
+            'dispatch_bot_response': True,
             "smtp_password": {
                 "_cls": "CustomActionRequestParameters",
                 "key": "smtp_password",
@@ -23346,6 +23348,7 @@ def test_list_email_actions():
             "action_name": "email_config_with_key_vault",
             "smtp_url": "test.test.com",
             "smtp_port": 25,
+            'dispatch_bot_response': True,
             "smtp_password": {
                 "_cls": "CustomActionRequestParameters",
                 "key": "smtp_password",

--- a/tests/unit_test/data_processor/data_processor_test.py
+++ b/tests/unit_test/data_processor/data_processor_test.py
@@ -16338,10 +16338,29 @@ class TestMongoProcessor:
                         "to_email": {"value": ["test@test.com", "test1@test.com"], "parameter_type": "value"},
                         "subject": "Test Subject",
                         "response": "Test Response",
+                        "dispatch_bot_response": True,
                         "tls": False
                         }
         with patch("kairon.shared.utils.SMTP", autospec=True) as mock_smtp:
             assert processor.add_email_action(email_config, "TEST", "tests") is not None
+
+    def test_add_email_action_dispatch_false(self):
+        processor = MongoProcessor()
+        email_config = {"action_name": "email_config_disp_false",
+                        "smtp_url": "test.test.com",
+                        "smtp_port": 25,
+                        "smtp_userid": None,
+                        "smtp_password": {'value': "test"},
+                        "from_email": {"value": "from_email", "parameter_type": "slot"},
+                        "to_email": {"value": ["test@test.com", "test1@test.com"], "parameter_type": "value"},
+                        "subject": "Test Subject",
+                        "response": "Test Response",
+                        "dispatch_bot_response": False,
+                        "tls": False
+                        }
+        with patch("kairon.shared.utils.SMTP", autospec=True) as mock_smtp:
+            assert processor.add_email_action(email_config, "TEST", "tests") is not None
+            EmailActionConfig.objects(action_name="email_config_disp_false").delete()
 
     def test_add_email_action_with_custom_text(self):
         processor = MongoProcessor()
@@ -16354,6 +16373,8 @@ class TestMongoProcessor:
                         "to_email": {"value": ["test@test.com", "test1@test.com"], "parameter_type": "value"},
                         "subject": "Test Subject",
                         "response": "Test Response",
+                        "dispatch_bot_response": True,
+
                         "tls": False,
                         "custom_text": {"value": "Hello from kairon!"}
                         }
@@ -16392,6 +16413,8 @@ class TestMongoProcessor:
                         "to_email": {"value": ["test@test.com", "test1@test.com"], "parameter_type": "value"},
                         "subject": "Test Subject",
                         "response": "Test Response",
+                        "dispatch_bot_response": True,
+
                         "tls": False
                         }
         with patch("kairon.shared.utils.SMTP", autospec=True) as mock_smtp:
@@ -16452,6 +16475,8 @@ class TestMongoProcessor:
                         "to_email": {"value": ["test@test.com", "test1@test.com"], "parameter_type": "value"},
                         "subject": "Test Subject",
                         "response": "Test Response",
+                        "dispatch_bot_response": True,
+
                         "tls": False
                         }
         with patch("kairon.shared.utils.SMTP", autospec=True) as mock_smtp:
@@ -16469,6 +16494,8 @@ class TestMongoProcessor:
                         "to_email": {"value": "to_email", "parameter_type": "slot"},
                         "subject": "Test Subject",
                         "response": "Test Response",
+                        "dispatch_bot_response": True,
+
                         "tls": False
                         }
         with patch("kairon.shared.utils.SMTP", autospec=True) as mock_smtp:
@@ -16486,12 +16513,14 @@ class TestMongoProcessor:
                         "to_email": {"value": "to_email", "parameter_type": "slot"},
                         "subject": "Test Subject",
                         "response": "Test Response",
+                        "dispatch_bot_response": False,
                         "tls": False
                         }
         with patch("kairon.shared.utils.SMTP", autospec=True) as mock_smtp:
             assert processor.edit_email_action(email_config, "TEST", "tests") is None
 
         email_config["custom_text"] = {"value": "custom_text_slot", "parameter_type": "slot"}
+        email_config["dispatch_bot_response"] = True
         with patch("kairon.shared.utils.SMTP", autospec=True) as mock_smtp:
             assert processor.edit_email_action(email_config, "TEST", "tests") is None
 
@@ -16506,6 +16535,7 @@ class TestMongoProcessor:
                         "to_email": {"value": "to_email", "parameter_type": "slot"},
                         "subject": "Test Subject",
                         "response": "Test Response",
+                        "dispatch_bot_response": True,
                         "tls": False
                         }
         with patch("kairon.shared.utils.SMTP", autospec=True) as mock_smtp:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configuration option to email actions that allows control over whether the bot's response message is sent to the user after an email is dispatched.

- **Tests**
  - Introduced new and updated test cases to verify the behavior of the email action when the bot response dispatch option is enabled or disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->