### PR TITLE
Built an end-to-end catalog ingestion flow from Petpooja(POS) to Meta

### DIFF
--- a/email.yaml
+++ b/email.yaml
@@ -25,4 +25,5 @@ email:
         book_a_demo_subject: ${EMAIL_TEMPLATES_BOOK_A_DEMO_SUBJECT:"kAIron Demo Requested"}
         member_left_bot_subject: ${EMAIL_TEMPLATES_USER_LEFT_BOT_SUBJECT:"User has left the BOT_NAME bot"}
         member_left_bot_mail_body: ${EMAIL_TEMPLATES_USER_LEFT_BOT_BODY:"User USER_NAME has left the BOT_NAME bot."}
+        catalog_sync_status_subject: ${EMAIL_TEMPLATES_CATALOG_SYNC_UPDATE:"Catalog Sync Update"}
 

--- a/kairon/api/app/main.py
+++ b/kairon/api/app/main.py
@@ -24,7 +24,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from kairon.api.app.routers import auth, augment, history, user, account, idp, system
 from kairon.api.app.routers.bot import action, bot, agents, secrets, multilingual, metric, data, \
-    channels, custom_widgets
+    channels, custom_widgets, integrations
 from kairon.api.models import Response
 from kairon.exceptions import AppException
 from kairon.shared.account.processor import AccountProcessor
@@ -276,3 +276,4 @@ app.include_router(idp.router, prefix="/api/idp", tags=["SSO", "IDP"])
 app.include_router(system.router, prefix="/api/system", tags=["Application"])
 app.include_router(data.router, prefix="/api/bot/{bot}/data", tags=["File Upload/Download"])
 app.include_router(custom_widgets.router, prefix="/api/bot/{bot}/widgets", tags=["Custom analytical widgets"])
+app.include_router(integrations.router, prefix="/api/bot/integration", tags=["Data Integrations"])

--- a/kairon/api/app/routers/bot/integrations.py
+++ b/kairon/api/app/routers/bot/integrations.py
@@ -1,0 +1,84 @@
+from typing import  Text
+
+from fastapi import Security, APIRouter, Path
+from starlette.requests import Request
+
+from kairon.api.models import Response
+from kairon.events.definitions.catalog_sync import CatalogSync
+from kairon.exceptions import AppException
+from kairon.shared.auth import Authentication
+from kairon.shared.catalog_sync.data_objects import CatalogSyncLogs
+from kairon.shared.cognition.processor import CognitionDataProcessor
+from kairon.shared.constants import CatalogProvider
+from kairon.shared.constants import DESIGNER_ACCESS
+from kairon.shared.models import User
+
+router = APIRouter()
+cognition_processor = CognitionDataProcessor()
+
+@router.post("/{provider}/{sync_type}/{bot}/{token}", response_model=Response)
+async def sync_data(
+    request: Request,
+    provider: CatalogProvider = Path(description="Catalog provider name",
+                                 examples=[CatalogProvider.PETPOOJA.value]),
+    bot: Text = Path(description="Bot id"),
+    sync_type: Text = Path(description="Sync Type"),
+    current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
+    token: str = Path(description="JWT token for authentication"),
+):
+    """
+    Handles incoming data from catalog_sync (e.g., Petpooja) for processing, validation, and eventual storage.
+    """
+
+    request_body = await request.json()
+
+    event = CatalogSync(
+        bot=bot,
+        user=current_user.get_user(),
+        provider=provider,
+        sync_type=sync_type,
+        token=token
+    )
+
+    is_event_data = await event.validate(request_body=request_body)
+    if is_event_data is True:
+        event.enqueue()
+        return {"message": "Sync in progress! Check logs."}
+    else:
+        raise AppException(is_event_data)
+
+
+
+@router.post("/{provider}/{sync_type}/{bot}/{token}/{execution_id}", response_model=Response)
+async def rerun_sync(
+    provider: CatalogProvider = Path(description="Catalog provider name",
+                                 examples=[CatalogProvider.PETPOOJA.value]),
+    bot: Text = Path(description="Bot id"),
+    sync_type: Text = Path(description="Sync Type"),
+    current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
+    token: str = Path(description="JWT token for authentication"),
+    execution_id: str = Path(description="Execution id"),
+):
+    """
+    Handles incoming data from catalog_sync and rerunning (e.g., Petpooja) for processing, validation, and eventual storage.
+    """
+    sync_log_entry = CatalogSyncLogs.objects(execution_id=execution_id).first()
+    if not sync_log_entry:
+        raise AppException(f"Sync log with execution ID {execution_id} not found.")
+
+    request_body = sync_log_entry.raw_payload
+
+    event = CatalogSync(
+        bot=bot,
+        user=current_user.get_user(),
+        provider=provider,
+        sync_type=sync_type,
+        token=token
+    )
+
+    is_event_data = await event.validate(request_body=request_body)
+    if is_event_data is True:
+        event.enqueue()
+        return {"message": "Sync in progress! Check logs."}
+    else:
+        raise AppException(is_event_data)

--- a/kairon/catalog_sync/definitions/base.py
+++ b/kairon/catalog_sync/definitions/base.py
@@ -1,0 +1,18 @@
+from abc import abstractmethod
+
+
+class CatalogSyncBase:
+
+    """Base class to create events"""
+
+    @abstractmethod
+    def validate(self):
+        raise NotImplementedError("Provider not implemented")
+
+    @abstractmethod
+    def preprocess(self):
+        raise NotImplementedError("Provider not implemented")
+
+    @abstractmethod
+    def execute(self, **kwargs):
+        raise NotImplementedError("Provider not implemented")

--- a/kairon/catalog_sync/definitions/factory.py
+++ b/kairon/catalog_sync/definitions/factory.py
@@ -1,0 +1,29 @@
+from kairon.events.definitions.petpooja_sync import PetpoojaSync
+from kairon.exceptions import AppException
+from kairon.shared.constants import CatalogSyncClass
+
+
+class CatalogSyncFactory:
+
+    __provider_implementations = {
+        CatalogSyncClass.petpooja: PetpoojaSync,
+    }
+
+    @staticmethod
+    def get_instance(provider: str):
+        """
+        Factory to retrieve catalog provider implementation for execution.
+        :param provider: catalog provider name (e.g., "petpooja")
+        :return: Corresponding Sync class
+        """
+        try:
+            provider_enum = CatalogSyncClass(provider.lower())
+        except ValueError:
+            valid_syncs = [sync.value for sync in CatalogSyncClass]
+            raise AppException(f"'{provider}' is not a valid catalog sync provider. Accepted types: {valid_syncs}")
+
+        sync_class = CatalogSyncFactory.__provider_implementations.get(provider_enum)
+        if not sync_class:
+            raise AppException(f"No implementation found for provider '{provider}'.")
+
+        return sync_class

--- a/kairon/events/definitions/catalog_sync.py
+++ b/kairon/events/definitions/catalog_sync.py
@@ -1,0 +1,73 @@
+from typing import Text
+from kairon import Utility
+from loguru import logger
+
+from kairon.catalog_sync.definitions.factory import CatalogSyncFactory
+from kairon.events.definitions.base import EventsBase
+from kairon.shared.account.processor import AccountProcessor
+from kairon.shared.constants import EventClass
+from kairon.shared.data.constant import SyncType, SYNC_STATUS
+from kairon.shared.catalog_sync.catalog_sync_log_processor import CatalogSyncLogProcessor
+
+
+class CatalogSync(EventsBase):
+    """
+    Validates and processes data from catalog (e.g., Petpooja) before importing it
+    to knowledge vault and meta
+    """
+
+    def __init__(self, bot: Text, user: Text, provider: Text, **kwargs):
+        """
+        Initialise event.
+        """
+        sync_class = CatalogSyncFactory.get_instance(provider)
+        self.catalog_sync = sync_class(
+            bot=bot,
+            user=user,
+            provider=provider,
+            sync_type=kwargs.get("sync_type", SyncType.item_toggle),
+            token=kwargs.get("token", "")
+        )
+        self.catalog_sync.data = []
+
+    async def validate(self, **kwargs):
+        """
+        Validates if an event is already running for that particular bot and
+        checks if the event trigger limit has been exceeded.
+        Then, preprocesses the received request
+        """
+        request = kwargs.get("request_body")
+        self.catalog_sync.data = request
+        is_event_data = await self.catalog_sync.validate(request_body = request)
+        return is_event_data
+
+    def enqueue(self, **kwargs):
+        """
+        Send event to event server
+        """
+        try:
+            payload = {
+                'bot': self.catalog_sync.bot,
+                'user': self.catalog_sync.user,
+                'provider': self.catalog_sync.provider,
+                'sync_type': self.catalog_sync.sync_type,
+                'token': self.catalog_sync.token,
+                'data': self.catalog_sync.data
+            }
+            CatalogSyncLogProcessor.add_log(self.catalog_sync.bot, self.catalog_sync.user, self.catalog_sync.provider, self.catalog_sync.sync_type, sync_status=SYNC_STATUS.ENQUEUED.value)
+            Utility.request_event_server(EventClass.catalog_integration, payload)
+        except Exception as e:
+            CatalogSyncLogProcessor.delete_enqueued_event_log(self.catalog_sync.bot)
+            raise e
+
+    async def execute(self, **kwargs):
+        """
+        Execute the document content import event.
+        """
+        AccountProcessor.load_system_properties()
+        self.catalog_sync.data = kwargs.get("data", [])
+        try:
+            initiate_import, stale_primary_keys= await self.catalog_sync.preprocess(request_body=self.catalog_sync.data)
+            await self.catalog_sync.execute(data=self.catalog_sync.data, initiate_import = initiate_import,stale_primary_keys = stale_primary_keys)
+        except Exception as e:
+            logger.error(str(e))

--- a/kairon/events/definitions/factory.py
+++ b/kairon/events/definitions/factory.py
@@ -10,6 +10,7 @@ from kairon.events.definitions.model_training import ModelTrainingEvent
 from kairon.events.definitions.multilingual import MultilingualEvent
 from kairon.exceptions import AppException
 from kairon.shared.constants import EventClass
+from kairon.events.definitions.catalog_sync import CatalogSync
 
 
 class EventFactory:
@@ -24,7 +25,8 @@ class EventFactory:
         EventClass.message_broadcast: MessageBroadcastEvent,
         EventClass.content_importer: DocContentImporterEvent,
         EventClass.mail_channel_read_mails: MailReadEvent,
-        EventClass.agentic_flow: AgenticFlowEvent
+        EventClass.agentic_flow: AgenticFlowEvent,
+        EventClass.catalog_integration: CatalogSync
     }
 
     @staticmethod

--- a/kairon/events/definitions/petpooja_sync.py
+++ b/kairon/events/definitions/petpooja_sync.py
@@ -7,6 +7,7 @@ from kairon.shared.data.constant import SyncType, SYNC_STATUS
 from kairon.shared.data.data_objects import POSIntegrations
 from kairon.shared.catalog_sync.catalog_sync_log_processor import CatalogSyncLogProcessor
 from kairon.shared.utils import MailUtility
+from loguru import logger
 
 
 class PetpoojaSync(CatalogSyncBase):
@@ -173,7 +174,7 @@ class PetpoojaSync(CatalogSyncBase):
             )
             CatalogSyncLogProcessor.add_log(self.bot, self.user, sync_status=sync_status, status=status)
         except Exception as e:
-            print(str(e))
+            logger.exception(str(e))
             execution_id = CatalogSyncLogProcessor.get_execution_id_for_bot(self.bot)
             await MailUtility.format_and_send_mail(
                 mail_type="catalog_sync_status", email="himanshu.gupta@nimblework.com", bot=self.bot,

--- a/kairon/events/definitions/petpooja_sync.py
+++ b/kairon/events/definitions/petpooja_sync.py
@@ -1,0 +1,190 @@
+from typing import Text
+
+from kairon.catalog_sync.definitions.base import CatalogSyncBase
+from kairon.meta.processor import MetaProcessor
+from kairon.shared.cognition.processor import CognitionDataProcessor
+from kairon.shared.data.constant import SyncType, SYNC_STATUS
+from kairon.shared.data.data_objects import POSIntegrations
+from kairon.shared.catalog_sync.catalog_sync_log_processor import CatalogSyncLogProcessor
+from kairon.shared.utils import MailUtility
+
+
+class PetpoojaSync(CatalogSyncBase):
+    """
+    Validates and processes data from catalog (e.g., Petpooja) before importing it
+    to knowledge vault and meta
+    """
+
+    def __init__(self, bot: Text, user: Text, provider: Text, **kwargs):
+        """
+        Initialise event.
+        """
+        self.bot = bot
+        self.user = user
+        self.provider = provider
+        self.token = kwargs.get("token", "")
+        self.sync_type = kwargs.get("sync_type", SyncType.item_toggle)
+        self.data = []
+
+    async def validate(self, **kwargs):
+        """
+        Validates if an event is already running for that particular bot and
+        checks if the event trigger limit has been exceeded.
+        Then, preprocesses the received request
+        """
+        try:
+            request = kwargs.get("request_body")
+            CatalogSyncLogProcessor.is_sync_in_progress(self.bot)
+            CatalogSyncLogProcessor.is_limit_exceeded(self.bot)
+            CatalogSyncLogProcessor.add_log(self.bot, self.user, self.provider, self.sync_type,
+                                            sync_status=SYNC_STATUS.INITIATED.value, raw_payload=request)
+
+            CatalogSyncLogProcessor.is_sync_type_allowed(self.bot, self.sync_type)
+            if not CatalogSyncLogProcessor.is_catalog_collection_exists(self.bot) and CatalogSyncLogProcessor.is_ai_enabled(self.bot):
+                CatalogSyncLogProcessor.create_catalog_collection(bot=self.bot, user=self.user)
+            CatalogSyncLogProcessor.add_log(self.bot, self.user, sync_status=SYNC_STATUS.VALIDATING_REQUEST)
+            if self.sync_type == SyncType.push_menu:
+                CatalogSyncLogProcessor.validate_item_ids(request)
+                CatalogSyncLogProcessor.validate_item_fields(self.bot, request, self.provider)
+                CatalogSyncLogProcessor.validate_image_configurations(self.bot, self.user)
+            else:
+                CatalogSyncLogProcessor.validate_item_toggle_request(request)
+            return True
+        except Exception as e:
+            execution_id = CatalogSyncLogProcessor.get_execution_id_for_bot(self.bot)
+            await MailUtility.format_and_send_mail(
+                    mail_type="catalog_sync_status", email="himanshu.gupta@nimblework.com", bot = self.bot, executionID = execution_id,
+                    sync_status=SYNC_STATUS.VALIDATING_FAILED, message = str(e), first_name = "HG"
+                )
+            CatalogSyncLogProcessor.add_log(self.bot, self.user, sync_status=SYNC_STATUS.FAILED.value,
+                                            exception=str(e),
+                                            status="Failure")
+            return str(e)
+
+    async def preprocess(self, **kwargs):
+        """
+        Transform and preprocess incoming payload data into `self.data`
+        for catalog sync and meta sync.
+        """
+        sync_status = SYNC_STATUS.VALIDATING_REQUEST_SUCCESS
+        try:
+            cognition_processor = CognitionDataProcessor()
+            sync_status=SYNC_STATUS.PREPROCESSING
+            CatalogSyncLogProcessor.add_log(self.bot, self.user, sync_status=sync_status)
+            request = kwargs.get("request_body")
+            if self.sync_type == SyncType.push_menu:
+                self.data = cognition_processor.preprocess_push_menu_data(self.bot, request, self.provider)
+            else:
+                self.data = cognition_processor.preprocess_item_toggle_data(self.bot, request, self.provider)
+            sync_status = SYNC_STATUS.PREPROCESSING_COMPLETED
+            CatalogSyncLogProcessor.add_log(self.bot, self.user, sync_status=sync_status, processed_payload= self.data)
+            stale_primary_keys = CognitionDataProcessor.save_ai_data(self.data, self.bot, self.user, self.sync_type)
+            initiate_import = True
+            if CatalogSyncLogProcessor.is_ai_enabled(self.bot):
+                restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(self.bot)
+                catalog_name = f"{restaurant_name}_{branch_name}_catalog"
+                sync_status = SYNC_STATUS.VALIDATING_KNOWLEDGE_VAULT_DATA
+                CatalogSyncLogProcessor.add_log(self.bot, self.user, sync_status=sync_status)
+                error_summary = cognition_processor.validate_data("id", catalog_name,
+                                                                  self.sync_type.lower(), self.data.get("kv", []), self.bot)
+                if error_summary:
+                    initiate_import = False
+                    sync_status = SYNC_STATUS.SAVE.value
+                    CatalogSyncLogProcessor.add_log(self.bot, self.user, validation_errors=error_summary,
+                                                    sync_status=sync_status, status="Failure")
+            return initiate_import, stale_primary_keys
+        except Exception as e:
+            execution_id = CatalogSyncLogProcessor.get_execution_id_for_bot(self.bot)
+            await MailUtility.format_and_send_mail(
+                mail_type="catalog_sync_status", email="himanshu.gupta@nimblework.com", bot=self.bot,
+                executionID=execution_id,
+                sync_status=sync_status, message=str(e), first_name="HG"
+            )
+            CatalogSyncLogProcessor.add_log(self.bot, self.user, sync_status=SYNC_STATUS.FAILED.value,
+                                            exception=str(e),
+                                            status="Failure")
+            return None
+
+
+    async def execute(self, **kwargs):
+        """
+        Execute the document content import event.
+        """
+        self.data = kwargs.get("data", {})
+        cognition_processor = CognitionDataProcessor()
+        initiate_import = kwargs.get("initiate_import", False)
+        stale_primary_keys = kwargs.get("stale_primary_keys")
+        status = "Failure"
+        sync_status = SYNC_STATUS.PREPROCESSING_COMPLETED
+        try:
+            knowledge_vault_data = self.data.get("kv", [])
+            restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(self.bot)
+            catalog_name = f"{restaurant_name}_{branch_name}_catalog"
+
+            if not CatalogSyncLogProcessor.is_ai_enabled(self.bot) and not CatalogSyncLogProcessor.is_meta_enabled(self.bot):
+                CatalogSyncLogProcessor.add_log(self.bot, self.user,
+                                                exception="Sync to knowledge vault and Meta is not allowed for this bot. Contact Support!!",
+                                                status="Success")
+                raise Exception("Sync to knowledge vault and Meta is not allowed for this bot. Contact Support!!")
+
+            if initiate_import and CatalogSyncLogProcessor.is_ai_enabled(self.bot):
+                result = await cognition_processor.upsert_data("id", catalog_name,
+                                                                   self.sync_type.lower(), knowledge_vault_data,
+                                                                   self.bot, self.user)
+                stale_primary_keys = result.get("stale_ids")
+            else:
+                sync_status = SYNC_STATUS.COMPLETED.value
+                CatalogSyncLogProcessor.add_log(self.bot, self.user,
+                                                exception="Sync to knowledge vault is not allowed for this bot. Contact Support!!",
+                                                status="Success")
+
+            if not CatalogSyncLogProcessor.is_meta_enabled(self.bot):
+                sync_status = SYNC_STATUS.COMPLETED.value
+                CatalogSyncLogProcessor.add_log(self.bot, self.user,
+                                                exception="Sync to Meta is not allowed for this bot. Contact Support!!",
+                                                status="Success")
+
+            integrations_doc = POSIntegrations.objects(bot=self.bot, provider=self.provider,
+                                                    sync_type=self.sync_type).first()
+            if integrations_doc and 'meta_config' in integrations_doc:
+                sync_status=SYNC_STATUS.SAVE_META.value
+                CatalogSyncLogProcessor.add_log(self.bot, self.user, sync_status=sync_status)
+                meta_processor = MetaProcessor(integrations_doc.meta_config.get('access_token'),
+                                               integrations_doc.meta_config.get('catalog_id'))
+
+                meta_payload = self.data.get("meta", [])
+                if self.sync_type == SyncType.push_menu:
+                    meta_processor.preprocess_data(self.bot, meta_payload, "CREATE", self.provider)
+                    await meta_processor.push_meta_catalog()
+                    if stale_primary_keys:
+                        delete_payload = meta_processor.preprocess_delete_data(stale_primary_keys)
+                        await meta_processor.delete_meta_catalog(delete_payload)
+                    status = "Success"
+                else:
+                    meta_processor.preprocess_data(self.bot, meta_payload, "UPDATE", self.provider)
+                    await meta_processor.update_meta_catalog()
+                    status = "Success"
+            execution_id = CatalogSyncLogProcessor.get_execution_id_for_bot(self.bot)
+            sync_status=SYNC_STATUS.COMPLETED.value
+            await MailUtility.format_and_send_mail(
+                mail_type="catalog_sync_status", email="himanshu.gupta@nimblework.com", bot=self.bot,
+                executionID=execution_id,
+                sync_status=sync_status, message="Catalog has been synced successfully", first_name="HG"
+            )
+            CatalogSyncLogProcessor.add_log(self.bot, self.user, sync_status=sync_status, status=status)
+        except Exception as e:
+            print(str(e))
+            execution_id = CatalogSyncLogProcessor.get_execution_id_for_bot(self.bot)
+            await MailUtility.format_and_send_mail(
+                mail_type="catalog_sync_status", email="himanshu.gupta@nimblework.com", bot=self.bot,
+                executionID=execution_id,
+                sync_status=sync_status, message=str(e), first_name="HG"
+            )
+            if not CatalogSyncLogProcessor.is_meta_enabled(self.bot) and not CatalogSyncLogProcessor.is_ai_enabled(self.bot):
+                CatalogSyncLogProcessor.add_log(self.bot, self.user,
+                                                sync_status=SYNC_STATUS.COMPLETED.value)
+            else:
+                CatalogSyncLogProcessor.add_log(self.bot, self.user,
+                                                    exception=str(e),
+                                                    status="Failure",
+                                                    sync_status=sync_status)

--- a/kairon/meta/processor.py
+++ b/kairon/meta/processor.py
@@ -70,8 +70,8 @@ class MetaProcessor:
 
             response = await asyncio.to_thread(requests.post, url, headers={}, data=data)
             response.raise_for_status()
-            print("Response JSON:", response.json())
-            print("Successfully synced product items to Meta catalog(Push Menu)")
+            logger.info("Response JSON:", response.json())
+            logger.info("Successfully synced product items to Meta catalog(Push Menu)")
         except Exception as e:
             logger.exception(f"Error syncing product items to Meta catalog for push menu: {str(e)}")
             raise e
@@ -91,8 +91,8 @@ class MetaProcessor:
 
             response = await asyncio.to_thread(requests.post, url, headers={}, data=data)
             response.raise_for_status()
-            print("Response JSON:", response.json())
-            print("Successfully synced product items to Meta catalog(Item Toggle)")
+            logger.info("Response JSON:", response.json())
+            logger.info("Successfully synced product items to Meta catalog(Item Toggle)")
         except Exception as e:
             logger.exception(f"Error syncing product items to Meta catalog for item toggle: {str(e)}")
             raise e
@@ -112,8 +112,8 @@ class MetaProcessor:
             }
             response = await asyncio.to_thread(requests.post, url, headers={}, data=data)
             response.raise_for_status()
-            print("Response JSON:", response.json())
-            print("Successfully deleted data from meta.")
+            logger.info("Response JSON:", response.json())
+            logger.info("Successfully deleted data from meta.")
         except Exception as e:
             logger.exception(f"Error deleting data from meta: {str(e)}")
             raise e

--- a/kairon/meta/processor.py
+++ b/kairon/meta/processor.py
@@ -1,0 +1,119 @@
+import asyncio
+import json
+from typing import Text, List
+from loguru import logger
+import requests
+from kairon.shared.catalog_sync.data_objects import CatalogProviderMapping
+from urllib.parse import quote
+
+
+class MetaProcessor:
+
+    def __init__(self, access_token: Text, catalog_id:Text):
+        self.catalog_id = catalog_id
+        self.access_token = access_token
+        self.headers = {}
+        self.processed_data = []
+
+    def preprocess_data(self,bot: Text, data: List[dict], method: Text, provider: str):
+        doc = CatalogProviderMapping.objects(provider=provider).first()
+        if not doc:
+            raise Exception(f"Metadata mappings not found for provider={provider}")
+
+        meta_fields = list(doc.meta_mappings.keys())
+
+        for item in data:
+            transformed_item = {"retailer_id": item["id"]}
+
+            if method == "UPDATE":
+                transformed_item["data"] = {}
+                for field in meta_fields:
+                    if field in item:
+                        value = int(item[field]) if field == "price" else item[field]
+                        transformed_item["data"][field] = value
+
+            else:
+                transformed_item["data"] = {"currency": "INR"}
+                for field in meta_fields:
+                    if field in item:
+                        value = int(item[field]) if field == "price" else item[field]
+                        transformed_item["data"][field] = value
+
+            transformed_item["method"] = method
+            transformed_item["item_type"] = "PRODUCT_ITEM"
+            self.processed_data.append(transformed_item)
+
+        return self.processed_data
+
+    def preprocess_delete_data(self, remaining_ids: List):
+        """
+        Creates a payload for deleting stale records from the catalog.
+        Args:
+            remaining_ids: List of primary keys that need to be deleted.
+        Returns:
+            Dict: Payload containing the list of delete operations.
+        """
+        return [{"retailer_id": id, "method": "DELETE"} for id in remaining_ids]
+
+    async def push_meta_catalog(self):
+        """
+        Sync the data to meta when event type is 'push_menu'
+        """
+        try:
+            req = quote(json.dumps(self.processed_data))
+            base_url = f"https://graph.facebook.com/v21.0/{self.catalog_id}/batch"
+            url = f"{base_url}?item_type=PRODUCT_ITEM&requests={req}"
+
+            data = {
+                "access_token": self.access_token,
+            }
+
+            response = await asyncio.to_thread(requests.post, url, headers={}, data=data)
+            response.raise_for_status()
+            print("Response JSON:", response.json())
+            print("Successfully synced product items to Meta catalog(Push Menu)")
+        except Exception as e:
+            logger.exception(f"Error syncing product items to Meta catalog for push menu: {str(e)}")
+            raise e
+
+    async def update_meta_catalog(self):
+        """
+        Sync the data to meta when event type is 'push_menu'
+        """
+        try:
+            req = quote(json.dumps(self.processed_data))
+            base_url = f"https://graph.facebook.com/v21.0/{self.catalog_id}/batch"
+            url = f"{base_url}?item_type=PRODUCT_ITEM&requests={req}"
+
+            data = {
+                "access_token": self.access_token,
+            }
+
+            response = await asyncio.to_thread(requests.post, url, headers={}, data=data)
+            response.raise_for_status()
+            print("Response JSON:", response.json())
+            print("Successfully synced product items to Meta catalog(Item Toggle)")
+        except Exception as e:
+            logger.exception(f"Error syncing product items to Meta catalog for item toggle: {str(e)}")
+            raise e
+
+
+    async def delete_meta_catalog(self, delete_payload: list):
+        """
+        Sync the data to meta when event type is 'push_menu'
+        """
+        try:
+            req = quote(json.dumps(delete_payload))
+            base_url = f"https://graph.facebook.com/v21.0/{self.catalog_id}/batch"
+            url = f"{base_url}?requests={req}"
+
+            data = {
+                "access_token": self.access_token,
+            }
+            response = await asyncio.to_thread(requests.post, url, headers={}, data=data)
+            response.raise_for_status()
+            print("Response JSON:", response.json())
+            print("Successfully deleted data from meta.")
+        except Exception as e:
+            logger.exception(f"Error deleting data from meta: {str(e)}")
+            raise e

--- a/kairon/shared/account/data_objects.py
+++ b/kairon/shared/account/data_objects.py
@@ -155,6 +155,7 @@ class MailTemplates(EmbeddedDocument):
     add_trusted_device = StringField()
     button_template = StringField()
     leave_bot_owner_notification = StringField()
+    catalog_sync_status = StringField()
 
 
 class SystemProperties(Document):

--- a/kairon/shared/account/processor.py
+++ b/kairon/shared/account/processor.py
@@ -959,6 +959,7 @@ class AccountProcessor:
                 ).read(),
                 button_template=open("template/emails/button.html", "r").read(),
                 leave_bot_owner_notification=open("template/emails/leaveBotOwnerNotification.html", "r").read(),
+                catalog_sync_status=open("template/emails/catalog_sync_status.html", "r").read(),
             )
             system_properties = (
                 SystemProperties(mail_templates=mail_templates)
@@ -1013,6 +1014,8 @@ class AccountProcessor:
         ]["button_template"]
         Utility.email_conf["email"]["templates"]["leave_bot_owner_notification"] = system_properties["mail_templates"][
             "leave_bot_owner_notification"]
+        Utility.email_conf["email"]["templates"]["catalog_sync_status"] = system_properties["mail_templates"][
+            "catalog_sync_status"]
 
     @staticmethod
     async def confirm_email(token: str):

--- a/kairon/shared/catalog_sync/catalog_sync_log_processor.py
+++ b/kairon/shared/catalog_sync/catalog_sync_log_processor.py
@@ -1,0 +1,315 @@
+from datetime import datetime
+
+from bson import ObjectId
+from loguru import logger
+from mongoengine import Q, DoesNotExist
+
+from kairon.shared.cognition.data_objects import CognitionSchema, CollectionData
+from kairon.shared.cognition.processor import CognitionDataProcessor
+from kairon.shared.data.constant import SYNC_STATUS, SyncType
+from kairon.shared.data.data_models import CognitionSchemaRequest
+from kairon.shared.data.data_objects import BotSettings, BotSyncConfig
+from kairon.shared.catalog_sync.data_objects import CatalogSyncLogs, CatalogProviderMapping
+from kairon.shared.models import CognitionMetadataType
+
+
+class CatalogSyncLogProcessor:
+    """
+    Log processor for content importer event.
+    """
+
+    @staticmethod
+    def add_log(bot: str, user: str, provider: str = None, sync_type: str = None, validation_errors: dict = None,
+                raw_payload: dict = None, processed_payload: dict = None, exception: str = None, status: str = None,
+                sync_status: str = SYNC_STATUS.INITIATED.value):
+        """
+        Adds or updates log for content importer event.
+        @param bot: bot id.
+        @param user: kairon username.
+        @param provider: provider (e.g. Petpooja, Shopify etc.)
+        @param sync_type: sync type
+        @param validation_errors: Dictionary containing any validation errors encountered
+        @param exception: Exception occurred during event.
+        @param status: Validation success or failure.
+        @param sync_status: Event success or failed due to any error during validation or import.
+        @return:
+        """
+        try:
+            doc = CatalogSyncLogs.objects(bot=bot).filter(
+                Q(sync_status__ne=SYNC_STATUS.COMPLETED.value) &
+                Q(sync_status__ne=SYNC_STATUS.FAILED.value)).get()
+        except DoesNotExist:
+            doc = CatalogSyncLogs(
+                bot=bot,
+                user=user,
+                execution_id=str(ObjectId()),
+                provider=provider,
+                raw_payload = raw_payload,
+                sync_type = sync_type,
+                start_timestamp=datetime.utcnow()
+            )
+        doc.sync_status = sync_status
+        if processed_payload:
+            doc.processed_payload = processed_payload
+        if exception:
+            doc.exception = exception
+        if status:
+            doc.status = status
+        if validation_errors:
+            doc.validation_errors = validation_errors
+        if sync_status in {SYNC_STATUS.FAILED.value, SYNC_STATUS.COMPLETED.value}:
+            doc.end_timestamp = datetime.utcnow()
+        doc.save()
+
+    @staticmethod
+    def is_sync_in_progress(bot: str, raise_exception=True):
+        """
+        Checks if event is in progress.
+        @param bot: bot id
+        @param raise_exception: Raise exception if event is in progress.
+        @return: boolean flag.
+        """
+        in_progress = False
+        try:
+            CatalogSyncLogs.objects(bot=bot).filter(
+                Q(sync_status__ne=SYNC_STATUS.COMPLETED.value) &
+                Q(sync_status__ne=SYNC_STATUS.FAILED.value) &
+                Q(sync_status__ne=SYNC_STATUS.ABORTED.value)).get()
+
+            if raise_exception:
+                raise Exception("Sync already in progress! Check logs.")
+            in_progress = True
+        except DoesNotExist as e:
+            logger.error(e)
+        return in_progress
+
+    @staticmethod
+    def is_limit_exceeded(bot: str, raise_exception=True):
+        """
+        Checks if daily event triggering limit exceeded.
+        @param bot: bot id.
+        @param raise_exception: Raise exception if limit is reached.
+        @return: boolean flag
+        """
+        today = datetime.today()
+
+        today_start = today.replace(hour=0, minute=0, second=0)
+        doc_count = CatalogSyncLogs.objects(
+            bot=bot, start_timestamp__gte=today_start
+        ).count()
+        if doc_count >= BotSettings.objects(bot=bot).get().catalog_sync_limit_per_day:
+            if raise_exception:
+                raise Exception("Daily limit exceeded.")
+            else:
+                return True
+        else:
+            return False
+
+    @staticmethod
+    def get_logs(bot: str, start_idx: int = 0, page_size: int = 10):
+        """
+        Get all logs for content importer event.
+        @param bot: bot id.
+        @param start_idx: start index
+        @param page_size: page size
+        @return: list of logs.
+        """
+        for log in CatalogSyncLogs.objects(bot=bot).order_by("-start_timestamp").skip(start_idx).limit(page_size):
+            log = log.to_mongo().to_dict()
+            log.pop('_id')
+            log.pop('bot')
+            log.pop('user')
+            yield log
+
+    @staticmethod
+    def delete_enqueued_event_log(bot: str):
+        """
+        Deletes latest log if it is present in enqueued state.
+        """
+        latest_log = CatalogSyncLogs.objects(bot=bot).order_by('-id').first()
+        if latest_log and latest_log.sync_status == SYNC_STATUS.ENQUEUED.value:
+            latest_log.delete()
+
+    @staticmethod
+    def is_catalog_collection_exists(bot: str) -> bool:
+        """
+        Checks if the 'catalogue_table' exists in CognitionSchema for the given bot.
+        """
+        restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(bot)
+        catalog_name = f"{restaurant_name}_{branch_name}_catalog"
+        return CognitionSchema.objects(bot=bot, collection_name=catalog_name).first() is not None
+
+    @staticmethod
+    def  create_catalog_collection(bot: str, user: str):
+        """
+        Creates a 'catalogue_table' collection in CognitionSchema for the given bot with predefined metadata fields.
+        """
+        # Define column names and their data types
+        cognition_processor = CognitionDataProcessor()
+        column_definitions = [
+            ("id", CognitionMetadataType.str.value),
+            ("title", CognitionMetadataType.str.value),
+            ("description", CognitionMetadataType.str.value),
+            ("price", CognitionMetadataType.float.value),
+            ("facebook_product_category", CognitionMetadataType.str.value),
+            ("availability", CognitionMetadataType.str.value),
+        ]
+
+        bot_settings = BotSettings.objects(bot=bot).first()
+        if bot_settings:
+            bot_settings.cognition_columns_per_collection_limit = 10
+            bot_settings.llm_settings['enable_faq'] = True
+            bot_settings.save()
+
+        metadata= [
+            {
+                "column_name": col,
+                "data_type": data_type,
+                "enable_search": True,
+                "create_embeddings": True
+            }
+            for col, data_type in column_definitions
+        ]
+        restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(bot)
+        catalog_name = f"{restaurant_name}_{branch_name}_catalog"
+        catalog_schema = CognitionSchemaRequest(
+            collection_name=catalog_name,
+            metadata=metadata
+        )
+
+        metadata_id = cognition_processor.save_cognition_schema(
+            catalog_schema.dict(),
+            user, bot)
+
+        return metadata_id
+
+    @staticmethod
+    def validate_item_ids(json_data):
+        """
+        Validates that all items have an 'itemid' and extracts a list of valid category IDs.
+        Raises an exception if any item is missing 'itemid'.
+        Returns a set of valid category IDs.
+        """
+        for item in json_data.get("items", []):
+            if "itemid" not in item:
+                raise Exception(f"Missing 'itemid' in item: {item}")
+
+    @staticmethod
+    def validate_item_toggle_request(json_data: dict) -> None:
+        """
+        Validates that `inStock` exists and is a boolean,
+        and `itemID` exists in the payload.
+        Raises:
+            ValueError: If any validation fails.
+        """
+        body = json_data.get("body", {})
+
+        if "inStock" not in body:
+            raise Exception("Missing required field: 'inStock'")
+        if not isinstance(body["inStock"], bool):
+            raise Exception("'inStock' must be a boolean (true or false)")
+
+        if "itemID" not in body:
+            raise Exception("Missing required field: 'itemID'")
+
+    @staticmethod
+    def validate_item_fields(bot, json_data, provider):
+        """
+        Validates that each item has the required source fields as defined in the metadata file.
+        Ensures 'item_categoryid' is within valid categories.
+        Only runs if event_type is 'push_menu'.
+        """
+        doc = CatalogProviderMapping.objects(provider=provider).first()
+        if not doc:
+            raise Exception(f"Metadata mappings not found and provider={provider}")
+
+        provider_mappings = {
+            "meta": doc.meta_mappings,
+            "kv": doc.kv_mappings
+        }
+
+        valid_category_ids = {cat["categoryid"] for cat in json_data.get("categories", [])}
+
+        required_fields = set()
+        for system_fields in provider_mappings.values():
+            for config in system_fields.values():
+                source_field = config.get("source")
+                if source_field:
+                    required_fields.add(source_field)
+
+        for item in json_data.get("items", []):
+            missing_fields = [field for field in required_fields if field not in item]
+            if missing_fields:
+                raise Exception(f"Missing fields {missing_fields} in item: {item}")
+
+            if "item_categoryid" in item and item["item_categoryid"] not in valid_category_ids:
+                raise Exception(f"Invalid 'item_categoryid' {item['item_categoryid']} in item: {item}")
+
+    @staticmethod
+    def is_sync_type_allowed(bot: str, sync_type: str):
+        config = BotSyncConfig.objects(branch_bot=bot).first()
+        if not config:
+            raise Exception("No bot sync config found for bot")
+
+        if sync_type == SyncType.push_menu and not config.process_push_menu:
+            raise Exception("Push menu processing is disabled for this bot")
+
+        if sync_type == SyncType.item_toggle and not config.process_item_toggle:
+            raise Exception("Item toggle is disabled for this bot")
+
+
+    @staticmethod
+    def is_ai_enabled(bot: str):
+        config = BotSyncConfig.objects(branch_bot=bot).first()
+        if not config:
+            raise Exception("No bot sync config found for bot")
+        return config.ai_enabled
+
+    @staticmethod
+    def is_meta_enabled(bot: str):
+        config = BotSyncConfig.objects(branch_bot=bot).first()
+        if not config:
+            raise Exception("No bot sync config found for bot")
+        return config.meta_enabled
+
+    @staticmethod
+    def validate_image_configurations(bot: str, user: str):
+        restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(bot)
+        catalog_images_collection = f"{restaurant_name}_{branch_name}_catalog_images"
+
+        if not CollectionData.objects(bot=bot, collection_name=catalog_images_collection).first():
+            global_fallback_data = {
+                "image_type": "global",
+                "image_url":"",
+                "image_base64":""
+            }
+            CollectionData(
+                collection_name=catalog_images_collection,
+                data=global_fallback_data,
+                user=user,
+                bot=bot,
+                status=True,
+                timestamp=datetime.utcnow()
+            ).save()
+
+        document = CollectionData.objects(
+            collection_name=catalog_images_collection,
+            bot=bot,
+            data__image_type="global"
+        ).first()
+
+        if not document:
+            raise Exception(
+                f"Global fallback image document not found in `{catalog_images_collection}`")
+
+        if not document.data.get("image_url"):
+            raise Exception("Global fallback image URL not found")
+
+    @staticmethod
+    def get_execution_id_for_bot(bot: str):
+        doc = CatalogSyncLogs.objects(bot=bot).filter(
+            Q(sync_status__ne=SYNC_STATUS.COMPLETED.value) &
+            Q(sync_status__ne=SYNC_STATUS.FAILED.value)
+        ).order_by('-start_timestamp').first()
+
+        return doc.execution_id if doc else None

--- a/kairon/shared/catalog_sync/data_objects.py
+++ b/kairon/shared/catalog_sync/data_objects.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+from mongoengine import StringField, DateTimeField, DynamicDocument, DictField
+from kairon.shared.data.signals import push_notification, auditlogger
+
+
+@auditlogger.log
+@push_notification.apply
+class CatalogSyncLogs(DynamicDocument):
+    execution_id = StringField(required=True, unique=True)
+    raw_payload = DictField(required=True)
+    processed_payload = DictField(default=None)
+    validation_errors = DictField(default={})
+    exception = StringField(default="")
+    bot = StringField(required=True)
+    user = StringField(required=True)
+    provider = StringField(required=True)
+    sync_type = StringField(required=True)
+    start_timestamp = DateTimeField(default=datetime.utcnow)
+    end_timestamp = DateTimeField(default=None)
+    status = StringField(default=None)
+    sync_status = StringField(default="COMPLETED")
+
+    meta = {"indexes": [{"fields": ["bot", "event_id", ("bot", "event_status", "-start_timestamp")]}]}
+
+
+@auditlogger.log
+@push_notification.apply
+class CatalogProviderMapping(DynamicDocument):
+    """
+    Stores field mappings (meta and kv) for each bot and provider combination.
+    """
+    provider = StringField(required=True)
+    meta_mappings = DictField(default=dict)
+    kv_mappings = DictField(default=dict)

--- a/kairon/shared/cognition/processor.py
+++ b/kairon/shared/cognition/processor.py
@@ -1,17 +1,26 @@
+import json
 from datetime import datetime
+from pathlib import Path
 from typing import Text, Dict, Any, List
 import json
 from loguru import logger
 from mongoengine import DoesNotExist, Q
 from pydantic import constr, create_model, ValidationError
+from pymongo import UpdateOne
 
 from kairon import Utility
 from kairon.exceptions import AppException
 from kairon.shared.actions.data_objects import PromptAction, DatabaseAction
+from kairon.shared.catalog_sync.data_objects import CatalogProviderMapping
 from kairon.shared.cognition.data_objects import CognitionData, CognitionSchema, ColumnMetadata, CollectionData
-from kairon.shared.data.constant import DEFAULT_LLM
+from kairon.shared.data.constant import DEFAULT_LLM, SyncType
+from kairon.shared.data.data_objects import BotSyncConfig, POSIntegrations
 from kairon.shared.data.processor import MongoProcessor
-from kairon.shared.models import CognitionDataType, CognitionMetadataType, VaultSyncEventType
+from kairon.shared.constants import  CatalogSyncClass
+from kairon.shared.data.utils import DataUtility
+from kairon.shared.models import CognitionDataType, CognitionMetadataType, VaultSyncType
+from tqdm import tqdm
+import uuid
 
 
 class CognitionDataProcessor:
@@ -323,22 +332,22 @@ class CognitionDataProcessor:
         else:
             raise ValueError(f"Unsupported data type: {data_type}")
 
-    def validate_data(self, primary_key_col: str, collection_name: str, event_type: str, data: List[Dict], bot: str) -> Dict:
+    def validate_data(self, primary_key_col: str, collection_name: str, sync_type: str, data: List[Dict], bot: str) -> Dict:
         """
         Validates each dictionary in the data list according to the expected schema from column_dict.
 
         Args:
             data: List of dictionaries where each dictionary represents a row to be validated.
             collection_name: The name of the collection (table name).
-            event_type: The type of the event being validated.
+            sync_type: The type of the event being validated.
             bot: The bot identifier.
             primary_key_col: The primary key column for identifying rows.
 
         Returns:
             Dict: Summary of validation errors, if any.
         """
-        self._validate_event_type(event_type)
-        event_validations = VaultSyncEventType[event_type].value
+        self._validate_sync_type(sync_type)
+        event_validations = VaultSyncType[sync_type].value
 
         self._validate_collection_exists(collection_name)
         column_dict = MongoProcessor().get_column_datatype_dict(bot, collection_name)
@@ -366,10 +375,9 @@ class CognitionDataProcessor:
                         "expected_columns": list(column_dict.keys()),
                         "actual_columns": list(row.keys())
                     })
-
             if "invalid_columns" in event_validations:
                 expected_columns = list(column_dict.keys())
-                if event_type == "field_update":
+                if sync_type == VaultSyncType.item_toggle.name:
                     expected_columns = [primary_key_col + " + any from " + str([col for col in column_dict.keys() if col != primary_key_col])]
                 if not set(row.keys()).issubset(set(column_dict.keys())):
                     row_errors.append({
@@ -415,19 +423,150 @@ class CognitionDataProcessor:
 
         return error_summary
 
-    async def upsert_data(self, primary_key_col: str, collection_name: str, event_type: str, data: List[Dict], bot: str, user: Text):
+    def _validate_sync_type(self, sync_type: str):
+        if sync_type not in VaultSyncType.__members__.keys():
+            raise AppException("Sync type does not exist")
+
+    def _validate_collection_exists(self, collection_name: str):
+        if not CognitionSchema.objects(collection_name=collection_name).first():
+            raise AppException(f"Collection '{collection_name}' does not exist.")
+
+    def save_pos_integration_config(self, configuration: Dict, bot: Text, user: Text, sync_type: Text = None):
         """
-        Upserts data into the CognitionData collection.
-        If document with the primary key exists, it will be updated.
-        If not, it will be inserted.
+        save or updates data integration configuration
+        :param configuration: config dict
+        :param bot: bot id
+        :param user: user id
+        :param sync_type: event type
+        :return: None
+        """
+        self._validate_sync_type(sync_type)
+        try:
+            integration = POSIntegrations.objects(bot=bot, provider=configuration['provider'],
+                                                  sync_type=sync_type).get()
+            integration.config = configuration['config']
+            integration.meta_config = configuration['meta_config']
+        except DoesNotExist:
+            integration = POSIntegrations(**configuration)
+        integration.bot = bot
+        integration.user = user
+        integration.sync_type = sync_type
+        integration.timestamp = datetime.utcnow()
+
+        if 'meta_config' in configuration:
+            integration.meta_config = configuration['meta_config']
+
+        integration.save()
+        integration_endpoint = DataUtility.get_integration_endpoint(integration)
+        return integration_endpoint
+
+    @staticmethod
+    def preprocess_push_menu_data(bot, json_data, provider):
+        """
+        Preprocess the JSON data received from Petpooja to extract relevant fields for knowledge base or meta synchronization.
+        Handles different event types ("push_menu" vs others) and uses metadata to drive the field extraction and defaulting.
+        """
+        doc = CatalogProviderMapping.objects(provider=provider).first()
+        if not doc:
+            raise Exception(f"Metadata mappings not found for provider={provider}")
+
+        category_map = {
+            cat["categoryid"]: cat["categoryname"]
+            for cat in json_data.get("categories", [])
+        }
+
+        provider_mappings = {
+            "meta": doc.meta_mappings,
+            "kv": doc.kv_mappings
+        }
+
+        data = {sync_target: [] for sync_target in provider_mappings}
+        for item in json_data.get("items", []):
+            for sync_target, fields in provider_mappings.items():
+                transformed_item = {"id": item["itemid"]}
+
+                for target_field, field_config in fields.items():
+                    source_key = field_config.get("source")
+                    default_value = field_config.get("default")
+                    value = item.get(source_key) if source_key else None
+
+                    if target_field == "availability":
+                        value = "in stock" if int(value or 0) > 0 else default_value
+                    elif target_field == "facebook_product_category":
+                        category_id = value or ""
+                        value = f"Food and drink > {category_map.get(category_id, 'General')}"
+                    elif target_field == "image_url":
+                        value = CognitionDataProcessor.resolve_image_link(bot, item["itemid"])
+                    elif target_field == "price":
+                        value = float(value)
+                    if not value:
+                        value = default_value
+
+                    transformed_item[target_field] = value
+
+                data[sync_target].append(transformed_item)
+
+        return data
+
+    @staticmethod
+    def preprocess_item_toggle_data(bot, json_data, provider):
+        doc = CatalogProviderMapping.objects(provider=provider).first()
+        if not doc:
+            raise Exception(f"Metadata mappings not found for provider={provider}")
+
+        provider_mappings = {
+            "meta": doc.meta_mappings,
+            "kv": doc.kv_mappings
+        }
+
+        in_stock = json_data["body"]["inStock"]
+        item_ids = json_data["body"]["itemID"]
+        availability = "in stock" if in_stock else "out of stock"
+        processed_data = [{"id": item_id, "availability": availability} for item_id in item_ids]
+
+        data = {sync_target: processed_data for sync_target in provider_mappings}
+
+        return data
+
+    @staticmethod
+    def resolve_image_link(bot: str, item_id: str):
+        restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(bot)
+        catalog_images_collection = f"{restaurant_name}_{branch_name}_catalog_images"
+
+        document = CollectionData.objects(
+            collection_name=catalog_images_collection,
+            data__item_id=int(item_id),
+            data__image_type="local"
+        ).first()
+
+        if not document:
+            document = CollectionData.objects(
+                collection_name=catalog_images_collection,
+                bot=bot,
+                data__image_type="global"
+            ).first()
+
+        if document:
+            data = document.data or {}
+            image_link = data.get("image_url")
+
+            if image_link:
+                return image_link
+        else:
+            raise Exception(f"Image URL not found for {item_id} in {catalog_images_collection}")
+
+    async def upsert_data(self, primary_key_col: str, collection_name: str, sync_type: str, data: List[Dict], bot: str,
+                          user: Text):
+        """
+        Upserts data into the CognitionData collection in batches and syncs embeddings with Qdrant.
 
         Args:
             primary_key_col: The primary key column name to check for uniqueness.
             collection_name: The collection name (table).
-            event_type: The type of the event being upserted
+            sync_type: The type of the event being upserted.
             data: List of rows of data to upsert.
             bot: The bot identifier associated with the data.
-            user: The user
+            user: The user.
         """
 
         from kairon.shared.llm.processor import LLMProcessor
@@ -435,7 +574,7 @@ class CognitionDataProcessor:
         suffix = "_faq_embd"
         qdrant_collection = f"{bot}_{collection_name}{suffix}" if collection_name else f"{bot}{suffix}"
 
-        if await llm_processor.__collection_exists__(qdrant_collection) is False:
+        if not await llm_processor.__collection_exists__(qdrant_collection):
             await llm_processor.__create_collection__(qdrant_collection)
 
         existing_documents = CognitionData.objects(bot=bot, collection=collection_name).as_pymongo()
@@ -444,73 +583,215 @@ class CognitionDataProcessor:
             doc["data"].get(primary_key_col): doc for doc in existing_documents
         }
 
-        for row in data:
-            primary_key_value = row.get(primary_key_col)
+        processed_keys = set()
 
-            existing_document = existing_document_map.get(primary_key_value)
+        update_operations = []
+        insert_operations = []
 
-            if event_type == "field_update" and existing_document:
-                existing_data = existing_document.get("data", {})
-                merged_data = {**existing_data, **row}
-                logger.debug(f"Merged row for {primary_key_col} {primary_key_value}: {merged_data}")
-            else:
+        embedding_payloads = []
+        search_payloads = []
+        vector_ids = []
+
+        batch_size = 50
+        for i in tqdm(range(0, len(data), batch_size), desc="Syncing Knowledge Vault"):
+            batch_contents = data[i:i + batch_size]
+
+            for row in batch_contents:
+                primary_key_value = row.get(primary_key_col)
+                existing_document = existing_document_map.get(primary_key_value)
+
+                vector_id = str(uuid.uuid4()) if not existing_document else existing_document.get("vector_id")
+
                 merged_data = row
+                if existing_document:
+                    existing_data = existing_document.get("data", {})
+                    merged_data = {**existing_data, **row}
+                    update_operations.append(UpdateOne(
+                        {"_id": existing_document["_id"]},
+                        {"$set": {"data": merged_data, "timestamp": datetime.utcnow()}}
+                    ))
+                else:
+                    new_doc = CognitionData(
+                        data=merged_data,
+                        vector_id=vector_id,
+                        content_type=CognitionDataType.json.value,
+                        collection=collection_name,
+                        bot=bot,
+                        user=user
+                    )
+                    insert_operations.append(new_doc)
 
-            payload = {
-                "data": merged_data,
-                "content_type": CognitionDataType.json.value,
-                "collection": collection_name
-            }
+                processed_keys.add(primary_key_value)
 
-            if existing_document:
-                row_id = str(existing_document["_id"])
-                self.update_cognition_data(row_id, payload, user, bot)
-                updated_document = CognitionData.objects(id=row_id).first()
-                if not isinstance(updated_document, dict):
-                    updated_document = updated_document.to_mongo().to_dict()
-                logger.info(f"Row with {primary_key_col}: {primary_key_value} updated in MongoDB")
-                await self.sync_with_qdrant(llm_processor, qdrant_collection, bot, updated_document, user,
-                                            primary_key_col)
+                metadata = self.find_matching_metadata(bot, merged_data, collection_name)
+                search_payload, embedding_payload = Utility.retrieve_search_payload_and_embedding_payload(merged_data,
+                                                                                                          metadata)
+
+                embedding_payloads.append(embedding_payload)
+                search_payloads.append(search_payload)
+                vector_ids.append(vector_id)
+
+            if update_operations:
+                CognitionData._get_collection().bulk_write(update_operations)
+                logger.info(f"Updated {len(update_operations)} documents in MongoDB")
+
+            if insert_operations:
+                CognitionData.objects.insert(insert_operations, load_bulk=False)
+                logger.info(f"Inserted {len(insert_operations)} new documents in MongoDB")
+
+            update_operations.clear()
+            insert_operations.clear()
+            if embedding_payloads:
+                embeddings = await llm_processor.get_embedding(embedding_payloads, user,
+                                                               invocation="knowledge_vault_sync")
+                points = [{'id': vector_ids[idx], 'vector': embeddings[idx], 'payload': search_payloads[idx]}
+                          for idx in range(len(vector_ids))]
+                await llm_processor.__collection_upsert__(qdrant_collection, {'points': points},
+                                                          err_msg="Unable to upsert data in qdrant! Contact support")
+                logger.info(f"Upserted {len(points)} points in Qdrant.")
+
+            embedding_payloads.clear()
+            search_payloads.clear()
+            vector_ids.clear()
+
+        remaining_primary_keys = []
+        if sync_type == VaultSyncType.push_menu.name:
+            stale_docs = [doc for key, doc in existing_document_map.items() if key not in processed_keys]
+
+            if stale_docs:
+                doc_ids = []
+                vector_ids = []
+                remaining_primary_keys = []
+
+                for doc in stale_docs:
+                    doc_ids.append(doc["_id"])
+                    vector_ids.append(doc["vector_id"])
+                    remaining_primary_keys.append(doc["data"].get(primary_key_col))
+
+                CognitionData.objects(id__in=doc_ids).delete()
+                logger.info(f"Deleted {len(stale_docs)} stale documents from MongoDB.")
+
+                await llm_processor.__delete_collection_points__(qdrant_collection, vector_ids,
+                                                                 "Cannot delete stale points fro Qdrant!")
+                logger.info(f"Deleted {len(stale_docs)} stale points from Qdrant.")
+
+        return {"message": "Upsert complete!", "stale_ids": remaining_primary_keys}
+
+    @staticmethod
+    def save_ai_data(processed_data: dict, bot: str, user: str, sync_type: str):
+        """
+        Save each item in `kv` of the processed payload into CollectionData individually.
+        """
+        restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(bot)
+        catalog_data_collection = f"{restaurant_name}_{branch_name}_catalog_data"
+
+        kv_items = processed_data.get("kv", [])
+        incoming_data_map = {item["id"]: item for item in kv_items}
+        incoming_ids = set(incoming_data_map.keys())
+
+        existing_docs = CollectionData.objects(
+            collection_name=catalog_data_collection,
+            bot=bot,
+            status=True
+        )
+        existing_data_map = {doc.data.get("id"): doc for doc in existing_docs}
+        existing_ids = set(existing_data_map.keys())
+
+        for item_id, item in incoming_data_map.items():
+            if item_id in existing_data_map:
+                doc = existing_data_map[item_id]
+                if sync_type == SyncType.item_toggle:
+                    for key, value in item.items():
+                        doc.data[key] = value
+                else:
+                    doc.data = item
+                doc.timestamp = datetime.utcnow()
+                doc.user = user
+                doc.save()
             else:
-                row_id = self.save_cognition_data(payload, user, bot)
-                new_document = CognitionData.objects(id=row_id).first()
-                if not isinstance(new_document, dict):
-                    new_document = new_document.to_mongo().to_dict()
-                logger.info(f"Row with {primary_key_col}: {primary_key_value} inserted in MongoDB")
-                await self.sync_with_qdrant(llm_processor, qdrant_collection, bot, new_document, user, primary_key_col)
+                CollectionData(
+                    collection_name=catalog_data_collection,
+                    data=item,
+                    user=user,
+                    bot=bot,
+                    timestamp=datetime.utcnow(),
+                    status=True
+                ).save()
+        stale_ids = []
+        if sync_type == SyncType.push_menu:
+            stale_ids = list(existing_ids - incoming_ids)
+            if stale_ids:
+                CollectionData.objects(
+                    collection_name=catalog_data_collection,
+                    bot=bot,
+                    status=True,
+                    data__id__in=stale_ids
+                ).delete()
 
-        return {"message": "Upsert complete!"}
+        return stale_ids
 
-    async def sync_with_qdrant(self, llm_processor, collection_name, bot, document, user, primary_key_col):
+    @staticmethod
+    def load_catalog_provider_mappings():
         """
-        Syncs a document with Qdrant vector database by generating embeddings and upserting them.
+        Load and store catalog provider mappings from a JSON file.
 
-        Args:
-            llm_processor (LLMProcessor): Instance of LLMProcessor for embedding and Qdrant operations.
-            collection_name (str): Name of the Qdrant collection.
-            bot (str): Bot identifier.
-            document (CognitionData): Document to sync with Qdrant.
-            user (Text): User performing the operation.
-
-        Raises:
-            AppException: If Qdrant upsert operation fails.
+        :param file_path: Path to the mappings JSON file.
+        :raises AppException: If file does not exist or mapping format is invalid.
         """
-        try:
-            metadata = self.find_matching_metadata(bot, document['data'], document.get('collection'))
-            search_payload, embedding_payload = Utility.retrieve_search_payload_and_embedding_payload(
-                document['data'], metadata)
-            embeddings = await llm_processor.get_embedding(embedding_payload, user, invocation='knowledge_vault_sync')
-            points = [{'id': document['vector_id'], 'vector': embeddings, 'payload': search_payload}]
-            await llm_processor.__collection_upsert__(collection_name, {'points': points},
-                                                      err_msg="Unable to train FAQ! Contact support")
-            logger.info(f"Row with {primary_key_col}: {document['data'].get(primary_key_col)} upserted in Qdrant.")
-        except Exception as e:
-            raise AppException(f"Failed to sync document with Qdrant: {str(e)}")
+        file_path = "./metadata/catalog_provider_mappings.json"
+        path = Path(file_path)
 
-    def _validate_event_type(self, event_type: str):
-        if event_type not in VaultSyncEventType.__members__.keys():
-            raise AppException("Event type does not exist")
+        if not path.exists():
+            raise AppException(f"Mappings file not found at {file_path}")
 
-    def _validate_collection_exists(self, collection_name: str):
-        if not CognitionSchema.objects(collection_name=collection_name).first():
-            raise AppException(f"Collection '{collection_name}' does not exist.")
+        with open(path, "r") as f:
+            mapping_data = json.load(f)
+
+        for provider, mappings in mapping_data.items():
+            meta = mappings.get("meta")
+            kv = mappings.get("kv")
+
+            if not meta or not kv:
+                raise AppException(f"Mappings for provider '{provider}' is missing required 'meta' or 'kv' fields.")
+
+            try:
+                metadata_doc = CatalogProviderMapping.objects.get(provider=provider)
+                metadata_doc.update(
+                    set__meta_mappings=meta,
+                    set__kv_mappings=kv
+                )
+            except DoesNotExist:
+                CatalogProviderMapping(
+                    provider=provider,
+                    meta_mappings=meta,
+                    kv_mappings=kv
+                ).save()
+
+    @staticmethod
+    def add_bot_sync_config(request_data, bot: Text, user: Text):
+        if request_data.provider.lower() == CatalogSyncClass.petpooja:
+            if BotSyncConfig.objects(branch_bot=bot, provider=CatalogSyncClass.petpooja).first():
+                return
+
+            bot_sync_config = BotSyncConfig(
+                process_push_menu=False,
+                process_item_toggle=False,
+                parent_bot=bot,
+                restaurant_name=request_data.config.get("restaurant_name"),
+                provider=CatalogSyncClass.petpooja,
+                branch_name=request_data.config.get("branch_name"),
+                branch_bot=bot,
+                ai_enabled=False,
+                meta_enabled=False,
+                user=user
+            )
+            bot_sync_config.save()
+
+    @staticmethod
+    def get_restaurant_and_branch_name(bot: Text):
+        config = BotSyncConfig.objects(branch_bot=bot).first()
+        if not config:
+            raise Exception(f"No bot sync config found for bot: {bot}")
+        restaurant_name = config.restaurant_name.replace(" ", "_")
+        branch_name = config.branch_name.replace(" ", "_")
+        return restaurant_name.lower(), branch_name.lower()

--- a/kairon/shared/constants.py
+++ b/kairon/shared/constants.py
@@ -83,7 +83,10 @@ class EventClass(str, Enum):
     content_importer = "content_importer"
     mail_channel_read_mails = "email_channel_read_mails"
     agentic_flow = "agentic_flow"
+    catalog_integration = "catalog_integration"
 
+class CatalogSyncClass(str, Enum):
+    petpooja = "petpooja"
 
 class EventRequestType(str, Enum):
     trigger_async = "trigger_async"
@@ -119,6 +122,9 @@ class ChannelTypes(str, Enum):
     BUSINESS_MESSAGES = "business_messages"
     LINE = "line"
     MAIL = "mail"
+
+class CatalogProvider(str, Enum):
+    PETPOOJA = "petpooja"
 
 class ElementTypes(str, Enum):
     LINK = "link"

--- a/kairon/shared/data/constant.py
+++ b/kairon/shared/data/constant.py
@@ -110,6 +110,22 @@ class EVENT_STATUS(str, Enum):
     FAIL = "Fail"
     ABORTED = "Aborted"
 
+class SYNC_STATUS(str, Enum):
+    INITIATED = "Initiated"
+    VALIDATING_REQUEST = "Validating request"
+    VALIDATING_REQUEST_SUCCESS = "Validating request successful"
+    VALIDATING_FAILED = "Validation Failed"
+    VALIDATING_KNOWLEDGE_VAULT_DATA = "Validating Knowledge vault processed data"
+    PREPROCESSING = "Preprocessing in progress"
+    PREPROCESSING_FAILED = "Preprocessing Failed"
+    PREPROCESSING_COMPLETED = "Preprocessing Completed"
+    SAVE = "Importing data to kairon"
+    SAVE_META = "Importing data to Meta"
+    SYNC_FAILED = "Sync Failed"
+    ENQUEUED = "Enqueued"
+    COMPLETED = "Completed"
+    FAILED = "Failed"
+    ABORTED = "Aborted"
 
 class ONBOARDING_STATUS(str, Enum):
     NOT_COMPLETED = "Not Completed"
@@ -185,6 +201,7 @@ class TOKEN_TYPE(str, Enum):
     DYNAMIC = "dynamic"
     CHANNEL = "channel"
     REFRESH = "refresh"
+    DATA_INTEGRATION = "data_integration"
 
 
 class ModelTestType(str, Enum):
@@ -261,6 +278,9 @@ class FeatureMappings(str, Enum):
     ONLY_SSO_LOGIN = "only_sso_login"
     CREATE_USER = "create_user"
 
+class SyncType(str, Enum):
+    push_menu = "push_menu"
+    item_toggle = "item_toggle"
 
 ORG_SETTINGS_MESSAGES = {
     "create_user": "User creation is blocked by your OrgAdmin from SSO",

--- a/kairon/shared/data/data_models.py
+++ b/kairon/shared/data/data_models.py
@@ -1404,6 +1404,15 @@ class FlowTagChangeRequest(BaseModel):
     tag: str
     type: str
 
+class MetaConfig(BaseModel):
+    access_token: str
+    catalog_id: str
+
+class POSIntegrationRequest(BaseModel):
+    provider: str
+    config: dict
+    meta_config: Optional[MetaConfig]
+
 
 class ParallelActionRequest(BaseModel):
     """

--- a/kairon/shared/data/data_objects.py
+++ b/kairon/shared/data/data_objects.py
@@ -931,6 +931,7 @@ class BotSettings(Auditlog):
     integrations_per_user_limit = IntField(default=3)
     live_agent_enabled = BooleanField(default=False)
     max_actions_per_parallel_action = IntField(default=5)
+    catalog_sync_limit_per_day = IntField(default=5)
 
     meta = {"indexes": [{"fields": ["bot", ("bot", "status")]}]}
 
@@ -1089,3 +1090,33 @@ class UserMediaData(Auditlog):
 
 
     meta = {"indexes": [{"fields": ["bot", ("bot", "sender_id"), "media_id"]}]}
+
+
+@auditlogger.log
+@push_notification.apply
+class POSIntegrations(Auditlog):
+    bot = StringField(required=True)
+    provider = StringField(required=True)
+    config = DictField(required=True)
+    sync_type = StringField(required=True, default=None)
+    user = StringField(required=True)
+    timestamp = DateTimeField(default=datetime.utcnow)
+    meta_config = DictField()
+
+    meta = {"indexes": [{"fields": ["bot", "provider"]}]}
+
+
+@auditlogger.log
+@push_notification.apply
+class BotSyncConfig(Auditlog):
+    process_push_menu = BooleanField(default=False)
+    process_item_toggle = BooleanField(default=False)
+    parent_bot = StringField(required=True)
+    restaurant_name = StringField(required=True)
+    provider = StringField(required=True)
+    branch_name = StringField(required=True)
+    branch_bot = StringField(required=True)
+    ai_enabled = BooleanField(default=False)
+    meta_enabled = BooleanField(default=False)
+    user = StringField(required=True)
+    timestamp = DateTimeField(default=datetime.utcnow)

--- a/kairon/shared/data/utils.py
+++ b/kairon/shared/data/utils.py
@@ -398,6 +398,23 @@ class DataUtility:
         return channel_endpoint
 
     @staticmethod
+    def get_integration_endpoint(integration_config: dict):
+        from kairon.shared.auth import Authentication
+
+        token, _ = Authentication.generate_integration_token(
+            integration_config['bot'], integration_config['user'], role=ACCESS_ROLES.DESIGNER.value,
+            access_limit=[
+                f"/api/bot/integration/{integration_config['provider']}/{integration_config['sync_type']}/{integration_config['bot']}/.+"],
+            token_type=TOKEN_TYPE.DATA_INTEGRATION.value
+        )
+
+        integration_endpoint = urljoin(
+            Utility.environment['model']['agent']['url'],
+            f"/api/bot/integration/{integration_config['provider']}/{integration_config['sync_type']}/{integration_config['bot']}/{token}"
+        )
+        return integration_endpoint
+
+    @staticmethod
     def save_channel_metadata(**kwargs):
         token = kwargs["token"]
         channel_config = kwargs.get("config")

--- a/kairon/shared/llm/processor.py
+++ b/kairon/shared/llm/processor.py
@@ -344,8 +344,6 @@ class LLMProcessor(LLMBase):
                                         request_body={"points": point_ids},
                                         return_json=True,
                                         timeout=5)
-        print(response)
-
         if not response.get('result'):
             if "status" in response:
                 logging.exception(response['status'].get('error'))

--- a/kairon/shared/llm/processor.py
+++ b/kairon/shared/llm/processor.py
@@ -335,6 +335,24 @@ class LLMProcessor(LLMBase):
             timeout=5)
         return response
 
+    async def __delete_collection_points__(self, collection_name: Text, point_ids: List, err_msg: Text,
+                                           raise_err=True):
+        client = AioRestClient()
+        response = await client.request(http_url=urljoin(self.db_url, f"/collections/{collection_name}/points/delete"),
+                                        request_method="POST",
+                                        headers=self.headers,
+                                        request_body={"points": point_ids},
+                                        return_json=True,
+                                        timeout=5)
+        print(response)
+
+        if not response.get('result'):
+            if "status" in response:
+                logging.exception(response['status'].get('error'))
+                if raise_err:
+                    raise AppException(err_msg)
+
+
     async def __collection_hybrid_query__(self, collection_name: Text, embeddings: Dict, limit: int, score_threshold: float):
         client = AioRestClient()
         request_body = {

--- a/kairon/shared/models.py
+++ b/kairon/shared/models.py
@@ -118,9 +118,9 @@ class CognitionMetadataType(str, Enum):
     int = "int"
     float = "float"
 
-class VaultSyncEventType(str, Enum):
+class VaultSyncType(str, Enum):
     push_menu = ["column_length_mismatch", "invalid_columns", "pydantic_validation"]
-    field_update = ["invalid_columns", "document_non_existence", "pydantic_validation"]
+    item_toggle = ["invalid_columns", "document_non_existence", "pydantic_validation"]
 
 class GlobalSlotsEntryType(str, Enum):
     agentic_flow = "agentic_flow"

--- a/kairon/shared/utils.py
+++ b/kairon/shared/utils.py
@@ -2526,6 +2526,7 @@ class MailUtility:
             "add_trusted_device": MailUtility.__handle_add_trusted_device,
             "book_a_demo": MailUtility.__handle_book_a_demo,
             "member_left_bot": MailUtility.__handle_member_left_bot,
+            "catalog_sync_status": MailUtility.__handle_catalog_sync_status
         }
         base_url = kwargs.get("base_url")
         if not base_url:
@@ -2660,6 +2661,22 @@ class MailUtility:
         body = Utility.email_conf["email"]["templates"]["verification_confirmation"]
         body = body.replace("FIRST_NAME", first_name.capitalize())
         subject = Utility.email_conf["email"]["templates"]["confirmed_subject"]
+        return body, subject
+
+    @staticmethod
+    def __handle_catalog_sync_status(**kwargs):
+        bot = kwargs.get("bot")
+        executionID = kwargs.get("executionID")
+        sync_status = kwargs.get("sync_status")
+        message = kwargs.get("message")
+
+        body = Utility.email_conf["email"]["templates"]["catalog_sync_status"]
+
+        body = body.replace("BOT_ID", bot)
+        body = body.replace("EXECUTION_ID", executionID)
+        body = body.replace("SYNC_STATUS", sync_status)
+        body = body.replace("MESSAGE", message)
+        subject = Utility.email_conf["email"]["templates"]["catalog_sync_status_subject"]
         return body, subject
 
     @staticmethod

--- a/metadata/catalog_provider_mappings.json
+++ b/metadata/catalog_provider_mappings.json
@@ -1,0 +1,60 @@
+{
+  "petpooja": {
+    "meta": {
+      "name": {
+        "source": "itemname",
+        "default": "No title"
+      },
+      "description": {
+        "source": "itemdescription",
+        "default": "No description available"
+      },
+      "price": {
+        "source": "price",
+        "default": 0.0
+      },
+      "availability": {
+        "source": "in_stock",
+        "default": "out of stock"
+      },
+      "image_url": {
+        "source": "item_image_url",
+        "default": "https://www.kairon.com/default-image.jpg"
+      },
+      "url": {
+        "source": null,
+        "default": "https://www.kairon.com/"
+      },
+      "brand": {
+        "source": null,
+        "default": "Test Restaurant"
+      },
+      "condition": {
+        "source": null,
+        "default": "new"
+      }
+    },
+    "kv": {
+      "title": {
+        "source": "itemname",
+        "default": "No title"
+      },
+      "description": {
+        "source": "itemdescription",
+        "default": "No description available"
+      },
+      "price": {
+        "source": "price",
+        "default": 0.0
+      },
+      "facebook_product_category": {
+        "source": "item_categoryid",
+        "default": "Food and drink > General"
+      },
+      "availability": {
+        "source": "in_stock",
+        "default": "out of stock"
+      }
+    }
+  }
+}

--- a/template/emails/catalog_sync_status.html
+++ b/template/emails/catalog_sync_status.html
@@ -1,0 +1,278 @@
+<!-- REQUIRED PARAMS: Bot ID, Execution ID, Sync Status, Message -->
+<!-- Sub: Catalog Sync Status Update -->
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title></title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <style type="text/css">
+        @media screen {
+            @font-face {
+                font-family: 'Inter';
+                font-style: normal;
+                font-weight: 400;
+                font-display: swap;
+                src: url(https://fonts.gstatic.com/s/inter/v3/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa1ZL7.woff2) format('woff2');
+                unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+                    U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+            }
+
+            @font-face {
+                font-family: 'Inter';
+                font-style: normal;
+                font-weight: 700;
+                font-display: swap;
+                src: url(https://fonts.gstatic.com/s/inter/v3/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa1ZL7.woff2) format('woff2');
+                unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+                    U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+            }
+        }
+
+        /* CLIENT-SPECIFIC STYLES */
+        body,
+        table,
+        td,
+        a {
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+        }
+
+        table,
+        td {
+            mso-table-lspace: 0pt;
+            mso-table-rspace: 0pt;
+        }
+
+        img {
+            -ms-interpolation-mode: bicubic;
+        }
+
+        /* RESET STYLES */
+        img {
+            border: 0;
+            height: auto;
+            line-height: 100%;
+            outline: none;
+            text-decoration: none;
+        }
+
+        table {
+            border-collapse: collapse !important;
+        }
+
+        body {
+            height: 100% !important;
+            margin: 0 !important;
+            padding: 0 !important;
+            width: 100% !important;
+        }
+
+        /* iOS BLUE LINKS */
+        a[x-apple-data-detectors] {
+            color: inherit !important;
+            text-decoration: none !important;
+            font-size: inherit !important;
+            font-family: inherit !important;
+            font-weight: inherit !important;
+            line-height: inherit !important;
+        }
+
+        /* MOBILE STYLES */
+        @media screen and (max-width: 600px) {
+            h1 {
+                font-size: 18px !important;
+                line-height: 18px !important;
+            }
+
+            #mailheadimage {
+                width: 100%;
+            }
+        }
+
+        /* ANDROID CENTER FIX */
+        div[style*='margin: 16px 0;'] {
+            margin: 0 !important;
+        }
+    </style>
+</head>
+
+<body style="background-color: #f5f5f5; margin: 0 !important; padding: 0 !important">
+    <!-- HIDDEN PREHEADER TEXT -->
+    <div style="
+        display: none;
+        font-size: 1px;
+        color: #fefefe;
+        line-height: 1px;
+        font-family: 'Inter', Helvetica, Arial, sans-serif;
+        max-height: 0px;
+        max-width: 0px;
+        opacity: 0;
+        overflow: hidden;
+      ">
+        We're thrilled to have you on kAIron! Get ready to dive into your first bot.
+    </div>
+    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+        <!-- LOGO -->
+        <tr>
+            <td bgcolor="#f5f5f5" align="center" style="padding: 0 10px">
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px">
+                    <tr>
+                        <td style="padding: 36px 0 10px">
+                            <img src="BASE_URL/assets/logo/kAIron.png" alt="Kairon" width="106px" />
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        <!-- MAIN CARD -->
+        <tr>
+            <td bgcolor="#f5f5f5" align="center" style="padding: 0 10px">
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px">
+                    <tr>
+                        <td bgcolor="#ffffff" align="center" style="padding: 0 60px 30px 60px">
+                            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px">
+                                <tr>
+                                    <td align="center" style="padding: 20px 0">
+                                        <img id="mailheadimage"
+                                            src="BASE_URL/assets/emails/email-verification.png"
+                                            alt="Verify Email" width="288" height="180" />
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td align="center" style="font-family: Inter, Arial, sans-serif">
+                                        <h1 style="font-size: 24px; font-weight: 600; margin: 0">
+                                            Catalog Sync Status Update
+                                        </h1>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="
+                        font-family: Inter, Arial, sans-serif;
+                        font-size: 15px;
+                        padding: 16px 0;
+                      ">
+                                        <p>Hi,</p>
+                                        <p>
+                                            Bot ID: <strong style="color: #2F45C5;">BOT_ID</strong><br/>
+                                            Execution ID: <strong style="color: #2F45C5;">EXECUTION_ID</strong><br/><br/>
+                                            Sync Status: <strong style="color: #2F45C5;">SYNC_STATUS</strong><br/><br/>
+                                            Message: <strong style="color: #2F45C5;">MESSAGE</strong><br/><br/>
+                                        </p>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="
+                        font-family: Inter, Arial, sans-serif;
+                        font-size: 15px;
+                        padding: 16px 0;
+                      ">
+                                        <p style="margin-bottom: 0">Thanks,</p>
+                                        <p style="margin-top: 0">The team behind kAIron!​</p>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        <!-- FOOTER -->
+        <tr>
+            <td bgcolor="#f5f5f5" align="center" style="
+            padding: 5px 10px;
+            font-size: 12px;
+            color: #404040;
+            font-family: Inter, Arial, sans-serif;
+          ">
+                This email was sent to
+                <span style="text-decoration: none; color: #2f45c5">USER_EMAIL</span>
+            </td>
+        </tr>
+        <tr>
+            <td bgcolor="#f5f5f5" align="center" style="padding: 0 10px">
+                <table cellpadding="0" cellspacing="0" width="100%">
+                    <tr>
+                        <td align="center" style="padding: 36px 0 10px">
+                            <img src="BASE_URL/assets/emails/nimble-logo.png" alt="Digite"
+                                width="106px" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td align="center">
+                            <table cellpadding="0" cellspacing="0" align="center">
+                                <tr>
+                                    <td align="center">
+                                        <table style="display: inline-block">
+                                            <tr>
+                                                <td style="padding: 5px 10px">
+                                                    <a href="https://www.facebook.com/digite" target="_blank">
+                                                        <img src="BASE_URL/assets/emails/facebook.png"
+                                                            alt="Facebook" width="24" height="24" style="
+                                  display: block;
+                                  width: 20px !important;
+                                  height: 20px !important;
+                                " class="CToWUd" /></a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                        <table style="display: inline-block">
+                                            <tr>
+                                                <td style="padding: 5px 10px">
+                                                    <a href="https://twitter.com/digiteinc" target="_blank">
+                                                        <img src="BASE_URL/assets/emails/twitter.png"
+                                                            alt="Twitter" width="24" height="24" style="
+                                  display: block;
+                                  width: 20px !important;
+                                  height: 20px !important;
+                                " class="CToWUd" /></a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                        <table style="display: inline-block">
+                                            <tr>
+                                                <td style="padding: 5px 10px">
+                                                    <a href="https://linkedin.com/company/digite" target="_blank"><img
+                                                            src="BASE_URL/assets/emails/linkedin.png"
+                                                            alt="LinkedIn" width="24" height="24" style="
+                                  display: block;
+                                  width: 20px !important;
+                                  height: 20px !important;
+                                " class="CToWUd" /></a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                        <table style="display: inline-block">
+                                            <tr>
+                                                <td style="padding: 5px 10px">
+                                                    <a href="https://www.youtube.com/user/digiteswift" target="_blank">
+                                                        <img src="BASE_URL/assets/emails/youtube.png"
+                                                            alt="YouTube" width="24" height="24" style="
+                                  display: block;
+                                  width: 20px !important;
+                                  height: 20px !important;
+                                " class="CToWUd" />
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td align="center"
+                            style="padding: 0 0 50px; font-family: Inter, Arial, sans-serif; font-size: 12px">
+                            <p>Digité, Inc. 21060 Homestead Rd, Suite 220 Cupertino, CA, 95014, US</p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+
+</html>

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -1,4 +1,5 @@
 import io
+import asyncio
 import os
 import re
 import shutil
@@ -8,7 +9,7 @@ import time
 from datetime import datetime, timedelta
 from io import BytesIO
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 from urllib.parse import urljoin
 from zipfile import ZipFile
 import litellm
@@ -42,6 +43,7 @@ import numpy as np
 
 Utility.load_system_metadata()
 
+from pathlib import Path
 from kairon.api.app.main import app
 from kairon.events.definitions.multilingual import MultilingualEvent
 from kairon.exceptions import AppException
@@ -52,7 +54,7 @@ from kairon.shared.actions.data_objects import ActionServerLogs, ScheduleAction,
 from kairon.shared.actions.utils import ActionUtility
 from kairon.shared.auth import Authentication
 from kairon.shared.cloud.utils import CloudUtility
-from kairon.shared.cognition.data_objects import CognitionSchema, CognitionData
+from kairon.shared.cognition.data_objects import CognitionSchema, CognitionData, CollectionData
 from kairon.shared.constants import EventClass, ChannelTypes, KaironSystemSlots
 from kairon.shared.data.audit.data_objects import AuditLogData
 from kairon.shared.data.constant import (
@@ -75,8 +77,12 @@ from kairon.shared.data.data_objects import (
     ChatClientConfig,
     BotSettings,
     LLMSettings,
-    DemoRequestLogs, UserMediaData,
+    DemoRequestLogs, UserMediaData, BotSyncConfig, POSIntegrations
 )
+from kairon.events.definitions.catalog_sync import CatalogSync
+from kairon.meta.processor import MetaProcessor
+from kairon.shared.catalog_sync.data_objects import CatalogProviderMapping, CatalogSyncLogs
+from kairon.shared.cognition.processor import CognitionDataProcessor
 from kairon.shared.data.model_processor import ModelProcessor
 from kairon.shared.data.processor import MongoProcessor
 from kairon.shared.data.utils import DataUtility
@@ -97,7 +103,7 @@ refresh_token = None
 token_type = None
 
 
-@pytest.fixture(autouse=True, scope="class")
+@pytest.fixture(autouse=True, scope="function")
 def setup():
     os.environ["system_file"] = "./tests/testing_data/system.yaml"
     Utility.load_environment()
@@ -149,6 +155,12 @@ def complete_end_to_end_event_execution(bot, user, event_class, **kwargs):
     if event_class == EventClass.data_importer:
         overwrite = kwargs.get('overwrite', True)
         TrainingDataImporterEvent(bot, user, import_data=True, overwrite=overwrite).execute()
+    elif event_class == EventClass.catalog_integration:
+        provider = kwargs.get('provider')
+        sync_type = kwargs.get('sync_type')
+        token = kwargs.get('token')
+        data = kwargs.get('data')
+        asyncio.run(CatalogSync(bot, user, provider, sync_type=sync_type, token=token).execute(data=data))
     elif event_class == EventClass.model_training:
         ModelTrainingEvent(bot, user).execute()
     elif event_class == EventClass.content_importer:
@@ -2409,6 +2421,7 @@ def test_bsp_upload_media_360dialog_upload_failed(mock_get_buffer):
 @mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
 @mock.patch.object(litellm, "aembedding", autospec=True)
 def test_knowledge_vault_sync_push_menu(mock_embedding, mock_collection_exists, mock_create_collection, mock_collection_upsert):
+    LLMSecret.objects.delete()
     bot_settings = BotSettings.objects(bot=pytest.bot).get()
     bot_settings.content_importer_limit_per_day = 10
     bot_settings.cognition_collections_limit = 10
@@ -2420,7 +2433,21 @@ def test_knowledge_vault_sync_push_menu(mock_embedding, mock_collection_exists, 
     mock_collection_upsert.return_value = None
 
     embedding = list(np.random.random(LLMProcessor.__embedding__))
-    mock_embedding.return_value = litellm.EmbeddingResponse(**{'data': [{'embedding': embedding}]})
+    mock_embedding.return_value = litellm.EmbeddingResponse(**{'data': [{'embedding': embedding}, {'embedding': embedding}]})
+
+
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        },
+    ]
+
+    for secret in secrets:
+        LLMSecret(**secret).save()
 
     response = client.post(
         url=f"/api/bot/{pytest.bot}/data/cognition/schema",
@@ -2464,7 +2491,7 @@ def test_knowledge_vault_sync_push_menu(mock_embedding, mock_collection_exists, 
     ]
 
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/data/cognition/sync?primary_key_col=id&collection_name=groceries&event_type=push_menu",
+        url=f"/api/bot/{pytest.bot}/data/cognition/sync?primary_key_col=id&collection_name=groceries&sync_type=push_menu",
         json=sync_data,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token}
     )
@@ -2489,18 +2516,11 @@ def test_knowledge_vault_sync_push_menu(mock_embedding, mock_collection_exists, 
     expected_calls = [
         {
             "model": "text-embedding-3-large",
-            "input": ['{"id":1,"item":"Juice","price":2.5,"quantity":10}'],  # First input
+            "input": ['{"id":1,"item":"Juice","price":2.5,"quantity":10}', '{"id":2,"item":"Apples","price":1.2,"quantity":20}'],
             "metadata": {'user': 'integration@demo.ai', 'bot': pytest.bot, 'invocation': 'knowledge_vault_sync'},
-            "api_key": "value",
+            "api_key": "common_openai_key",
             "num_retries": 3
         },
-        {
-            "model": "text-embedding-3-large",
-            "input": ['{"id":2,"item":"Apples","price":1.2,"quantity":20}'],  # Second input
-            "metadata": {'user': 'integration@demo.ai', 'bot': pytest.bot, 'invocation': 'knowledge_vault_sync'},
-            "api_key": "value",
-            "num_retries": 3
-        }
     ]
 
     for i, expected in enumerate(expected_calls):
@@ -2509,6 +2529,7 @@ def test_knowledge_vault_sync_push_menu(mock_embedding, mock_collection_exists, 
 
     CognitionData.objects(bot=pytest.bot, collection="groceries").delete()
     CognitionSchema.objects(bot=pytest.bot, collection_name="groceries").delete()
+    LLMSecret.objects.delete()
 
 
 @pytest.mark.asyncio
@@ -2517,7 +2538,8 @@ def test_knowledge_vault_sync_push_menu(mock_embedding, mock_collection_exists, 
 @mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
 @mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
 @mock.patch.object(litellm, "aembedding", autospec=True)
-def test_knowledge_vault_sync_field_update(mock_embedding, mock_collection_exists, mock_create_collection, mock_collection_upsert):
+def test_knowledge_vault_sync_item_toggle(mock_embedding, mock_collection_exists, mock_create_collection, mock_collection_upsert):
+    LLMSecret.objects.delete()
     bot_settings = BotSettings.objects(bot=pytest.bot).get()
     bot_settings.content_importer_limit_per_day = 10
     bot_settings.cognition_collections_limit = 10
@@ -2529,7 +2551,20 @@ def test_knowledge_vault_sync_field_update(mock_embedding, mock_collection_exist
     mock_collection_upsert.return_value = None
 
     embedding = list(np.random.random(LLMProcessor.__embedding__))
-    mock_embedding.return_value = litellm.EmbeddingResponse(**{'data': [{'embedding': embedding}]})
+    mock_embedding.return_value = litellm.EmbeddingResponse(**{'data': [{'embedding': embedding}, {'embedding': embedding}]})
+
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        },
+    ]
+
+    for secret in secrets:
+        LLMSecret(**secret).save()
 
     response = client.post(
         url=f"/api/bot/{pytest.bot}/data/cognition/schema",
@@ -2588,7 +2623,7 @@ def test_knowledge_vault_sync_field_update(mock_embedding, mock_collection_exist
     ]
 
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/data/cognition/sync?primary_key_col=id&collection_name=groceries&event_type=field_update",
+        url=f"/api/bot/{pytest.bot}/data/cognition/sync?primary_key_col=id&collection_name=groceries&sync_type=item_toggle",
         json=sync_data,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token}
     )
@@ -2613,18 +2648,11 @@ def test_knowledge_vault_sync_field_update(mock_embedding, mock_collection_exist
     expected_calls = [
         {
             "model": "text-embedding-3-large",
-            "input": ['{"id":1,"item":"Juice","price":80.5,"quantity":56}'],
+            "input": ['{"id":1,"item":"Juice","price":80.5,"quantity":56}', '{"id":2,"item":"Milk","price":27.0,"quantity":12}'],
             "metadata": {'user': 'integration@demo.ai', 'bot': pytest.bot, 'invocation': 'knowledge_vault_sync'},
-            "api_key": "value",
+            "api_key": "common_openai_key",
             "num_retries": 3
         },
-        {
-            "model": "text-embedding-3-large",
-            "input": ['{"id":2,"item":"Milk","price":27.0,"quantity":12}'],  # Second input
-            "metadata": {'user': 'integration@demo.ai', 'bot': pytest.bot, 'invocation': 'knowledge_vault_sync'},
-            "api_key": "value",
-            "num_retries": 3
-        }
     ]
 
     for i, expected in enumerate(expected_calls):
@@ -2637,7 +2665,8 @@ def test_knowledge_vault_sync_field_update(mock_embedding, mock_collection_exist
 @pytest.mark.asyncio
 @responses.activate
 @mock.patch.object(litellm, "aembedding", autospec=True)
-def test_knowledge_vault_sync_event_type_does_not_exist(mock_embedding):
+def test_knowledge_vault_sync_sync_type_does_not_exist(mock_embedding):
+    LLMSecret.objects.delete()
     bot_settings = BotSettings.objects(bot=pytest.bot).get()
     bot_settings.content_importer_limit_per_day = 10
     bot_settings.cognition_collections_limit = 10
@@ -2645,7 +2674,7 @@ def test_knowledge_vault_sync_event_type_does_not_exist(mock_embedding):
     bot_settings.save()
 
     embedding = list(np.random.random(LLMProcessor.__embedding__))
-    mock_embedding.return_value = litellm.EmbeddingResponse(**{'data': [{'embedding': embedding}]})
+    mock_embedding.return_value = litellm.EmbeddingResponse(**{'data': [{'embedding': embedding}, {'embedding': embedding}]})
 
     secrets = [
         {
@@ -2665,14 +2694,14 @@ def test_knowledge_vault_sync_event_type_does_not_exist(mock_embedding):
     ]
 
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/data/cognition/sync?primary_key_col=id&collection_name=groceries&event_type=non_existent_event_type",
+        url=f"/api/bot/{pytest.bot}/data/cognition/sync?primary_key_col=id&collection_name=groceries&sync_type=non_existent_sync_type",
         json=sync_data,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token}
     )
 
     actual = response.json()
     assert not actual["success"]
-    assert actual["message"] == "Event type does not exist"
+    assert actual["message"] == "Sync type does not exist"
     assert actual["error_code"] == 422
 
     cognition_data = CognitionData.objects(bot=pytest.bot, collection="nonexistent_collection")
@@ -2683,6 +2712,7 @@ def test_knowledge_vault_sync_event_type_does_not_exist(mock_embedding):
 @responses.activate
 @mock.patch.object(litellm, "aembedding", autospec=True)
 def test_knowledge_vault_sync_missing_collection(mock_embedding):
+    LLMSecret.objects.delete()
     bot_settings = BotSettings.objects(bot=pytest.bot).get()
     bot_settings.content_importer_limit_per_day = 10
     bot_settings.cognition_collections_limit = 10
@@ -2690,7 +2720,7 @@ def test_knowledge_vault_sync_missing_collection(mock_embedding):
     bot_settings.save()
 
     embedding = list(np.random.random(LLMProcessor.__embedding__))
-    mock_embedding.return_value = litellm.EmbeddingResponse(**{'data': [{'embedding': embedding}]})
+    mock_embedding.return_value = litellm.EmbeddingResponse(**{'data': [{'embedding': embedding}, {'embedding': embedding}]})
 
     secrets = [
         {
@@ -2710,7 +2740,7 @@ def test_knowledge_vault_sync_missing_collection(mock_embedding):
     ]
 
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/data/cognition/sync?primary_key_col=id&collection_name=nonexistent_collection&event_type=push_menu",
+        url=f"/api/bot/{pytest.bot}/data/cognition/sync?primary_key_col=id&collection_name=nonexistent_collection&sync_type=push_menu",
         json=sync_data,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token}
     )
@@ -2736,7 +2766,20 @@ def test_knowledge_vault_sync_missing_primary_key(mock_embedding):
     bot_settings.save()
 
     embedding = list(np.random.random(LLMProcessor.__embedding__))
-    mock_embedding.return_value = litellm.EmbeddingResponse(**{'data': [{'embedding': embedding}]})
+    mock_embedding.return_value = litellm.EmbeddingResponse(**{'data': [{'embedding': embedding}, {'embedding': embedding}]})
+
+    LLMSecret.objects.delete()
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        }
+    ]
+    for secret in secrets:
+        LLMSecret(**secret).save()
 
     schema_response = client.post(
         url=f"/api/bot/{pytest.bot}/data/cognition/schema",
@@ -2762,7 +2805,7 @@ def test_knowledge_vault_sync_missing_primary_key(mock_embedding):
     ]
 
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/data/cognition/sync?primary_key_col=id&collection_name=groceries&event_type=push_menu",
+        url=f"/api/bot/{pytest.bot}/data/cognition/sync?primary_key_col=id&collection_name=groceries&sync_type=push_menu",
         json=sync_data,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token}
     )
@@ -2790,7 +2833,20 @@ def test_knowledge_vault_sync_column_length_mismatch(mock_embedding):
     bot_settings.save()
 
     embedding = list(np.random.random(LLMProcessor.__embedding__))
-    mock_embedding.return_value = litellm.EmbeddingResponse(**{'data': [{'embedding': embedding}]})
+    mock_embedding.return_value = litellm.EmbeddingResponse(**{'data': [{'embedding': embedding}, {'embedding': embedding}]})
+
+    LLMSecret.objects.delete()
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        }
+    ]
+    for secret in secrets:
+        LLMSecret(**secret).save()
 
     schema_response = client.post(
         url=f"/api/bot/{pytest.bot}/data/cognition/schema",
@@ -2816,7 +2872,7 @@ def test_knowledge_vault_sync_column_length_mismatch(mock_embedding):
     ]
 
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/data/cognition/sync?primary_key_col=id&collection_name=groceries&event_type=push_menu",
+        url=f"/api/bot/{pytest.bot}/data/cognition/sync?primary_key_col=id&collection_name=groceries&sync_type=push_menu",
         json=sync_data,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token}
     )
@@ -2844,6 +2900,19 @@ def test_knowledge_vault_sync_invalid_columns(mock_embedding):
 
     embedding = list(np.random.random(LLMProcessor.__embedding__))
     mock_embedding.return_value = litellm.EmbeddingResponse(**{'data': [{'embedding': embedding}]})
+
+    LLMSecret.objects.delete()
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        }
+    ]
+    for secret in secrets:
+        LLMSecret(**secret).save()
 
     schema_response = client.post(
         url=f"/api/bot/{pytest.bot}/data/cognition/schema",
@@ -2884,7 +2953,7 @@ def test_knowledge_vault_sync_invalid_columns(mock_embedding):
     ]
 
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/data/cognition/sync?primary_key_col=id&collection_name=groceries&event_type=field_update",
+        url=f"/api/bot/{pytest.bot}/data/cognition/sync?primary_key_col=id&collection_name=groceries&sync_type=item_toggle",
         json=sync_data,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token}
     )
@@ -2920,6 +2989,19 @@ def test_knowledge_vault_sync_document_non_existence(mock_embedding):
 
     embedding = list(np.random.random(LLMProcessor.__embedding__))
     mock_embedding.return_value = litellm.EmbeddingResponse(**{'data': [{'embedding': embedding}]})
+
+    LLMSecret.objects.delete()
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        }
+    ]
+    for secret in secrets:
+        LLMSecret(**secret).save()
 
     schema_response = client.post(
         url=f"/api/bot/{pytest.bot}/data/cognition/schema",
@@ -2960,7 +3042,7 @@ def test_knowledge_vault_sync_document_non_existence(mock_embedding):
     ]
 
     response = client.post(
-        url=f"/api/bot/{pytest.bot}/data/cognition/sync?primary_key_col=id&collection_name=groceries&event_type=field_update",
+        url=f"/api/bot/{pytest.bot}/data/cognition/sync?primary_key_col=id&collection_name=groceries&sync_type=item_toggle",
         json=sync_data,
         headers={"Authorization": pytest.token_type + " " + pytest.access_token}
     )
@@ -3574,6 +3656,2393 @@ def test_upload_doc_content_file_type_validation_failure():
 
 
 @responses.activate
+def test_add_pos_integration_config_success():
+    payload = {
+      "provider": "petpooja",
+      "config": {
+        "restaurant_name": "restaurant1",
+        "branch_name": "branch1",
+        "restaurant_id": "98765"
+       },
+       "meta_config": {
+        "access_token":"dummy_access_token",
+        "catalog_id":"12345"
+       }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=push_menu",
+        json = payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "POS Integration Complete"
+    assert actual["error_code"] == 0
+    assert actual["success"]
+    assert "integration/petpooja/push_menu" in actual["data"]
+    assert str(pytest.bot) in actual["data"]
+
+    provider_mapping = CatalogProviderMapping.objects(provider="petpooja").first()
+    assert provider_mapping is not None
+    assert provider_mapping.meta_mappings is not None
+    assert provider_mapping.kv_mappings is not None
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    assert bot_sync_config is not None
+    assert bot_sync_config.restaurant_name == "restaurant1"
+    assert bot_sync_config.branch_name == "branch1"
+    assert bot_sync_config.parent_bot == pytest.bot
+
+    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").first()
+    assert pos_integration is not None
+    assert pos_integration.config["restaurant_id"] == "98765"
+    assert pos_integration.meta_config["access_token"] == "dummy_access_token"
+
+    BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
+    CatalogProviderMapping.objects(provider="petpooja").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").delete()
+
+
+@responses.activate
+def test_add_pos_integration_config_invalid_provider():
+    payload = {
+        "provider": "invalid_provider",
+        "config": {
+            "restaurant_name": "invalid",
+            "branch_name": "invalid",
+            "restaurant_id": "00000"
+        },
+        "meta_config": {
+            "access_token": "invalid",
+            "catalog_id": "000"
+        }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=push_menu",
+        json=payload,
+        headers={"Authorization": f"{pytest.token_type} {pytest.access_token}"}
+    )
+
+    actual = response.json()
+    assert actual["message"] == "Invalid Provider"
+    assert actual["error_code"] == 422
+    assert not actual["success"]
+
+    CatalogProviderMapping.objects(provider="invalid_provider").delete()
+    BotSyncConfig.objects(branch_bot=pytest.bot, provider="invalid_provider").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="invalid_provider", sync_type="push_menu").delete()
+
+
+@responses.activate
+def test_add_pos_integration_config_does_not_update_existing_bot_sync_config():
+    payload = {
+        "provider": "petpooja",
+        "config": {
+            "restaurant_name": "restaurant1",
+            "branch_name": "branch1",
+            "restaurant_id": "11111"
+        },
+        "meta_config": {
+            "access_token": "access_token_1",
+            "catalog_id": "catalog_1"
+        }
+    }
+
+    client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=push_menu",
+        json=payload,
+        headers={"Authorization": f"{pytest.token_type} {pytest.access_token}"}
+    )
+
+    updated_payload = {
+        "provider": "petpooja",
+        "config": {
+            "restaurant_name": "updated_restaurant",
+            "branch_name": "updated_branch",
+            "restaurant_id": "22222"
+        },
+        "meta_config": {
+            "access_token": "access_token_2",
+            "catalog_id": "catalog_2"
+        }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=push_menu",
+        json=updated_payload,
+        headers={"Authorization": f"{pytest.token_type} {pytest.access_token}"}
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["message"] == "POS Integration Complete"
+    assert "integration/petpooja/push_menu" in actual["data"]
+    assert str(pytest.bot) in actual["data"]
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    assert bot_sync_config.restaurant_name == "restaurant1"
+    assert bot_sync_config.branch_name == "branch1"
+
+    CatalogProviderMapping.objects(provider="petpooja").delete()
+    BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").delete()
+
+
+@responses.activate
+def test_add_pos_integration_config_invalid_sync_type():
+    payload = {
+        "provider": "petpooja",
+        "config": {
+            "restaurant_name": "restaurant3",
+            "branch_name": "branch3",
+            "restaurant_id": "33333"
+        },
+        "meta_config": {
+            "access_token": "access_333",
+            "catalog_id": "333"
+        }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=invalid_sync",
+        json=payload,
+        headers={"Authorization": f"{pytest.token_type} {pytest.access_token}"}
+    )
+
+    actual = response.json()
+    assert actual["message"] == "Sync type does not exist"
+    assert actual["error_code"] == 422
+    assert not actual["success"]
+
+    CatalogProviderMapping.objects(provider="petpooja").delete()
+    BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="invalid_sync").delete()
+
+
+@pytest.mark.asyncio
+@responses.activate
+@mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
+@mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
+@mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
+@mock.patch.object(MetaProcessor, "push_meta_catalog", autospec=True)
+@mock.patch.object(MetaProcessor, "delete_meta_catalog", autospec=True)
+@mock.patch.object(litellm, "aembedding", autospec=True)
+def test_catalog_sync_push_menu_success(mock_embedding, mock_collection_exists, mock_create_collection,
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_delete_meta_catalog, mock_push_meta_catalog):
+    mock_collection_exists.return_value = False
+    mock_create_collection.return_value = None
+    mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
+    mock_push_meta_catalog.return_value = None
+    mock_delete_meta_catalog.return_value = None
+
+    embedding = list(np.random.random(LLMProcessor.__embedding__))
+    mock_embedding.return_value = litellm.EmbeddingResponse(
+        **{'data': [{'embedding': embedding}, {'embedding': embedding}, {'embedding': embedding}]})
+
+    LLMSecret.objects.delete()
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        },
+    ]
+
+    for secret in secrets:
+        LLMSecret(**secret).save()
+
+    payload = {
+      "provider": "petpooja",
+      "config": {
+        "restaurant_name": "restaurant1",
+        "branch_name": "branch1",
+        "restaurant_id": "98765"
+       },
+       "meta_config": {
+        "access_token":"dummy_access_token",
+        "catalog_id":"12345"
+       }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=push_menu",
+        json = payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "POS Integration Complete"
+    assert actual["error_code"] == 0
+    assert actual["success"]
+    assert "integration/petpooja/push_menu" in actual["data"]
+    assert str(pytest.bot) in actual["data"]
+    sync_url = actual["data"]
+    token = sync_url.split(str(pytest.bot) + "/")[1]
+
+    provider_mapping = CatalogProviderMapping.objects(provider="petpooja").first()
+    assert provider_mapping is not None
+    assert provider_mapping.meta_mappings is not None
+    assert provider_mapping.kv_mappings is not None
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    assert bot_sync_config is not None
+    assert bot_sync_config.restaurant_name == "restaurant1"
+    assert bot_sync_config.branch_name == "branch1"
+    assert bot_sync_config.parent_bot == pytest.bot
+
+    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").first()
+    assert pos_integration is not None
+    assert pos_integration.config["restaurant_id"] == "98765"
+    assert pos_integration.meta_config["access_token"] == "dummy_access_token"
+
+    event_url = urljoin(
+        Utility.environment["events"]["server_url"],
+        f"/api/events/execute/{EventClass.catalog_integration}",
+    )
+    responses.add(
+        "POST",
+        event_url,
+        json={"success": True, "message": "Event triggered successfully!"},
+    )
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    bot_sync_config.process_push_menu= True
+    bot_sync_config.process_item_toggle = True
+    bot_sync_config.ai_enabled = True
+    bot_sync_config.meta_enabled = True
+    bot_sync_config.save()
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_images_collection = f"{restaurant_name}_{branch_name}_catalog_images"
+    fallback_data = {
+        "image_type": "global",
+        "image_url": "https://picsum.photos/id/237/200/300",
+        "image_base64": ""
+    }
+    CollectionData(
+        collection_name=catalog_images_collection,
+        data=fallback_data,
+        user="integration@demo.ai",
+        bot=pytest.bot,
+        status=True,
+        timestamp=datetime.utcnow()
+    ).save()
+
+    push_menu_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_push_menu_payload.json")
+
+    with push_menu_payload_path.open("r", encoding="utf-8") as f:
+        push_menu_payload = json.load(f)
+
+    response = client.post(
+        url=sync_url,
+        json=push_menu_payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+
+    actual = response.json()
+    assert actual["message"] == "Sync in progress! Check logs."
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["success"]
+
+    complete_end_to_end_event_execution(
+        pytest.bot, "integration@demo.ai", EventClass.catalog_integration, sync_type="push_menu", token = token,
+        provider = "petpooja", data = push_menu_payload
+    )
+
+    latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
+    assert latest_log is not None
+    assert latest_log.execution_id
+    assert latest_log.sync_status == "Completed"
+    assert latest_log.status == "Success"
+    assert hasattr(latest_log, "exception")
+    assert latest_log.exception == ""
+
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_data_collection = f"{restaurant_name}_{branch_name}_catalog_data"
+    catalog_data_docs = CollectionData.objects(collection_name=catalog_data_collection, bot=pytest.bot)
+    catalog_item_summaries = [
+        {"id": doc.data["id"], "price": doc.data["price"]}
+        for doc in catalog_data_docs
+    ]
+
+    expected_items = [
+        {"id": "10539634", "price": 8700.0},
+        {"id": "10539699", "price": 3426.0},
+        {"id": "10539580", "price": 3159.0},
+    ]
+
+    assert all(item in catalog_item_summaries for item in expected_items)
+
+    cognition_data_docs = CognitionData.objects(bot=str(pytest.bot))
+    cognition_map = {doc.data["id"]: doc.data["price"] for doc in cognition_data_docs if
+                     "id" in doc.data and "price" in doc.data}
+    for item in expected_items:
+        assert item["id"] in cognition_map
+        assert cognition_map[item["id"]] == item["price"]
+
+@pytest.mark.asyncio
+@responses.activate
+@mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
+@mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
+@mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(LLMProcessor, "__delete_collection_points__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
+@mock.patch.object(MetaProcessor, "push_meta_catalog", autospec=True)
+@mock.patch.object(MetaProcessor, "delete_meta_catalog", autospec=True)
+@mock.patch.object(litellm, "aembedding", autospec=True)
+def test_catalog_sync_push_menu_success_with_delete_data(mock_embedding, mock_collection_exists, mock_create_collection,
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_delete_collection_points,
+                                                         mock_delete_meta_catalog, mock_push_meta_catalog):
+    mock_collection_exists.return_value = False
+    mock_create_collection.return_value = None
+    mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
+    mock_push_meta_catalog.return_value = None
+    mock_delete_meta_catalog.return_value = None
+    mock_delete_collection_points.return_value = None
+
+    embedding = list(np.random.random(LLMProcessor.__embedding__))
+    mock_embedding.return_value = litellm.EmbeddingResponse(
+        **{'data': [{'embedding': embedding}, {'embedding': embedding}]})
+
+    payload = {
+      "provider": "petpooja",
+      "config": {
+        "restaurant_name": "restaurant1",
+        "branch_name": "branch1",
+        "restaurant_id": "98765"
+       },
+       "meta_config": {
+        "access_token":"dummy_access_token",
+        "catalog_id":"12345"
+       }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=push_menu",
+        json = payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "POS Integration Complete"
+    assert actual["error_code"] == 0
+    assert actual["success"]
+    assert "integration/petpooja/push_menu" in actual["data"]
+    assert str(pytest.bot) in actual["data"]
+    sync_url = actual["data"]
+    token = sync_url.split(str(pytest.bot) + "/")[1]
+
+    provider_mapping = CatalogProviderMapping.objects(provider="petpooja").first()
+    assert provider_mapping is not None
+    assert provider_mapping.meta_mappings is not None
+    assert provider_mapping.kv_mappings is not None
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    assert bot_sync_config is not None
+    assert bot_sync_config.restaurant_name == "restaurant1"
+    assert bot_sync_config.branch_name == "branch1"
+    assert bot_sync_config.parent_bot == pytest.bot
+
+    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").first()
+    assert pos_integration is not None
+    assert pos_integration.config["restaurant_id"] == "98765"
+    assert pos_integration.meta_config["access_token"] == "dummy_access_token"
+
+    event_url = urljoin(
+        Utility.environment["events"]["server_url"],
+        f"/api/events/execute/{EventClass.catalog_integration}",
+    )
+    responses.add(
+        "POST",
+        event_url,
+        json={"success": True, "message": "Event triggered successfully!"},
+    )
+
+    push_menu_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_push_menu_payload_with_delete_data.json")
+
+    with push_menu_payload_path.open("r", encoding="utf-8") as f:
+        push_menu_payload = json.load(f)
+
+    response = client.post(
+        url=sync_url,
+        json=push_menu_payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+
+    actual = response.json()
+    assert actual["message"] == "Sync in progress! Check logs."
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["success"]
+
+    complete_end_to_end_event_execution(
+        pytest.bot, "integration@demo.ai", EventClass.catalog_integration, sync_type="push_menu", token = token,
+        provider = "petpooja", data = push_menu_payload
+    )
+
+    latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
+    assert latest_log is not None
+    assert latest_log.execution_id
+    assert latest_log.sync_status == "Completed"
+    assert latest_log.status == "Success"
+    assert hasattr(latest_log, "exception")
+    assert latest_log.exception == ""
+
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_data_collection = f"{restaurant_name}_{branch_name}_catalog_data"
+    catalog_data_docs = CollectionData.objects(collection_name=catalog_data_collection, bot=pytest.bot)
+    catalog_item_summaries = [
+        {"id": doc.data["id"], "price": doc.data["price"]}
+        for doc in catalog_data_docs
+    ]
+    expected_items = [
+        {"id": "10539699", "price": 123.0},
+        {"id": "10539580", "price": 3159.0},
+    ]
+
+    assert all(item in catalog_item_summaries for item in expected_items)
+
+    cognition_data_docs = CognitionData.objects(bot=str(pytest.bot))
+    cognition_map = {doc.data["id"]: doc.data["price"] for doc in cognition_data_docs if
+                     "id" in doc.data and "price" in doc.data}
+    for item in expected_items:
+        assert item["id"] in cognition_map
+        assert cognition_map[item["id"]] == item["price"]
+
+
+@pytest.mark.asyncio
+@responses.activate
+@mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
+@mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
+@mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
+@mock.patch.object(MetaProcessor, "update_meta_catalog", autospec=True)
+@mock.patch.object(litellm, "aembedding", autospec=True)
+def test_catalog_sync_item_toggle_success(mock_embedding, mock_collection_exists, mock_create_collection,
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_update_meta_catalog):
+    mock_collection_exists.return_value = False
+    mock_create_collection.return_value = None
+    mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
+    mock_update_meta_catalog.return_value = None
+
+    embedding = list(np.random.random(LLMProcessor.__embedding__))
+    mock_embedding.return_value = litellm.EmbeddingResponse(
+        **{'data': [{'embedding': embedding}, {'embedding': embedding}]})
+
+    payload = {
+        "provider": "petpooja",
+        "config": {
+            "restaurant_name": "restaurant1",
+            "branch_name": "branch1",
+            "restaurant_id": "98765"
+        },
+        "meta_config": {
+            "access_token": "dummy_access_token",
+            "catalog_id": "12345"
+        }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=item_toggle",
+        json = payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "POS Integration Complete"
+    assert actual["error_code"] == 0
+    assert actual["success"]
+    assert "integration/petpooja/item_toggle" in actual["data"]
+    assert str(pytest.bot) in actual["data"]
+    sync_url = actual["data"]
+    token = sync_url.split(str(pytest.bot) + "/")[1]
+
+    provider_mapping = CatalogProviderMapping.objects(provider="petpooja").first()
+    assert provider_mapping is not None
+    assert provider_mapping.meta_mappings is not None
+    assert provider_mapping.kv_mappings is not None
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    assert bot_sync_config is not None
+    assert bot_sync_config.restaurant_name == "restaurant1"
+    assert bot_sync_config.branch_name == "branch1"
+    assert bot_sync_config.parent_bot == pytest.bot
+
+    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="item_toggle").first()
+    assert pos_integration is not None
+    assert pos_integration.config["restaurant_id"] == "98765"
+    assert pos_integration.meta_config["access_token"] == "dummy_access_token"
+
+    event_url = urljoin(
+        Utility.environment["events"]["server_url"],
+        f"/api/events/execute/{EventClass.catalog_integration}",
+    )
+    responses.add(
+        "POST",
+        event_url,
+        json={"success": True, "message": "Event triggered successfully!"},
+    )
+
+    item_toggle_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload.json")
+
+    with item_toggle_payload_path.open("r", encoding="utf-8") as f:
+        item_toggle_payload = json.load(f)
+
+    response = client.post(
+        url=sync_url,
+        json=item_toggle_payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+
+    actual = response.json()
+    assert actual["message"] == "Sync in progress! Check logs."
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["success"]
+
+    complete_end_to_end_event_execution(
+        pytest.bot, "integration@demo.ai", EventClass.catalog_integration, sync_type="item_toggle", token = token,
+        provider = "petpooja", data = item_toggle_payload
+    )
+
+    latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
+    assert latest_log is not None
+    assert latest_log.execution_id
+    assert latest_log.sync_status == "Completed"
+    assert latest_log.status == "Success"
+    assert hasattr(latest_log, "exception")
+    assert latest_log.exception == ""
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_data_collection = f"{restaurant_name}_{branch_name}_catalog_data"
+    catalog_data_docs = CollectionData.objects(collection_name=catalog_data_collection, bot=pytest.bot)
+    catalog_item_summaries = [
+        {"id": doc.data["id"], "availability": doc.data["availability"]}
+        for doc in catalog_data_docs
+    ]
+    expected_items = [
+        {"id": "10539699", "availability": "in stock"},
+        {"id": "10539580", "availability": "out of stock"},
+    ]
+
+    assert all(item in catalog_item_summaries for item in expected_items)
+
+    cognition_data_docs = CognitionData.objects(bot=str(pytest.bot))
+    cognition_map = {doc.data["id"]: doc.data["availability"] for doc in cognition_data_docs if
+                     "id" in doc.data and "availability" in doc.data}
+    for item in expected_items:
+        assert item["id"] in cognition_map
+        assert cognition_map[item["id"]] == item["availability"]
+
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_images_collection = f"{restaurant_name}_{branch_name}_catalog_images"
+
+    CatalogProviderMapping.objects(provider="petpooja").delete()
+    BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="item_toggle").delete()
+    LLMSecret.objects.delete()
+    CollectionData.objects(collection_name=catalog_data_collection).delete()
+    CollectionData.objects(collection_name=catalog_images_collection).delete()
+    CatalogSyncLogs.objects.delete()
+    CognitionData.objects(bot=pytest.bot).delete()
+    CognitionSchema.objects(bot=pytest.bot).delete()
+
+@pytest.mark.asyncio
+@responses.activate
+@mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
+@mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
+@mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
+@mock.patch.object(MetaProcessor, "push_meta_catalog", autospec=True)
+@mock.patch.object(MetaProcessor, "delete_meta_catalog", autospec=True)
+@mock.patch.object(litellm, "aembedding", autospec=True)
+def test_catalog_sync_push_menu_process_push_menu_disabled(mock_embedding, mock_collection_exists, mock_create_collection,
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_delete_meta_catalog, mock_push_meta_catalog):
+    mock_collection_exists.return_value = False
+    mock_create_collection.return_value = None
+    mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
+    mock_push_meta_catalog.return_value = None
+    mock_delete_meta_catalog.return_value = None
+
+    embedding = list(np.random.random(LLMProcessor.__embedding__))
+    mock_embedding.return_value = litellm.EmbeddingResponse(
+        **{'data': [{'embedding': embedding}, {'embedding': embedding}, {'embedding': embedding}]})
+
+    LLMSecret.objects.delete()
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        },
+    ]
+
+    for secret in secrets:
+        LLMSecret(**secret).save()
+
+    payload = {
+      "provider": "petpooja",
+      "config": {
+        "restaurant_name": "restaurant1",
+        "branch_name": "branch1",
+        "restaurant_id": "98765"
+       },
+       "meta_config": {
+        "access_token":"dummy_access_token",
+        "catalog_id":"12345"
+       }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=push_menu",
+        json = payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "POS Integration Complete"
+    assert actual["error_code"] == 0
+    assert actual["success"]
+    assert "integration/petpooja/push_menu" in actual["data"]
+    assert str(pytest.bot) in actual["data"]
+    sync_url = actual["data"]
+    token = sync_url.split(str(pytest.bot) + "/")[1]
+
+    provider_mapping = CatalogProviderMapping.objects(provider="petpooja").first()
+    assert provider_mapping is not None
+    assert provider_mapping.meta_mappings is not None
+    assert provider_mapping.kv_mappings is not None
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    assert bot_sync_config is not None
+    assert bot_sync_config.restaurant_name == "restaurant1"
+    assert bot_sync_config.branch_name == "branch1"
+    assert bot_sync_config.parent_bot == pytest.bot
+
+    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").first()
+    assert pos_integration is not None
+    assert pos_integration.config["restaurant_id"] == "98765"
+    assert pos_integration.meta_config["access_token"] == "dummy_access_token"
+
+    event_url = urljoin(
+        Utility.environment["events"]["server_url"],
+        f"/api/events/execute/{EventClass.catalog_integration}",
+    )
+    responses.add(
+        "POST",
+        event_url,
+        json={"success": True, "message": "Event triggered successfully!"},
+    )
+
+    push_menu_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_push_menu_payload.json")
+
+    with push_menu_payload_path.open("r", encoding="utf-8") as f:
+        push_menu_payload = json.load(f)
+
+    response = client.post(
+        url=sync_url,
+        json=push_menu_payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+
+    actual = response.json()
+    assert actual["message"] == "Push menu processing is disabled for this bot"
+    assert actual["error_code"] == 422
+    assert not actual["success"]
+
+    latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
+    print(latest_log.to_mongo().to_dict())
+    assert latest_log is not None
+    assert latest_log.execution_id
+    assert latest_log.sync_status == "Failed"
+    assert latest_log.status == "Failure"
+    assert hasattr(latest_log, "exception")
+    assert latest_log.exception == "Push menu processing is disabled for this bot"
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_data_collection = f"{restaurant_name}_{branch_name}_catalog_data"
+    catalog_data_docs = CollectionData.objects(collection_name=catalog_data_collection, bot=pytest.bot)
+    assert catalog_data_docs.count() == 0
+    cognition_data_docs = CognitionData.objects(bot=str(pytest.bot))
+    assert cognition_data_docs.count() == 0
+
+    CatalogProviderMapping.objects(provider="petpooja").delete()
+    BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").delete()
+    LLMSecret.objects.delete()
+    CollectionData.objects(collection_name=catalog_data_collection).delete()
+    # CollectionData.objects(collection_name=catalog_images_collection).delete()
+    CatalogSyncLogs.objects.delete()
+    CognitionData.objects(bot=pytest.bot).delete()
+    CognitionSchema.objects(bot=pytest.bot).delete()
+
+
+@pytest.mark.asyncio
+@responses.activate
+@mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
+@mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
+@mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
+@mock.patch.object(MetaProcessor, "update_meta_catalog", autospec=True)
+@mock.patch.object(litellm, "aembedding", autospec=True)
+def test_catalog_sync_item_toggle_process_item_toggle_disabled(mock_embedding, mock_collection_exists, mock_create_collection,
+                                        mock_collection_upsert, mock_format_and_send_mail, update_meta_catalog):
+    mock_collection_exists.return_value = False
+    mock_create_collection.return_value = None
+    mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
+    update_meta_catalog.return_value = None
+
+    embedding = list(np.random.random(LLMProcessor.__embedding__))
+    mock_embedding.return_value = litellm.EmbeddingResponse(
+        **{'data': [{'embedding': embedding}, {'embedding': embedding}, {'embedding': embedding}]})
+
+    LLMSecret.objects.delete()
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        },
+    ]
+
+    for secret in secrets:
+        LLMSecret(**secret).save()
+
+    payload = {
+      "provider": "petpooja",
+      "config": {
+        "restaurant_name": "restaurant1",
+        "branch_name": "branch1",
+        "restaurant_id": "98765"
+       },
+       "meta_config": {
+        "access_token":"dummy_access_token",
+        "catalog_id":"12345"
+       }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=item_toggle",
+        json = payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "POS Integration Complete"
+    assert actual["error_code"] == 0
+    assert actual["success"]
+    assert "integration/petpooja/item_toggle" in actual["data"]
+    assert str(pytest.bot) in actual["data"]
+    sync_url = actual["data"]
+    token = sync_url.split(str(pytest.bot) + "/")[1]
+
+    provider_mapping = CatalogProviderMapping.objects(provider="petpooja").first()
+    assert provider_mapping is not None
+    assert provider_mapping.meta_mappings is not None
+    assert provider_mapping.kv_mappings is not None
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    assert bot_sync_config is not None
+    assert bot_sync_config.restaurant_name == "restaurant1"
+    assert bot_sync_config.branch_name == "branch1"
+    assert bot_sync_config.parent_bot == pytest.bot
+
+    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="item_toggle").first()
+    assert pos_integration is not None
+    assert pos_integration.config["restaurant_id"] == "98765"
+    assert pos_integration.meta_config["access_token"] == "dummy_access_token"
+
+    event_url = urljoin(
+        Utility.environment["events"]["server_url"],
+        f"/api/events/execute/{EventClass.catalog_integration}",
+    )
+    responses.add(
+        "POST",
+        event_url,
+        json={"success": True, "message": "Event triggered successfully!"},
+    )
+
+    item_toggle_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload.json")
+
+    with item_toggle_payload_path.open("r", encoding="utf-8") as f:
+        item_toggle_payload = json.load(f)
+
+    response = client.post(
+        url=sync_url,
+        json=item_toggle_payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+
+    actual = response.json()
+    assert actual["message"] == "Item toggle is disabled for this bot"
+    assert actual["error_code"] == 422
+    assert not actual["success"]
+
+    latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
+    print(latest_log.to_mongo().to_dict())
+    assert latest_log is not None
+    assert latest_log.execution_id
+    assert latest_log.sync_status == "Failed"
+    assert latest_log.status == "Failure"
+    assert hasattr(latest_log, "exception")
+    assert latest_log.exception == "Item toggle is disabled for this bot"
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_data_collection = f"{restaurant_name}_{branch_name}_catalog_data"
+    catalog_data_docs = CollectionData.objects(collection_name=catalog_data_collection, bot=pytest.bot)
+    assert catalog_data_docs.count() == 0
+    cognition_data_docs = CognitionData.objects(bot=str(pytest.bot))
+    assert cognition_data_docs.count() == 0
+
+    CatalogProviderMapping.objects(provider="petpooja").delete()
+    BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="item_toggle").delete()
+    LLMSecret.objects.delete()
+    CollectionData.objects(collection_name=catalog_data_collection).delete()
+    # CollectionData.objects(collection_name=catalog_images_collection).delete()
+    CatalogSyncLogs.objects.delete()
+    CognitionData.objects(bot=pytest.bot).delete()
+    CognitionSchema.objects(bot=pytest.bot).delete()
+
+
+@pytest.mark.asyncio
+@responses.activate
+@mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
+@mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
+@mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
+@mock.patch.object(MetaProcessor, "push_meta_catalog", autospec=True)
+@mock.patch.object(MetaProcessor, "delete_meta_catalog", autospec=True)
+@mock.patch.object(litellm, "aembedding", autospec=True)
+def test_catalog_sync_push_menu_ai_disabled_meta_disabled(mock_embedding, mock_collection_exists, mock_create_collection,
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_delete_meta_catalog, mock_push_meta_catalog):
+    mock_collection_exists.return_value = False
+    mock_create_collection.return_value = None
+    mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
+    mock_push_meta_catalog.return_value = None
+    mock_delete_meta_catalog.return_value = None
+
+    embedding = list(np.random.random(LLMProcessor.__embedding__))
+    mock_embedding.return_value = litellm.EmbeddingResponse(
+        **{'data': [{'embedding': embedding}, {'embedding': embedding}, {'embedding': embedding}]})
+
+    LLMSecret.objects.delete()
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        },
+    ]
+
+    for secret in secrets:
+        LLMSecret(**secret).save()
+
+    payload = {
+      "provider": "petpooja",
+      "config": {
+        "restaurant_name": "restaurant1",
+        "branch_name": "branch1",
+        "restaurant_id": "98765"
+       },
+       "meta_config": {
+        "access_token":"dummy_access_token",
+        "catalog_id":"12345"
+       }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=push_menu",
+        json = payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "POS Integration Complete"
+    assert actual["error_code"] == 0
+    assert actual["success"]
+    assert "integration/petpooja/push_menu" in actual["data"]
+    assert str(pytest.bot) in actual["data"]
+    sync_url = actual["data"]
+    token = sync_url.split(str(pytest.bot) + "/")[1]
+
+    provider_mapping = CatalogProviderMapping.objects(provider="petpooja").first()
+    assert provider_mapping is not None
+    assert provider_mapping.meta_mappings is not None
+    assert provider_mapping.kv_mappings is not None
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    assert bot_sync_config is not None
+    assert bot_sync_config.restaurant_name == "restaurant1"
+    assert bot_sync_config.branch_name == "branch1"
+    assert bot_sync_config.parent_bot == pytest.bot
+
+    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").first()
+    assert pos_integration is not None
+    assert pos_integration.config["restaurant_id"] == "98765"
+    assert pos_integration.meta_config["access_token"] == "dummy_access_token"
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    bot_sync_config.process_push_menu = True
+    bot_sync_config.save()
+
+    event_url = urljoin(
+        Utility.environment["events"]["server_url"],
+        f"/api/events/execute/{EventClass.catalog_integration}",
+    )
+    responses.add(
+        "POST",
+        event_url,
+        json={"success": True, "message": "Event triggered successfully!"},
+    )
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_images_collection = f"{restaurant_name}_{branch_name}_catalog_images"
+    fallback_data = {
+        "image_type": "global",
+        "image_url": "https://picsum.photos/id/237/200/300",
+        "image_base64": ""
+    }
+    CollectionData(
+        collection_name=catalog_images_collection,
+        data=fallback_data,
+        user="integration@demo.ai",
+        bot=pytest.bot,
+        status=True,
+        timestamp=datetime.utcnow()
+    ).save()
+
+    push_menu_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_push_menu_payload.json")
+
+    with push_menu_payload_path.open("r", encoding="utf-8") as f:
+        push_menu_payload = json.load(f)
+
+    response = client.post(
+        url=sync_url,
+        json=push_menu_payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "Sync in progress! Check logs."
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["success"]
+
+    complete_end_to_end_event_execution(
+        pytest.bot, "integration@demo.ai", EventClass.catalog_integration, sync_type="push_menu", token=token,
+        provider="petpooja", data=push_menu_payload
+    )
+
+    latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
+    print(latest_log.to_mongo().to_dict())
+    assert latest_log is not None
+    assert latest_log.execution_id
+    assert latest_log.sync_status == "Completed"
+    assert latest_log.status == "Success"
+    assert hasattr(latest_log, "exception")
+    assert latest_log.exception == "Sync to knowledge vault and Meta is not allowed for this bot. Contact Support!!"
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_data_collection = f"{restaurant_name}_{branch_name}_catalog_data"
+    catalog_data_docs = CollectionData.objects(collection_name=catalog_data_collection, bot=pytest.bot)
+    catalog_item_summaries = [
+        {"id": doc.data["id"], "price": doc.data["price"]}
+        for doc in catalog_data_docs
+    ]
+    for i in catalog_data_docs:
+        print(i.to_mongo().to_dict())
+
+    expected_items = [
+        {"id": "10539634", "price": 8700.0},
+        {"id": "10539699", "price": 3426.0},
+        {"id": "10539580", "price": 3159.0},
+    ]
+
+    assert all(item in catalog_item_summaries for item in expected_items)
+
+    cognition_data_docs = CognitionData.objects(bot=str(pytest.bot))
+    assert cognition_data_docs.count() == 0
+
+    CatalogProviderMapping.objects(provider="petpooja").delete()
+    BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").delete()
+    LLMSecret.objects.delete()
+    # CollectionData.objects(collection_name=catalog_data_collection).delete()
+    CollectionData.objects(collection_name=catalog_images_collection).delete()
+    CatalogSyncLogs.objects.delete()
+    CognitionData.objects(bot=pytest.bot).delete()
+    CognitionSchema.objects(bot=pytest.bot).delete()
+
+
+
+@pytest.mark.asyncio
+@responses.activate
+@mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
+@mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
+@mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
+@mock.patch.object(MetaProcessor, "update_meta_catalog", autospec=True)
+@mock.patch.object(litellm, "aembedding", autospec=True)
+def test_catalog_sync_item_toggle_ai_disabled_meta_disabled(mock_embedding, mock_collection_exists, mock_create_collection,
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_update_meta_catalog):
+    mock_collection_exists.return_value = False
+    mock_create_collection.return_value = None
+    mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
+    mock_update_meta_catalog.return_value = None
+
+    embedding = list(np.random.random(LLMProcessor.__embedding__))
+    mock_embedding.return_value = litellm.EmbeddingResponse(
+        **{'data': [{'embedding': embedding}, {'embedding': embedding}, {'embedding': embedding}]})
+
+    LLMSecret.objects.delete()
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        },
+    ]
+
+    for secret in secrets:
+        LLMSecret(**secret).save()
+
+    payload = {
+      "provider": "petpooja",
+      "config": {
+        "restaurant_name": "restaurant1",
+        "branch_name": "branch1",
+        "restaurant_id": "98765"
+       },
+       "meta_config": {
+        "access_token":"dummy_access_token",
+        "catalog_id":"12345"
+       }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=item_toggle",
+        json = payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "POS Integration Complete"
+    assert actual["error_code"] == 0
+    assert actual["success"]
+    assert "integration/petpooja/item_toggle" in actual["data"]
+    assert str(pytest.bot) in actual["data"]
+    sync_url = actual["data"]
+    token = sync_url.split(str(pytest.bot) + "/")[1]
+
+    provider_mapping = CatalogProviderMapping.objects(provider="petpooja").first()
+    assert provider_mapping is not None
+    assert provider_mapping.meta_mappings is not None
+    assert provider_mapping.kv_mappings is not None
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    assert bot_sync_config is not None
+    assert bot_sync_config.restaurant_name == "restaurant1"
+    assert bot_sync_config.branch_name == "branch1"
+    assert bot_sync_config.parent_bot == pytest.bot
+
+    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="item_toggle").first()
+    assert pos_integration is not None
+    assert pos_integration.config["restaurant_id"] == "98765"
+    assert pos_integration.meta_config["access_token"] == "dummy_access_token"
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    bot_sync_config.process_item_toggle = True
+    bot_sync_config.save()
+
+    event_url = urljoin(
+        Utility.environment["events"]["server_url"],
+        f"/api/events/execute/{EventClass.catalog_integration}",
+    )
+    responses.add(
+        "POST",
+        event_url,
+        json={"success": True, "message": "Event triggered successfully!"},
+    )
+
+    item_toggle_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload.json")
+
+    with item_toggle_payload_path.open("r", encoding="utf-8") as f:
+        item_toggle_payload = json.load(f)
+
+    response = client.post(
+        url=sync_url,
+        json=item_toggle_payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "Sync in progress! Check logs."
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["success"]
+
+    complete_end_to_end_event_execution(
+        pytest.bot, "integration@demo.ai", EventClass.catalog_integration, sync_type="item_toggle", token=token,
+        provider="petpooja", data=item_toggle_payload
+    )
+
+    latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
+    print(latest_log.to_mongo().to_dict())
+    assert latest_log is not None
+    assert latest_log.execution_id
+    assert latest_log.sync_status == "Completed"
+    assert latest_log.status == "Success"
+    assert hasattr(latest_log, "exception")
+    assert latest_log.exception == "Sync to knowledge vault and Meta is not allowed for this bot. Contact Support!!"
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_data_collection = f"{restaurant_name}_{branch_name}_catalog_data"
+    catalog_data_docs = CollectionData.objects(collection_name=catalog_data_collection, bot=pytest.bot)
+    catalog_item_summaries = [
+        {"id": doc.data["id"], "availability": doc.data["availability"]}
+        for doc in catalog_data_docs
+    ]
+
+    expected_items = [
+        {"id": "10539634", "availability": "in stock"},
+        {"id": "10539699", "availability": "in stock"},
+        {"id": "10539580", "availability": "out of stock"},
+    ]
+
+    assert all(item in catalog_item_summaries for item in expected_items)
+
+    cognition_data_docs = CognitionData.objects(bot=str(pytest.bot))
+    assert cognition_data_docs.count() == 0
+
+    CatalogProviderMapping.objects(provider="petpooja").delete()
+    BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="item_toggle").delete()
+    LLMSecret.objects.delete()
+    CollectionData.objects(collection_name=catalog_data_collection).delete()
+    # CollectionData.objects(collection_name=catalog_images_collection).delete()
+    CatalogSyncLogs.objects.delete()
+    CognitionData.objects(bot=pytest.bot).delete()
+    CognitionSchema.objects(bot=pytest.bot).delete()
+
+
+@pytest.mark.asyncio
+@responses.activate
+@mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
+@mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
+@mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
+@mock.patch.object(MetaProcessor, "push_meta_catalog", autospec=True)
+@mock.patch.object(MetaProcessor, "delete_meta_catalog", autospec=True)
+@mock.patch.object(litellm, "aembedding", autospec=True)
+def test_catalog_sync_push_menu_ai_enabled_meta_disabled(mock_embedding, mock_collection_exists, mock_create_collection,
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_delete_meta_catalog, mock_push_meta_catalog):
+    mock_collection_exists.return_value = False
+    mock_create_collection.return_value = None
+    mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
+    mock_push_meta_catalog.return_value = None
+    mock_delete_meta_catalog.return_value = None
+
+    embedding = list(np.random.random(LLMProcessor.__embedding__))
+    mock_embedding.return_value = litellm.EmbeddingResponse(
+        **{'data': [{'embedding': embedding}, {'embedding': embedding}, {'embedding': embedding}]})
+
+    LLMSecret.objects.delete()
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        },
+    ]
+
+    for secret in secrets:
+        LLMSecret(**secret).save()
+
+    payload = {
+      "provider": "petpooja",
+      "config": {
+        "restaurant_name": "restaurant1",
+        "branch_name": "branch1",
+        "restaurant_id": "98765"
+       },
+       "meta_config": {
+        "access_token":"dummy_access_token",
+        "catalog_id":"12345"
+       }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=push_menu",
+        json = payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "POS Integration Complete"
+    assert actual["error_code"] == 0
+    assert actual["success"]
+    assert "integration/petpooja/push_menu" in actual["data"]
+    assert str(pytest.bot) in actual["data"]
+    sync_url = actual["data"]
+    token = sync_url.split(str(pytest.bot) + "/")[1]
+
+    provider_mapping = CatalogProviderMapping.objects(provider="petpooja").first()
+    assert provider_mapping is not None
+    assert provider_mapping.meta_mappings is not None
+    assert provider_mapping.kv_mappings is not None
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    assert bot_sync_config is not None
+    assert bot_sync_config.restaurant_name == "restaurant1"
+    assert bot_sync_config.branch_name == "branch1"
+    assert bot_sync_config.parent_bot == pytest.bot
+
+    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").first()
+    assert pos_integration is not None
+    assert pos_integration.config["restaurant_id"] == "98765"
+    assert pos_integration.meta_config["access_token"] == "dummy_access_token"
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    bot_sync_config.process_push_menu = True
+    bot_sync_config.ai_enabled = True
+    bot_sync_config.save()
+
+    event_url = urljoin(
+        Utility.environment["events"]["server_url"],
+        f"/api/events/execute/{EventClass.catalog_integration}",
+    )
+    responses.add(
+        "POST",
+        event_url,
+        json={"success": True, "message": "Event triggered successfully!"},
+    )
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_images_collection = f"{restaurant_name}_{branch_name}_catalog_images"
+    fallback_data = {
+        "image_type": "global",
+        "image_url": "https://picsum.photos/id/237/200/300",
+        "image_base64": ""
+    }
+    CollectionData(
+        collection_name=catalog_images_collection,
+        data=fallback_data,
+        user="integration@demo.ai",
+        bot=pytest.bot,
+        status=True,
+        timestamp=datetime.utcnow()
+    ).save()
+
+    push_menu_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_push_menu_payload.json")
+
+    with push_menu_payload_path.open("r", encoding="utf-8") as f:
+        push_menu_payload = json.load(f)
+
+    response = client.post(
+        url=sync_url,
+        json=push_menu_payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "Sync in progress! Check logs."
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["success"]
+
+    complete_end_to_end_event_execution(
+        pytest.bot, "integration@demo.ai", EventClass.catalog_integration, sync_type="push_menu", token=token,
+        provider="petpooja", data=push_menu_payload
+    )
+
+    latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
+    print(latest_log.to_mongo().to_dict())
+    assert latest_log is not None
+    assert latest_log.execution_id
+    assert latest_log.sync_status == "Completed"
+    assert latest_log.status == "Success"
+    assert hasattr(latest_log, "exception")
+    assert latest_log.exception == "Sync to Meta is not allowed for this bot. Contact Support!!"
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_data_collection = f"{restaurant_name}_{branch_name}_catalog_data"
+    catalog_data_docs = CollectionData.objects(collection_name=catalog_data_collection, bot=pytest.bot)
+    catalog_item_summaries = [
+        {"id": doc.data["id"], "price": doc.data["price"]}
+        for doc in catalog_data_docs
+    ]
+
+    expected_items = [
+        {"id": "10539634", "price": 8700.0},
+        {"id": "10539699", "price": 3426.0},
+        {"id": "10539580", "price": 3159.0},
+    ]
+
+    assert all(item in catalog_item_summaries for item in expected_items)
+
+    cognition_data_docs = CognitionData.objects(bot=str(pytest.bot))
+    assert cognition_data_docs.count() == 3
+
+    cognition_map = {doc.data["id"]: doc.data["price"] for doc in cognition_data_docs if
+                     "id" in doc.data and "price" in doc.data}
+    for item in expected_items:
+        assert item["id"] in cognition_map
+        assert cognition_map[item["id"]] == item["price"]
+
+    CatalogProviderMapping.objects(provider="petpooja").delete()
+    BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").delete()
+    LLMSecret.objects.delete()
+    # CollectionData.objects(collection_name=catalog_data_collection).delete()
+    CollectionData.objects(collection_name=catalog_images_collection).delete()
+    CatalogSyncLogs.objects.delete()
+    # CognitionData.objects(bot=pytest.bot).delete()
+    # CognitionSchema.objects(bot=pytest.bot).delete()
+
+@pytest.mark.asyncio
+@responses.activate
+@mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
+@mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
+@mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
+@mock.patch.object(MetaProcessor, "update_meta_catalog", autospec=True)
+@mock.patch.object(litellm, "aembedding", autospec=True)
+def test_catalog_sync_item_toggle_ai_enabled_meta_disabled(mock_embedding, mock_collection_exists, mock_create_collection,
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_update_meta_catalog):
+    mock_collection_exists.return_value = False
+    mock_create_collection.return_value = None
+    mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
+    mock_update_meta_catalog.return_value = None
+
+    embedding = list(np.random.random(LLMProcessor.__embedding__))
+    mock_embedding.return_value = litellm.EmbeddingResponse(
+        **{'data': [{'embedding': embedding}, {'embedding': embedding}, {'embedding': embedding}]})
+
+    LLMSecret.objects.delete()
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        },
+    ]
+
+    for secret in secrets:
+        LLMSecret(**secret).save()
+
+    payload = {
+      "provider": "petpooja",
+      "config": {
+        "restaurant_name": "restaurant1",
+        "branch_name": "branch1",
+        "restaurant_id": "98765"
+       },
+       "meta_config": {
+        "access_token":"dummy_access_token",
+        "catalog_id":"12345"
+       }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=item_toggle",
+        json = payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "POS Integration Complete"
+    assert actual["error_code"] == 0
+    assert actual["success"]
+    assert "integration/petpooja/item_toggle" in actual["data"]
+    assert str(pytest.bot) in actual["data"]
+    sync_url = actual["data"]
+    token = sync_url.split(str(pytest.bot) + "/")[1]
+
+    provider_mapping = CatalogProviderMapping.objects(provider="petpooja").first()
+    assert provider_mapping is not None
+    assert provider_mapping.meta_mappings is not None
+    assert provider_mapping.kv_mappings is not None
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    assert bot_sync_config is not None
+    assert bot_sync_config.restaurant_name == "restaurant1"
+    assert bot_sync_config.branch_name == "branch1"
+    assert bot_sync_config.parent_bot == pytest.bot
+
+    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="item_toggle").first()
+    assert pos_integration is not None
+    assert pos_integration.config["restaurant_id"] == "98765"
+    assert pos_integration.meta_config["access_token"] == "dummy_access_token"
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    bot_sync_config.process_item_toggle = True
+    bot_sync_config.ai_enabled = True
+    bot_sync_config.save()
+
+    event_url = urljoin(
+        Utility.environment["events"]["server_url"],
+        f"/api/events/execute/{EventClass.catalog_integration}",
+    )
+    responses.add(
+        "POST",
+        event_url,
+        json={"success": True, "message": "Event triggered successfully!"},
+    )
+
+    item_toggle_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload.json")
+
+    with item_toggle_payload_path.open("r", encoding="utf-8") as f:
+        item_toggle_payload = json.load(f)
+
+    response = client.post(
+        url=sync_url,
+        json=item_toggle_payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "Sync in progress! Check logs."
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["success"]
+
+    complete_end_to_end_event_execution(
+        pytest.bot, "integration@demo.ai", EventClass.catalog_integration, sync_type="item_toggle", token=token,
+        provider="petpooja", data=item_toggle_payload
+    )
+
+    latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
+    print(latest_log.to_mongo().to_dict())
+    assert latest_log is not None
+    assert latest_log.execution_id
+    assert latest_log.sync_status == "Completed"
+    assert latest_log.status == "Success"
+    assert hasattr(latest_log, "exception")
+    assert latest_log.exception == "Sync to Meta is not allowed for this bot. Contact Support!!"
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_data_collection = f"{restaurant_name}_{branch_name}_catalog_data"
+    catalog_data_docs = CollectionData.objects(collection_name=catalog_data_collection, bot=pytest.bot)
+    catalog_item_summaries = [
+        {"id": doc.data["id"], "availability": doc.data["availability"]}
+        for doc in catalog_data_docs
+    ]
+
+    expected_items = [
+        {"id": "10539634", "availability": "in stock"},
+        {"id": "10539699", "availability": "in stock"},
+        {"id": "10539580", "availability": "out of stock"},
+    ]
+
+    assert all(item in catalog_item_summaries for item in expected_items)
+
+    cognition_data_docs = CognitionData.objects(bot=str(pytest.bot))
+    assert cognition_data_docs.count() == 3
+
+    cognition_map = {doc.data["id"]: doc.data["availability"] for doc in cognition_data_docs if
+                     "id" in doc.data and "availability" in doc.data}
+    for item in expected_items:
+        assert item["id"] in cognition_map
+        assert cognition_map[item["id"]] == item["availability"]
+
+    CatalogProviderMapping.objects(provider="petpooja").delete()
+    BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="item_toggle").delete()
+    LLMSecret.objects.delete()
+    CollectionData.objects(collection_name=catalog_data_collection).delete()
+    # CollectionData.objects(collection_name=catalog_images_collection).delete()
+    CatalogSyncLogs.objects.delete()
+    CognitionData.objects(bot=pytest.bot).delete()
+    CognitionSchema.objects(bot=pytest.bot).delete()
+
+
+
+@pytest.mark.asyncio
+@responses.activate
+@mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
+@mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
+@mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
+@mock.patch.object(MetaProcessor, "push_meta_catalog", autospec=True)
+@mock.patch.object(MetaProcessor, "delete_meta_catalog", autospec=True)
+@mock.patch.object(litellm, "aembedding", autospec=True)
+def test_catalog_sync_push_menu_ai_disabled_meta_enabled(mock_embedding, mock_collection_exists, mock_create_collection,
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_delete_meta_catalog, mock_push_meta_catalog):
+    mock_collection_exists.return_value = False
+    mock_create_collection.return_value = None
+    mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
+    mock_push_meta_catalog.return_value = None
+    mock_delete_meta_catalog.return_value = None
+
+    embedding = list(np.random.random(LLMProcessor.__embedding__))
+    mock_embedding.return_value = litellm.EmbeddingResponse(
+        **{'data': [{'embedding': embedding}, {'embedding': embedding}, {'embedding': embedding}]})
+
+    LLMSecret.objects.delete()
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        },
+    ]
+
+    for secret in secrets:
+        LLMSecret(**secret).save()
+
+    payload = {
+      "provider": "petpooja",
+      "config": {
+        "restaurant_name": "restaurant1",
+        "branch_name": "branch1",
+        "restaurant_id": "98765"
+       },
+       "meta_config": {
+        "access_token":"dummy_access_token",
+        "catalog_id":"12345"
+       }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=push_menu",
+        json = payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "POS Integration Complete"
+    assert actual["error_code"] == 0
+    assert actual["success"]
+    assert "integration/petpooja/push_menu" in actual["data"]
+    assert str(pytest.bot) in actual["data"]
+    sync_url = actual["data"]
+    token = sync_url.split(str(pytest.bot) + "/")[1]
+
+    provider_mapping = CatalogProviderMapping.objects(provider="petpooja").first()
+    assert provider_mapping is not None
+    assert provider_mapping.meta_mappings is not None
+    assert provider_mapping.kv_mappings is not None
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    assert bot_sync_config is not None
+    assert bot_sync_config.restaurant_name == "restaurant1"
+    assert bot_sync_config.branch_name == "branch1"
+    assert bot_sync_config.parent_bot == pytest.bot
+
+    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").first()
+    assert pos_integration is not None
+    assert pos_integration.config["restaurant_id"] == "98765"
+    assert pos_integration.meta_config["access_token"] == "dummy_access_token"
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    bot_sync_config.process_push_menu = True
+    bot_sync_config.meta_enabled = True
+    bot_sync_config.save()
+
+    event_url = urljoin(
+        Utility.environment["events"]["server_url"],
+        f"/api/events/execute/{EventClass.catalog_integration}",
+    )
+    responses.add(
+        "POST",
+        event_url,
+        json={"success": True, "message": "Event triggered successfully!"},
+    )
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_images_collection = f"{restaurant_name}_{branch_name}_catalog_images"
+    fallback_data = {
+        "image_type": "global",
+        "image_url": "https://picsum.photos/id/237/200/300",
+        "image_base64": ""
+    }
+    CollectionData(
+        collection_name=catalog_images_collection,
+        data=fallback_data,
+        user="integration@demo.ai",
+        bot=pytest.bot,
+        status=True,
+        timestamp=datetime.utcnow()
+    ).save()
+
+    push_menu_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_push_menu_payload.json")
+
+    with push_menu_payload_path.open("r", encoding="utf-8") as f:
+        push_menu_payload = json.load(f)
+
+    response = client.post(
+        url=sync_url,
+        json=push_menu_payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "Sync in progress! Check logs."
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["success"]
+
+    complete_end_to_end_event_execution(
+        pytest.bot, "integration@demo.ai", EventClass.catalog_integration, sync_type="push_menu", token=token,
+        provider="petpooja", data=push_menu_payload
+    )
+
+    latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
+    print(latest_log.to_mongo().to_dict())
+    assert latest_log is not None
+    assert latest_log.execution_id
+    assert latest_log.sync_status == "Completed"
+    assert latest_log.status == "Success"
+    assert hasattr(latest_log, "exception")
+    assert latest_log.exception == "Sync to knowledge vault is not allowed for this bot. Contact Support!!"
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_data_collection = f"{restaurant_name}_{branch_name}_catalog_data"
+    catalog_data_docs = CollectionData.objects(collection_name=catalog_data_collection, bot=pytest.bot)
+    catalog_item_summaries = [
+        {"id": doc.data["id"], "price": doc.data["price"]}
+        for doc in catalog_data_docs
+    ]
+
+    expected_items = [
+        {"id": "10539634", "price": 8700.0},
+        {"id": "10539699", "price": 3426.0},
+        {"id": "10539580", "price": 3159.0},
+    ]
+
+    assert all(item in catalog_item_summaries for item in expected_items)
+
+    cognition_data_docs = CognitionData.objects(bot=str(pytest.bot))
+    assert cognition_data_docs.count() == 0
+
+    CatalogProviderMapping.objects(provider="petpooja").delete()
+    BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").delete()
+    LLMSecret.objects.delete()
+    # CollectionData.objects(collection_name=catalog_data_collection).delete()
+    CollectionData.objects(collection_name=catalog_images_collection).delete()
+    CatalogSyncLogs.objects.delete()
+    # CognitionData.objects(bot=pytest.bot).delete()
+    # CognitionSchema.objects(bot=pytest.bot).delete()
+
+
+@pytest.mark.asyncio
+@responses.activate
+@mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
+@mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
+@mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
+@mock.patch.object(MetaProcessor, "update_meta_catalog", autospec=True)
+@mock.patch.object(litellm, "aembedding", autospec=True)
+def test_catalog_sync_item_toggle_ai_disabled_meta_enabled(mock_embedding, mock_collection_exists, mock_create_collection,
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_update_meta_catalog):
+    mock_collection_exists.return_value = False
+    mock_create_collection.return_value = None
+    mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
+    mock_update_meta_catalog.return_value = None
+
+    embedding = list(np.random.random(LLMProcessor.__embedding__))
+    mock_embedding.return_value = litellm.EmbeddingResponse(
+        **{'data': [{'embedding': embedding}, {'embedding': embedding}, {'embedding': embedding}]})
+
+    LLMSecret.objects.delete()
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        },
+    ]
+
+    for secret in secrets:
+        LLMSecret(**secret).save()
+
+    payload = {
+      "provider": "petpooja",
+      "config": {
+        "restaurant_name": "restaurant1",
+        "branch_name": "branch1",
+        "restaurant_id": "98765"
+       },
+       "meta_config": {
+        "access_token":"dummy_access_token",
+        "catalog_id":"12345"
+       }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=item_toggle",
+        json = payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "POS Integration Complete"
+    assert actual["error_code"] == 0
+    assert actual["success"]
+    assert "integration/petpooja/item_toggle" in actual["data"]
+    assert str(pytest.bot) in actual["data"]
+    sync_url = actual["data"]
+    token = sync_url.split(str(pytest.bot) + "/")[1]
+
+    provider_mapping = CatalogProviderMapping.objects(provider="petpooja").first()
+    assert provider_mapping is not None
+    assert provider_mapping.meta_mappings is not None
+    assert provider_mapping.kv_mappings is not None
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    assert bot_sync_config is not None
+    assert bot_sync_config.restaurant_name == "restaurant1"
+    assert bot_sync_config.branch_name == "branch1"
+    assert bot_sync_config.parent_bot == pytest.bot
+
+    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="item_toggle").first()
+    assert pos_integration is not None
+    assert pos_integration.config["restaurant_id"] == "98765"
+    assert pos_integration.meta_config["access_token"] == "dummy_access_token"
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    bot_sync_config.process_item_toggle = True
+    bot_sync_config.meta_enabled = True
+    bot_sync_config.save()
+
+    event_url = urljoin(
+        Utility.environment["events"]["server_url"],
+        f"/api/events/execute/{EventClass.catalog_integration}",
+    )
+    responses.add(
+        "POST",
+        event_url,
+        json={"success": True, "message": "Event triggered successfully!"},
+    )
+
+    item_toggle_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload.json")
+
+    with item_toggle_payload_path.open("r", encoding="utf-8") as f:
+        item_toggle_payload = json.load(f)
+
+    response = client.post(
+        url=sync_url,
+        json=item_toggle_payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "Sync in progress! Check logs."
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["success"]
+
+    complete_end_to_end_event_execution(
+        pytest.bot, "integration@demo.ai", EventClass.catalog_integration, sync_type="item_toggle", token=token,
+        provider="petpooja", data=item_toggle_payload
+    )
+
+    latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
+    print(latest_log.to_mongo().to_dict())
+    assert latest_log is not None
+    assert latest_log.execution_id
+    assert latest_log.sync_status == "Completed"
+    assert latest_log.status == "Success"
+    assert hasattr(latest_log, "exception")
+    assert latest_log.exception == "Sync to knowledge vault is not allowed for this bot. Contact Support!!"
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_data_collection = f"{restaurant_name}_{branch_name}_catalog_data"
+    catalog_data_docs = CollectionData.objects(collection_name=catalog_data_collection, bot=pytest.bot)
+    catalog_item_summaries = [
+        {"id": doc.data["id"], "availability": doc.data["availability"]}
+        for doc in catalog_data_docs
+    ]
+
+    expected_items = [
+        {"id": "10539634", "availability": "in stock"},
+        {"id": "10539699", "availability": "in stock"},
+        {"id": "10539580", "availability": "out of stock"},
+    ]
+
+    assert all(item in catalog_item_summaries for item in expected_items)
+
+    cognition_data_docs = CognitionData.objects(bot=str(pytest.bot))
+    assert cognition_data_docs.count() == 0
+
+    CatalogProviderMapping.objects(provider="petpooja").delete()
+    BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="item_toggle").delete()
+    LLMSecret.objects.delete()
+    CollectionData.objects(collection_name=catalog_data_collection).delete()
+    # CollectionData.objects(collection_name=catalog_images_collection).delete()
+    CatalogSyncLogs.objects.delete()
+    CognitionData.objects(bot=pytest.bot).delete()
+    CognitionSchema.objects(bot=pytest.bot).delete()
+
+@pytest.mark.asyncio
+@responses.activate
+@mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
+@mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
+@mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
+@mock.patch.object(MetaProcessor, "push_meta_catalog", autospec=True)
+@mock.patch.object(MetaProcessor, "delete_meta_catalog", autospec=True)
+@mock.patch.object(litellm, "aembedding", autospec=True)
+def test_catalog_sync_push_menu_global_image_not_found(mock_embedding, mock_collection_exists, mock_create_collection,
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_delete_meta_catalog, mock_push_meta_catalog):
+    mock_collection_exists.return_value = False
+    mock_create_collection.return_value = None
+    mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
+    mock_push_meta_catalog.return_value = None
+    mock_delete_meta_catalog.return_value = None
+
+    embedding = list(np.random.random(LLMProcessor.__embedding__))
+    mock_embedding.return_value = litellm.EmbeddingResponse(
+        **{'data': [{'embedding': embedding}, {'embedding': embedding}, {'embedding': embedding}]})
+
+    LLMSecret.objects.delete()
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        },
+    ]
+
+    for secret in secrets:
+        LLMSecret(**secret).save()
+
+    payload = {
+      "provider": "petpooja",
+      "config": {
+        "restaurant_name": "restaurant1",
+        "branch_name": "branch1",
+        "restaurant_id": "98765"
+       },
+       "meta_config": {
+        "access_token":"dummy_access_token",
+        "catalog_id":"12345"
+       }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=push_menu",
+        json = payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "POS Integration Complete"
+    assert actual["error_code"] == 0
+    assert actual["success"]
+    assert "integration/petpooja/push_menu" in actual["data"]
+    assert str(pytest.bot) in actual["data"]
+    sync_url = actual["data"]
+    token = sync_url.split(str(pytest.bot) + "/")[1]
+
+    provider_mapping = CatalogProviderMapping.objects(provider="petpooja").first()
+    assert provider_mapping is not None
+    assert provider_mapping.meta_mappings is not None
+    assert provider_mapping.kv_mappings is not None
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    assert bot_sync_config is not None
+    assert bot_sync_config.restaurant_name == "restaurant1"
+    assert bot_sync_config.branch_name == "branch1"
+    assert bot_sync_config.parent_bot == pytest.bot
+
+    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").first()
+    assert pos_integration is not None
+    assert pos_integration.config["restaurant_id"] == "98765"
+    assert pos_integration.meta_config["access_token"] == "dummy_access_token"
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    bot_sync_config.process_push_menu = True
+    bot_sync_config.meta_enabled = True
+    bot_sync_config.save()
+
+    event_url = urljoin(
+        Utility.environment["events"]["server_url"],
+        f"/api/events/execute/{EventClass.catalog_integration}",
+    )
+    responses.add(
+        "POST",
+        event_url,
+        json={"success": True, "message": "Event triggered successfully!"},
+    )
+
+    push_menu_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_push_menu_payload.json")
+
+    with push_menu_payload_path.open("r", encoding="utf-8") as f:
+        push_menu_payload = json.load(f)
+
+    response = client.post(
+        url=sync_url,
+        json=push_menu_payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "Global fallback image URL not found"
+    assert actual["error_code"] == 422
+    assert not actual["success"]
+
+    latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
+    print(latest_log.to_mongo().to_dict())
+    assert latest_log is not None
+    assert latest_log.execution_id
+    assert latest_log.sync_status == "Failed"
+    assert latest_log.status == "Failure"
+    assert hasattr(latest_log, "exception")
+    assert latest_log.exception == "Global fallback image URL not found"
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_data_collection = f"{restaurant_name}_{branch_name}_catalog_data"
+    catalog_data_docs = CollectionData.objects(collection_name=catalog_data_collection, bot=pytest.bot)
+    assert catalog_data_docs.count() == 0
+    cognition_data_docs = CognitionData.objects(bot=str(pytest.bot))
+    assert cognition_data_docs.count() == 0
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_images_collection = f"{restaurant_name}_{branch_name}_catalog_images"
+
+    CatalogProviderMapping.objects(provider="petpooja").delete()
+    BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="invalid_sync").delete()
+    LLMSecret.objects.delete()
+    CollectionData.objects(collection_name=catalog_data_collection).delete()
+    CollectionData.objects(collection_name=catalog_images_collection).delete()
+    CatalogSyncLogs.objects.delete()
+    CognitionData.objects(bot=pytest.bot).delete()
+    CognitionSchema.objects(bot=pytest.bot).delete()
+
+
+@pytest.mark.asyncio
+@responses.activate
+@mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
+@mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
+@mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
+@mock.patch.object(MetaProcessor, "push_meta_catalog", autospec=True)
+@mock.patch.object(MetaProcessor, "delete_meta_catalog", autospec=True)
+@mock.patch.object(litellm, "aembedding", autospec=True)
+def test_catalog_sync_push_menu_global_local_images_success(mock_embedding, mock_collection_exists, mock_create_collection,
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_delete_meta_catalog, mock_push_meta_catalog):
+    mock_collection_exists.return_value = False
+    mock_create_collection.return_value = None
+    mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
+    mock_push_meta_catalog.return_value = None
+    mock_delete_meta_catalog.return_value = None
+
+    embedding = list(np.random.random(LLMProcessor.__embedding__))
+    mock_embedding.return_value = litellm.EmbeddingResponse(
+        **{'data': [{'embedding': embedding}, {'embedding': embedding}, {'embedding': embedding}]})
+
+    LLMSecret.objects.delete()
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        },
+    ]
+
+    for secret in secrets:
+        LLMSecret(**secret).save()
+
+    payload = {
+      "provider": "petpooja",
+      "config": {
+        "restaurant_name": "restaurant1",
+        "branch_name": "branch1",
+        "restaurant_id": "98765"
+       },
+       "meta_config": {
+        "access_token":"dummy_access_token",
+        "catalog_id":"12345"
+       }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=push_menu",
+        json = payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "POS Integration Complete"
+    assert actual["error_code"] == 0
+    assert actual["success"]
+    assert "integration/petpooja/push_menu" in actual["data"]
+    assert str(pytest.bot) in actual["data"]
+    sync_url = actual["data"]
+    token = sync_url.split(str(pytest.bot) + "/")[1]
+
+    provider_mapping = CatalogProviderMapping.objects(provider="petpooja").first()
+    assert provider_mapping is not None
+    assert provider_mapping.meta_mappings is not None
+    assert provider_mapping.kv_mappings is not None
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    assert bot_sync_config is not None
+    assert bot_sync_config.restaurant_name == "restaurant1"
+    assert bot_sync_config.branch_name == "branch1"
+    assert bot_sync_config.parent_bot == pytest.bot
+
+    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").first()
+    assert pos_integration is not None
+    assert pos_integration.config["restaurant_id"] == "98765"
+    assert pos_integration.meta_config["access_token"] == "dummy_access_token"
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    bot_sync_config.process_push_menu = True
+    bot_sync_config.ai_enabled = True
+    bot_sync_config.meta_enabled = True
+    bot_sync_config.save()
+
+    event_url = urljoin(
+        Utility.environment["events"]["server_url"],
+        f"/api/events/execute/{EventClass.catalog_integration}",
+    )
+    responses.add(
+        "POST",
+        event_url,
+        json={"success": True, "message": "Event triggered successfully!"},
+    )
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_images_collection = f"{restaurant_name}_{branch_name}_catalog_images"
+    fallback_data = {
+        "image_type": "global",
+        "image_url": "https://picsum.photos/id/237/200/300",
+        "image_base64": ""
+    }
+    CollectionData(
+        collection_name=catalog_images_collection,
+        data=fallback_data,
+        user="integration@demo.ai",
+        bot=pytest.bot,
+        status=True,
+        timestamp=datetime.utcnow()
+    ).save()
+
+    local_image_data = {
+        "image_type": "local",
+        "item_id": 10539634,
+        "image_url": "https://picsum.photos/id/local/237/200/300",
+        "image_base64": ""
+    }
+    CollectionData(
+        collection_name=catalog_images_collection,
+        data=local_image_data,
+        user="integration@demo.ai",
+        bot=pytest.bot,
+        status=True,
+        timestamp=datetime.utcnow()
+    ).save()
+
+    push_menu_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_push_menu_payload.json")
+
+    with push_menu_payload_path.open("r", encoding="utf-8") as f:
+        push_menu_payload = json.load(f)
+
+    response = client.post(
+        url=sync_url,
+        json=push_menu_payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+
+    actual = response.json()
+    assert actual["message"] == "Sync in progress! Check logs."
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["success"]
+
+    complete_end_to_end_event_execution(
+        pytest.bot, "integration@demo.ai", EventClass.catalog_integration, sync_type="push_menu", token=token,
+        provider="petpooja", data=push_menu_payload
+    )
+
+    latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
+    assert latest_log is not None
+    assert latest_log.execution_id
+    assert latest_log.sync_status == "Completed"
+    assert latest_log.status == "Success"
+    assert hasattr(latest_log, "exception")
+    assert latest_log.exception == ""
+
+    expected_id_image_map = {
+        '10539634': 'https://picsum.photos/id/local/237/200/300',
+        '10539699': 'https://picsum.photos/id/237/200/300',
+        '10539580': 'https://picsum.photos/id/237/200/300'
+    }
+    latest_log_dict = latest_log.to_mongo().to_dict()
+    meta_items = latest_log_dict["processed_payload"]["meta"]
+    id_image_map = {item["id"]: item["image_url"] for item in meta_items}
+
+    assert id_image_map == expected_id_image_map
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_data_collection = f"{restaurant_name}_{branch_name}_catalog_data"
+    catalog_data_docs = CollectionData.objects(collection_name=catalog_data_collection, bot=pytest.bot)
+    catalog_item_summaries = [
+        {"id": doc.data["id"], "price": doc.data["price"]}
+        for doc in catalog_data_docs
+    ]
+
+    expected_items = [
+        {"id": "10539634", "price": 8700.0},
+        {"id": "10539699", "price": 3426.0},
+        {"id": "10539580", "price": 3159.0},
+    ]
+
+    assert all(item in catalog_item_summaries for item in expected_items)
+
+    cognition_data_docs = CognitionData.objects(bot=str(pytest.bot))
+    cognition_map = {doc.data["id"]: doc.data["price"] for doc in cognition_data_docs if
+                     "id" in doc.data and "price" in doc.data}
+    for item in expected_items:
+        assert item["id"] in cognition_map
+        assert cognition_map[item["id"]] == item["price"]
+
+    CatalogProviderMapping.objects(provider="petpooja").delete()
+    BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="invalid_sync").delete()
+    LLMSecret.objects.delete()
+    CollectionData.objects(collection_name=catalog_data_collection).delete()
+    CollectionData.objects(collection_name=catalog_images_collection).delete()
+    CatalogSyncLogs.objects.delete()
+    CognitionData.objects(bot=pytest.bot).delete()
+    CognitionSchema.objects(bot=pytest.bot).delete()
+
+
+@pytest.mark.asyncio
+@responses.activate
+@mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
+@mock.patch.object(LLMProcessor, "__create_collection__", autospec=True)
+@mock.patch.object(LLMProcessor, "__collection_upsert__", autospec=True)
+@mock.patch.object(MailUtility,"format_and_send_mail", autospec=True)
+@mock.patch.object(MetaProcessor, "push_meta_catalog", autospec=True)
+@mock.patch.object(MetaProcessor, "delete_meta_catalog", autospec=True)
+@mock.patch.object(litellm, "aembedding", autospec=True)
+def test_catalog_rerun_sync_push_menu_success(mock_embedding, mock_collection_exists, mock_create_collection,
+                                        mock_collection_upsert, mock_format_and_send_mail, mock_delete_meta_catalog, mock_push_meta_catalog):
+    mock_collection_exists.return_value = False
+    mock_create_collection.return_value = None
+    mock_collection_upsert.return_value = None
+    mock_format_and_send_mail.return_value = None
+    mock_push_meta_catalog.return_value = None
+    mock_delete_meta_catalog.return_value = None
+
+    embedding = list(np.random.random(LLMProcessor.__embedding__))
+    mock_embedding.return_value = litellm.EmbeddingResponse(
+        **{'data': [{'embedding': embedding}, {'embedding': embedding}, {'embedding': embedding}]})
+
+    LLMSecret.objects.delete()
+    secrets = [
+        {
+            "llm_type": "openai",
+            "api_key": "common_openai_key",
+            "models": ["common_openai_model1", "common_openai_model2"],
+            "user": "123",
+            "timestamp": datetime.utcnow()
+        },
+    ]
+
+    for secret in secrets:
+        LLMSecret(**secret).save()
+
+    payload = {
+      "provider": "petpooja",
+      "config": {
+        "restaurant_name": "restaurant1",
+        "branch_name": "branch1",
+        "restaurant_id": "98765"
+       },
+       "meta_config": {
+        "access_token":"dummy_access_token",
+        "catalog_id":"12345"
+       }
+    }
+
+    response = client.post(
+        url=f"/api/bot/{pytest.bot}/data/integrations/add?sync_type=push_menu",
+        json = payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+    actual = response.json()
+    assert actual["message"] == "POS Integration Complete"
+    assert actual["error_code"] == 0
+    assert actual["success"]
+    assert "integration/petpooja/push_menu" in actual["data"]
+    assert str(pytest.bot) in actual["data"]
+    sync_url = actual["data"]
+    token = sync_url.split(str(pytest.bot) + "/")[1]
+
+    provider_mapping = CatalogProviderMapping.objects(provider="petpooja").first()
+    assert provider_mapping is not None
+    assert provider_mapping.meta_mappings is not None
+    assert provider_mapping.kv_mappings is not None
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    assert bot_sync_config is not None
+    assert bot_sync_config.restaurant_name == "restaurant1"
+    assert bot_sync_config.branch_name == "branch1"
+    assert bot_sync_config.parent_bot == pytest.bot
+
+    pos_integration = POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="push_menu").first()
+    assert pos_integration is not None
+    assert pos_integration.config["restaurant_id"] == "98765"
+    assert pos_integration.meta_config["access_token"] == "dummy_access_token"
+
+    event_url = urljoin(
+        Utility.environment["events"]["server_url"],
+        f"/api/events/execute/{EventClass.catalog_integration}",
+    )
+    responses.add(
+        "POST",
+        event_url,
+        json={"success": True, "message": "Event triggered successfully!"},
+    )
+
+    push_menu_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_push_menu_payload.json")
+
+    with push_menu_payload_path.open("r", encoding="utf-8") as f:
+        push_menu_payload = json.load(f)
+
+    response = client.post(
+        url=sync_url,
+        json=push_menu_payload,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+
+    actual = response.json()
+    assert actual["message"] == "Push menu processing is disabled for this bot"
+    assert actual["error_code"] == 422
+    assert not actual["success"]
+
+    latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
+    print(latest_log.to_mongo().to_dict())
+    assert latest_log is not None
+    assert latest_log.execution_id
+    assert latest_log.sync_status == "Failed"
+    assert latest_log.status == "Failure"
+    assert hasattr(latest_log, "exception")
+    assert latest_log.exception == "Push menu processing is disabled for this bot"
+    rerun_execution_id = latest_log.execution_id
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_data_collection = f"{restaurant_name}_{branch_name}_catalog_data"
+    catalog_data_docs = CollectionData.objects(collection_name=catalog_data_collection, bot=pytest.bot)
+    assert catalog_data_docs.count() == 0
+    cognition_data_docs = CognitionData.objects(bot=str(pytest.bot))
+    assert cognition_data_docs.count() == 0
+
+    bot_sync_config = BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").first()
+    bot_sync_config.process_push_menu = True
+    bot_sync_config.process_item_toggle = True
+    bot_sync_config.ai_enabled = True
+    bot_sync_config.meta_enabled = True
+    bot_sync_config.save()
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_images_collection = f"{restaurant_name}_{branch_name}_catalog_images"
+    fallback_data = {
+        "image_type": "global",
+        "image_url": "https://picsum.photos/id/237/200/300",
+        "image_base64": ""
+    }
+    CollectionData(
+        collection_name=catalog_images_collection,
+        data=fallback_data,
+        user="integration@demo.ai",
+        bot=pytest.bot,
+        status=True,
+        timestamp=datetime.utcnow()
+    ).save()
+
+    rerun_sync_url = f"{sync_url}/{rerun_execution_id}"
+
+    response = client.post(
+        url=rerun_sync_url,
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token}
+    )
+
+    actual = response.json()
+    print(actual)
+    assert actual["message"] == "Sync in progress! Check logs."
+    assert actual["error_code"] == 0
+    assert actual["data"] is None
+    assert actual["success"]
+
+    complete_end_to_end_event_execution(
+        pytest.bot, "integration@demo.ai", EventClass.catalog_integration, sync_type="push_menu", token=token,
+        provider="petpooja", data=push_menu_payload
+    )
+
+    latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
+    assert latest_log is not None
+    assert latest_log.execution_id
+    assert latest_log.sync_status == "Completed"
+    assert latest_log.status == "Success"
+    assert hasattr(latest_log, "exception")
+    assert latest_log.exception == ""
+
+    restaurant_name, branch_name = CognitionDataProcessor.get_restaurant_and_branch_name(pytest.bot)
+    catalog_data_collection = f"{restaurant_name}_{branch_name}_catalog_data"
+    catalog_data_docs = CollectionData.objects(collection_name=catalog_data_collection, bot=pytest.bot)
+    catalog_item_summaries = [
+        {"id": doc.data["id"], "price": doc.data["price"]}
+        for doc in catalog_data_docs
+    ]
+
+    expected_items = [
+        {"id": "10539634", "price": 8700.0},
+        {"id": "10539699", "price": 3426.0},
+        {"id": "10539580", "price": 3159.0},
+    ]
+
+    assert all(item in catalog_item_summaries for item in expected_items)
+
+    cognition_data_docs = CognitionData.objects(bot=str(pytest.bot))
+    cognition_map = {doc.data["id"]: doc.data["price"] for doc in cognition_data_docs if
+                     "id" in doc.data and "price" in doc.data}
+    for item in expected_items:
+        assert item["id"] in cognition_map
+        assert cognition_map[item["id"]] == item["price"]
+
+    CatalogProviderMapping.objects(provider="petpooja").delete()
+    BotSyncConfig.objects(branch_bot=pytest.bot, provider="petpooja").delete()
+    POSIntegrations.objects(bot=pytest.bot, provider="petpooja", sync_type="invalid_sync").delete()
+    LLMSecret.objects.delete()
+    CollectionData.objects(collection_name=catalog_data_collection).delete()
+    CollectionData.objects(collection_name=catalog_images_collection).delete()
+    CatalogSyncLogs.objects.delete()
+    CognitionData.objects(bot=pytest.bot).delete()
+    CognitionSchema.objects(bot=pytest.bot).delete()
+
+
+@responses.activate
 def test_upload_with_bot_content_only_validate_content_data():
     bot_settings = BotSettings.objects(bot=pytest.bot).get()
     bot_settings.data_importer_limit_per_day = 10
@@ -3970,7 +6439,6 @@ def test_upload_with_bot_content_event_append_validate_payload_data():
     bot_settings = BotSettings.objects(bot=pytest.bot).get()
     bot_settings.llm_settings['enable_faq'] = False
     bot_settings.save()
-
 
 @pytest.fixture()
 def get_executor_logs():
@@ -6867,6 +9335,9 @@ def test_metadata_upload_api(monkeypatch):
 
 
 def test_metadata_upload_api_column_limit_exceeded():
+    bot_settings = BotSettings.objects(bot=pytest.bot).get()
+    bot_settings.cognition_columns_per_collection_limit = 5
+    bot_settings.save()
     response = client.post(
         url=f"/api/bot/{pytest.bot}/data/cognition/schema",
         json={
@@ -26500,7 +28971,8 @@ def test_get_bot_settings():
                               'cognition_columns_per_collection_limit': 5,
                               'content_importer_limit_per_day': 5,
                               'integrations_per_user_limit': 3,
-                              'retry_broadcasting_limit': 3}
+                              'retry_broadcasting_limit': 3,
+                              'catalog_sync_limit_per_day': 5}
 
 
 @patch("kairon.shared.utils.Utility.request_event_server", autospec=True)
@@ -26608,7 +29080,8 @@ def test_update_analytics_settings():
                               'content_importer_limit_per_day': 5,
                               'cognition_columns_per_collection_limit': 5,
                               'integrations_per_user_limit': 3,
-                              'retry_broadcasting_limit': 3}
+                              'retry_broadcasting_limit': 3,
+                              'catalog_sync_limit_per_day': 5}
 
 
 def test_delete_channels_config():

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -2003,7 +2003,6 @@ def test_payload_upload_api_with_float_field_value_integer(monkeypatch):
     cognition_data = CognitionData.objects(bot=pytest.bot, collection="with_float_field_value_integer").first()
     assert cognition_data is not None
     data_dict = cognition_data.to_mongo().to_dict()
-    print(data_dict)
     assert data_dict['data']['item'] == 'Box'
     assert isinstance(data_dict['data']['price'], float)
     assert data_dict['data']['price'] == 54.0
@@ -2049,7 +2048,6 @@ def test_update_payload_upload_api_with_float_field_value_integer(monkeypatch):
     cognition_data = CognitionData.objects(bot=pytest.bot, collection="update_with_float_field_value_integer").first()
     assert cognition_data is not None
     data_dict = cognition_data.to_mongo().to_dict()
-    print(data_dict)
     assert data_dict['data']['item'] == 'Box'
     assert isinstance(data_dict['data']['price'], float)
     assert data_dict['data']['price'] == 54.08
@@ -2073,7 +2071,6 @@ def test_update_payload_upload_api_with_float_field_value_integer(monkeypatch):
     cognition_data = CognitionData.objects(bot=pytest.bot, collection="update_with_float_field_value_integer").first()
     assert cognition_data is not None
     data_dict = cognition_data.to_mongo().to_dict()
-    print(data_dict)
     assert data_dict['data']['item'] == 'Box'
     assert isinstance(data_dict['data']['price'], float)
     assert data_dict['data']['price'] == 27.0
@@ -3986,6 +3983,25 @@ def test_catalog_sync_push_menu_success(mock_embedding, mock_collection_exists, 
         assert item["id"] in cognition_map
         assert cognition_map[item["id"]] == item["price"]
 
+def test_get_catalog_sync_logs():
+    response = client.get(
+        f"/api/bot/{pytest.bot}/catalog/logs?start_idx=0&page_size=10",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    log = actual['data']['logs'][0]
+
+    assert 'execution_id' in log and log['execution_id']
+    assert 'raw_payload' in log and isinstance(log['raw_payload'], dict)
+    assert 'start_timestamp' in log and log['start_timestamp']
+    assert 'end_timestamp' in log and log['end_timestamp']
+    assert 'validation_errors' in log and log['validation_errors'] == {}
+    assert log['provider'] == 'petpooja'
+    assert log['sync_type'] == 'push_menu'
+    assert log['status'] == 'Success'
+    assert log['sync_status'] == 'Completed'
+
+
 @pytest.mark.asyncio
 @responses.activate
 @mock.patch.object(LLMProcessor, "__collection_exists__", autospec=True)
@@ -4362,7 +4378,6 @@ def test_catalog_sync_push_menu_process_push_menu_disabled(mock_embedding, mock_
     assert not actual["success"]
 
     latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
-    print(latest_log.to_mongo().to_dict())
     assert latest_log is not None
     assert latest_log.execution_id
     assert latest_log.sync_status == "Failed"
@@ -4492,7 +4507,6 @@ def test_catalog_sync_item_toggle_process_item_toggle_disabled(mock_embedding, m
     assert not actual["success"]
 
     latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
-    print(latest_log.to_mongo().to_dict())
     assert latest_log is not None
     assert latest_log.execution_id
     assert latest_log.sync_status == "Failed"
@@ -4649,7 +4663,6 @@ def test_catalog_sync_push_menu_ai_disabled_meta_disabled(mock_embedding, mock_c
     )
 
     latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
-    print(latest_log.to_mongo().to_dict())
     assert latest_log is not None
     assert latest_log.execution_id
     assert latest_log.sync_status == "Completed"
@@ -4664,8 +4677,6 @@ def test_catalog_sync_push_menu_ai_disabled_meta_disabled(mock_embedding, mock_c
         {"id": doc.data["id"], "price": doc.data["price"]}
         for doc in catalog_data_docs
     ]
-    for i in catalog_data_docs:
-        print(i.to_mongo().to_dict())
 
     expected_items = [
         {"id": "10539634", "price": 8700.0},
@@ -4803,7 +4814,6 @@ def test_catalog_sync_item_toggle_ai_disabled_meta_disabled(mock_embedding, mock
     )
 
     latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
-    print(latest_log.to_mongo().to_dict())
     assert latest_log is not None
     assert latest_log.execution_id
     assert latest_log.sync_status == "Completed"
@@ -4973,7 +4983,6 @@ def test_catalog_sync_push_menu_ai_enabled_meta_disabled(mock_embedding, mock_co
     )
 
     latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
-    print(latest_log.to_mongo().to_dict())
     assert latest_log is not None
     assert latest_log.execution_id
     assert latest_log.sync_status == "Completed"
@@ -5130,7 +5139,6 @@ def test_catalog_sync_item_toggle_ai_enabled_meta_disabled(mock_embedding, mock_
     )
 
     latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
-    print(latest_log.to_mongo().to_dict())
     assert latest_log is not None
     assert latest_log.execution_id
     assert latest_log.sync_status == "Completed"
@@ -5307,7 +5315,6 @@ def test_catalog_sync_push_menu_ai_disabled_meta_enabled(mock_embedding, mock_co
     )
 
     latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
-    print(latest_log.to_mongo().to_dict())
     assert latest_log is not None
     assert latest_log.execution_id
     assert latest_log.sync_status == "Completed"
@@ -5459,7 +5466,6 @@ def test_catalog_sync_item_toggle_ai_disabled_meta_enabled(mock_embedding, mock_
     )
 
     latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
-    print(latest_log.to_mongo().to_dict())
     assert latest_log is not None
     assert latest_log.execution_id
     assert latest_log.sync_status == "Completed"
@@ -5606,7 +5612,6 @@ def test_catalog_sync_push_menu_global_image_not_found(mock_embedding, mock_coll
     assert not actual["success"]
 
     latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
-    print(latest_log.to_mongo().to_dict())
     assert latest_log is not None
     assert latest_log.execution_id
     assert latest_log.sync_status == "Failed"
@@ -5942,7 +5947,6 @@ def test_catalog_rerun_sync_push_menu_success(mock_embedding, mock_collection_ex
     assert not actual["success"]
 
     latest_log = CatalogSyncLogs.objects(bot=str(pytest.bot)).order_by("-start_timestamp").first()
-    print(latest_log.to_mongo().to_dict())
     assert latest_log is not None
     assert latest_log.execution_id
     assert latest_log.sync_status == "Failed"
@@ -5989,7 +5993,6 @@ def test_catalog_rerun_sync_push_menu_success(mock_embedding, mock_collection_ex
     )
 
     actual = response.json()
-    print(actual)
     assert actual["message"] == "Sync in progress! Check logs."
     assert actual["error_code"] == 0
     assert actual["data"] is None

--- a/tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload.json
+++ b/tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload.json
@@ -1,0 +1,14 @@
+{
+    "type": "POST",
+    "body": {
+        "restID": "njrbv7mu",
+        "inStock": false,
+        "itemID": [
+            "10539580"
+        ],
+        "type": "item",
+        "autoTurnOnTime": "custom",
+        "customTurnOnTime": "2025-03-26 12:45:00"
+    },
+    "params": {}
+}

--- a/tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload_invalid_missing_instock.json
+++ b/tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload_invalid_missing_instock.json
@@ -1,0 +1,13 @@
+{
+    "type": "POST",
+    "body": {
+        "restID": "njrbv7mu",
+        "itemID": [
+            "10539580"
+        ],
+        "type": "item",
+        "autoTurnOnTime": "custom",
+        "customTurnOnTime": "2025-03-26 12:45:00"
+    },
+    "params": {}
+}

--- a/tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload_invalid_missing_itemid.json
+++ b/tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload_invalid_missing_itemid.json
@@ -1,0 +1,11 @@
+{
+    "type": "POST",
+    "body": {
+        "restID": "njrbv7mu",
+        "inStock": false,
+        "type": "item",
+        "autoTurnOnTime": "custom",
+        "customTurnOnTime": "2025-03-26 12:45:00"
+    },
+    "params": {}
+}

--- a/tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload_invalid_nonboolean_instock.json
+++ b/tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload_invalid_nonboolean_instock.json
@@ -1,0 +1,14 @@
+{
+    "type": "POST",
+    "body": {
+        "restID": "njrbv7mu",
+        "inStock": "invalid",
+        "itemID": [
+            "10539580"
+        ],
+        "type": "item",
+        "autoTurnOnTime": "custom",
+        "customTurnOnTime": "2025-03-26 12:45:00"
+    },
+    "params": {}
+}

--- a/tests/testing_data/catalog_sync/catalog_sync_push_menu_payload.json
+++ b/tests/testing_data/catalog_sync/catalog_sync_push_menu_payload.json
@@ -1,0 +1,270 @@
+{
+    "success": "1",
+    "message": "Menu items are successfully listed.",
+    "restaurants": [
+        {
+            "restaurantid": "4639",
+            "active": "1",
+            "details": {
+                "menusharingcode": "nu0wisf4",
+                "currency_html": "&#8377;",
+                "country": "India",
+                "country_id": "97",
+                "images": [],
+                "restaurantname": "Indisubb Foods Private Limited",
+                "address": "Ahmedabad",
+                "contact": "1234567890",
+                "latitude": "1",
+                "longitude": "1",
+                "landmark": "",
+                "city": "Ahmedabad",
+                "city_id": "1321851",
+                "state": "Gujarat",
+                "state_id": "1612",
+                "minimumorderamount": "0",
+                "minimumdeliverytime": "30 Minutes",
+                "deliverycharge": "0",
+                "deliveryhoursfrom1": "",
+                "deliveryhoursto1": "",
+                "deliveryhoursfrom2": "",
+                "deliveryhoursto2": "",
+                "calculatetaxonpacking": 0,
+                "calculatetaxondelivery": 0,
+                "dc_taxes_id": "",
+                "pc_taxes_id": "",
+                "packaging_applicable_on": "NONE",
+                "packaging_charge": "",
+                "packaging_charge_type": ""
+            }
+        }
+    ],
+    "ordertypes": [
+        {
+            "ordertypeid": 1,
+            "ordertype": "Delivery"
+        },
+        {
+            "ordertypeid": 2,
+            "ordertype": "Pick Up"
+        },
+        {
+            "ordertypeid": 3,
+            "ordertype": "Dine In"
+        }
+    ],
+    "categories": [
+        {
+            "categoryid": "77583",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Add Ons",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77581",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Beverages",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77585",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Chicken",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77578",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Chicken Meal",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77584",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Desserts",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77582",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Hot Coffees",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77579",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Seafood Meal",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77580",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Side Orders",
+            "categorytimings": "",
+            "category_image_url": ""
+        }
+    ],
+    "parentcategories": [],
+    "items": [
+        {
+            "itemid": "10539634",
+            "itemallowvariation": "0",
+            "itemrank": "1",
+            "item_categoryid": "77578",
+            "item_ordertype": "1,2,3",
+            "item_packingcharges": "0",
+            "itemallowaddon": "0",
+            "itemaddonbasedon": "0",
+            "item_favorite": "0",
+            "ignore_taxes": "0",
+            "ignore_discounts": "0",
+            "in_stock": "2",
+            "cuisine": [],
+            "variation_groupname": "",
+            "variation": [],
+            "addon": [],
+            "is_recommend": "0",
+            "itemname": "Potter 4",
+            "item_attributeid": "1",
+            "itemdescription": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+            "minimumpreparationtime": "",
+            "price": "8700.00",
+            "active": "1",
+            "item_image_url": "",
+            "item_tax": "2524,2525",
+            "gst_type": "services"
+        },
+        {
+            "itemid": "10539699",
+            "itemallowvariation": "0",
+            "itemrank": "1",
+            "item_categoryid": "77578",
+            "item_ordertype": "1,2,3",
+            "item_packingcharges": "0",
+            "itemallowaddon": "0",
+            "itemaddonbasedon": "0",
+            "item_favorite": "0",
+            "ignore_taxes": "0",
+            "ignore_discounts": "0",
+            "in_stock": "2",
+            "cuisine": [],
+            "variation_groupname": "",
+            "variation": [],
+            "addon": [],
+            "is_recommend": "0",
+            "itemname": "Potter 99",
+            "item_attributeid": "1",
+            "itemdescription": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+            "minimumpreparationtime": "",
+            "price": "3426.00",
+            "active": "1",
+            "item_image_url": "",
+            "item_tax": "2524,2525",
+            "gst_type": "services"
+        },
+        {
+            "itemid": "10539580",
+            "itemallowvariation": "0",
+            "itemrank": "1",
+            "item_categoryid": "77578",
+            "item_ordertype": "1,2,3",
+            "item_packingcharges": "0",
+            "itemallowaddon": "1",
+            "itemaddonbasedon": "0",
+            "item_favorite": "0",
+            "ignore_taxes": "0",
+            "ignore_discounts": "0",
+            "in_stock": "2",
+            "cuisine": [],
+            "variation_groupname": "",
+            "variation": [],
+            "addon": [
+                {
+                    "addon_group_id": "11425",
+                    "addon_item_selection_min": "1",
+                    "addon_item_selection_max": "1"
+                }
+            ],
+            "is_recommend": "0",
+            "itemname": "Potter 5",
+            "item_attributeid": "1",
+            "itemdescription": "chicken fillet  nuggets come with a sauce of your choice (nugget\/garlic sauce). Bite-sized pieces of tender all breast chicken fillets, marinated in our unique & signature blend, breaded and seasoned to perfection, then deep-fried until deliciously tender, crispy with a golden crust",
+            "minimumpreparationtime": "",
+            "price": "3159.00",
+            "active": "1",
+            "item_image_url": "",
+            "item_tax": "2524,2525",
+            "gst_type": "services"
+        }
+    ],
+    "variations": [],
+    "addongroups": [],
+    "attributes": [
+        {
+            "attributeid": "1",
+            "attribute": "veg",
+            "active": "1"
+        },
+        {
+            "attributeid": "2",
+            "attribute": "non-veg",
+            "active": "1"
+        }
+    ],
+    "taxes": [
+        {
+            "taxid": "2524",
+            "taxname": "CGST",
+            "tax": "2.5",
+            "taxtype": "1",
+            "tax_ordertype": "",
+            "active": "1",
+            "tax_coreortotal": "2",
+            "tax_taxtype": "1",
+            "rank": "1",
+            "consider_in_core_amount": "0",
+            "description": ""
+        },
+        {
+            "taxid": "2525",
+            "taxname": "SGST",
+            "tax": "2.5",
+            "taxtype": "1",
+            "tax_ordertype": "",
+            "active": "1",
+            "tax_coreortotal": "2",
+            "tax_taxtype": "1",
+            "rank": "2",
+            "consider_in_core_amount": "0",
+            "description": ""
+        }
+    ],
+    "discounts": [],
+    "serverdatetime": "2024-08-05 16:40:42",
+    "db_version": "1.0",
+    "application_version": "4.0",
+    "http_code": 200,
+    "error": ""
+}

--- a/tests/testing_data/catalog_sync/catalog_sync_push_menu_payload_invalid.json
+++ b/tests/testing_data/catalog_sync/catalog_sync_push_menu_payload_invalid.json
@@ -1,0 +1,269 @@
+{
+    "success": "1",
+    "message": "Menu items are successfully listed.",
+    "restaurants": [
+        {
+            "restaurantid": "4639",
+            "active": "1",
+            "details": {
+                "menusharingcode": "nu0wisf4",
+                "currency_html": "&#8377;",
+                "country": "India",
+                "country_id": "97",
+                "images": [],
+                "restaurantname": "Indisubb Foods Private Limited",
+                "address": "Ahmedabad",
+                "contact": "1234567890",
+                "latitude": "1",
+                "longitude": "1",
+                "landmark": "",
+                "city": "Ahmedabad",
+                "city_id": "1321851",
+                "state": "Gujarat",
+                "state_id": "1612",
+                "minimumorderamount": "0",
+                "minimumdeliverytime": "30 Minutes",
+                "deliverycharge": "0",
+                "deliveryhoursfrom1": "",
+                "deliveryhoursto1": "",
+                "deliveryhoursfrom2": "",
+                "deliveryhoursto2": "",
+                "calculatetaxonpacking": 0,
+                "calculatetaxondelivery": 0,
+                "dc_taxes_id": "",
+                "pc_taxes_id": "",
+                "packaging_applicable_on": "NONE",
+                "packaging_charge": "",
+                "packaging_charge_type": ""
+            }
+        }
+    ],
+    "ordertypes": [
+        {
+            "ordertypeid": 1,
+            "ordertype": "Delivery"
+        },
+        {
+            "ordertypeid": 2,
+            "ordertype": "Pick Up"
+        },
+        {
+            "ordertypeid": 3,
+            "ordertype": "Dine In"
+        }
+    ],
+    "categories": [
+        {
+            "categoryid": "77583",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Add Ons",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77581",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Beverages",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77585",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Chicken",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77578",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Chicken Meal",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77584",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Desserts",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77582",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Hot Coffees",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77579",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Seafood Meal",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77580",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Side Orders",
+            "categorytimings": "",
+            "category_image_url": ""
+        }
+    ],
+    "parentcategories": [],
+    "items": [
+        {
+            "itemid": "10539634",
+            "itemallowvariation": "0",
+            "itemrank": "1",
+            "item_categoryid": "77578",
+            "item_ordertype": "1,2,3",
+            "item_packingcharges": "0",
+            "itemallowaddon": "0",
+            "itemaddonbasedon": "0",
+            "item_favorite": "0",
+            "ignore_taxes": "0",
+            "ignore_discounts": "0",
+            "in_stock": "2",
+            "cuisine": [],
+            "variation_groupname": "",
+            "variation": [],
+            "addon": [],
+            "is_recommend": "0",
+            "itemname": "Potter 4",
+            "item_attributeid": "1",
+            "itemdescription": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+            "minimumpreparationtime": "",
+            "price": "8700.00",
+            "active": "1",
+            "item_image_url": "",
+            "item_tax": "2524,2525",
+            "gst_type": "services"
+        },
+        {
+            "itemallowvariation": "0",
+            "itemrank": "1",
+            "item_categoryid": "77578",
+            "item_ordertype": "1,2,3",
+            "item_packingcharges": "0",
+            "itemallowaddon": "0",
+            "itemaddonbasedon": "0",
+            "item_favorite": "0",
+            "ignore_taxes": "0",
+            "ignore_discounts": "0",
+            "in_stock": "2",
+            "cuisine": [],
+            "variation_groupname": "",
+            "variation": [],
+            "addon": [],
+            "is_recommend": "0",
+            "itemname": "Potter 99",
+            "item_attributeid": "1",
+            "itemdescription": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+            "minimumpreparationtime": "",
+            "price": "3426.00",
+            "active": "1",
+            "item_image_url": "",
+            "item_tax": "2524,2525",
+            "gst_type": "services"
+        },
+        {
+            "itemid": "10539580",
+            "itemallowvariation": "0",
+            "itemrank": "1",
+            "item_categoryid": "77578",
+            "item_ordertype": "1,2,3",
+            "item_packingcharges": "0",
+            "itemallowaddon": "1",
+            "itemaddonbasedon": "0",
+            "item_favorite": "0",
+            "ignore_taxes": "0",
+            "ignore_discounts": "0",
+            "in_stock": "2",
+            "cuisine": [],
+            "variation_groupname": "",
+            "variation": [],
+            "addon": [
+                {
+                    "addon_group_id": "11425",
+                    "addon_item_selection_min": "1",
+                    "addon_item_selection_max": "1"
+                }
+            ],
+            "is_recommend": "0",
+            "itemname": "Potter 5",
+            "item_attributeid": "1",
+            "itemdescription": "chicken fillet  nuggets come with a sauce of your choice (nugget\/garlic sauce). Bite-sized pieces of tender all breast chicken fillets, marinated in our unique & signature blend, breaded and seasoned to perfection, then deep-fried until deliciously tender, crispy with a golden crust",
+            "minimumpreparationtime": "",
+            "price": "3159.00",
+            "active": "1",
+            "item_image_url": "",
+            "item_tax": "2524,2525",
+            "gst_type": "services"
+        }
+    ],
+    "variations": [],
+    "addongroups": [],
+    "attributes": [
+        {
+            "attributeid": "1",
+            "attribute": "veg",
+            "active": "1"
+        },
+        {
+            "attributeid": "2",
+            "attribute": "non-veg",
+            "active": "1"
+        }
+    ],
+    "taxes": [
+        {
+            "taxid": "2524",
+            "taxname": "CGST",
+            "tax": "2.5",
+            "taxtype": "1",
+            "tax_ordertype": "",
+            "active": "1",
+            "tax_coreortotal": "2",
+            "tax_taxtype": "1",
+            "rank": "1",
+            "consider_in_core_amount": "0",
+            "description": ""
+        },
+        {
+            "taxid": "2525",
+            "taxname": "SGST",
+            "tax": "2.5",
+            "taxtype": "1",
+            "tax_ordertype": "",
+            "active": "1",
+            "tax_coreortotal": "2",
+            "tax_taxtype": "1",
+            "rank": "2",
+            "consider_in_core_amount": "0",
+            "description": ""
+        }
+    ],
+    "discounts": [],
+    "serverdatetime": "2024-08-05 16:40:42",
+    "db_version": "1.0",
+    "application_version": "4.0",
+    "http_code": 200,
+    "error": ""
+}

--- a/tests/testing_data/catalog_sync/catalog_sync_push_menu_payload_with_delete_data.json
+++ b/tests/testing_data/catalog_sync/catalog_sync_push_menu_payload_with_delete_data.json
@@ -1,0 +1,242 @@
+{
+    "success": "1",
+    "message": "Menu items are successfully listed.",
+    "restaurants": [
+        {
+            "restaurantid": "4639",
+            "active": "1",
+            "details": {
+                "menusharingcode": "nu0wisf4",
+                "currency_html": "&#8377;",
+                "country": "India",
+                "country_id": "97",
+                "images": [],
+                "restaurantname": "Indisubb Foods Private Limited",
+                "address": "Ahmedabad",
+                "contact": "1234567890",
+                "latitude": "1",
+                "longitude": "1",
+                "landmark": "",
+                "city": "Ahmedabad",
+                "city_id": "1321851",
+                "state": "Gujarat",
+                "state_id": "1612",
+                "minimumorderamount": "0",
+                "minimumdeliverytime": "30 Minutes",
+                "deliverycharge": "0",
+                "deliveryhoursfrom1": "",
+                "deliveryhoursto1": "",
+                "deliveryhoursfrom2": "",
+                "deliveryhoursto2": "",
+                "calculatetaxonpacking": 0,
+                "calculatetaxondelivery": 0,
+                "dc_taxes_id": "",
+                "pc_taxes_id": "",
+                "packaging_applicable_on": "NONE",
+                "packaging_charge": "",
+                "packaging_charge_type": ""
+            }
+        }
+    ],
+    "ordertypes": [
+        {
+            "ordertypeid": 1,
+            "ordertype": "Delivery"
+        },
+        {
+            "ordertypeid": 2,
+            "ordertype": "Pick Up"
+        },
+        {
+            "ordertypeid": 3,
+            "ordertype": "Dine In"
+        }
+    ],
+    "categories": [
+        {
+            "categoryid": "77583",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Add Ons",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77581",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Beverages",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77585",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Chicken",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77578",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Chicken Meal",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77584",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Desserts",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77582",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Hot Coffees",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77579",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Seafood Meal",
+            "categorytimings": "",
+            "category_image_url": ""
+        },
+        {
+            "categoryid": "77580",
+            "active": "1",
+            "categoryrank": "1",
+            "parent_category_id": "0",
+            "categoryname": "Side Orders",
+            "categorytimings": "",
+            "category_image_url": ""
+        }
+    ],
+    "parentcategories": [],
+    "items": [
+        {
+            "itemid": "10539699",
+            "itemallowvariation": "0",
+            "itemrank": "1",
+            "item_categoryid": "77578",
+            "item_ordertype": "1,2,3",
+            "item_packingcharges": "0",
+            "itemallowaddon": "0",
+            "itemaddonbasedon": "0",
+            "item_favorite": "0",
+            "ignore_taxes": "0",
+            "ignore_discounts": "0",
+            "in_stock": "2",
+            "cuisine": [],
+            "variation_groupname": "",
+            "variation": [],
+            "addon": [],
+            "is_recommend": "0",
+            "itemname": "Potter 99",
+            "item_attributeid": "1",
+            "itemdescription": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+            "minimumpreparationtime": "",
+            "price": "123.00",
+            "active": "1",
+            "item_image_url": "",
+            "item_tax": "2524,2525",
+            "gst_type": "services"
+        },
+        {
+            "itemid": "10539580",
+            "itemallowvariation": "0",
+            "itemrank": "1",
+            "item_categoryid": "77578",
+            "item_ordertype": "1,2,3",
+            "item_packingcharges": "0",
+            "itemallowaddon": "1",
+            "itemaddonbasedon": "0",
+            "item_favorite": "0",
+            "ignore_taxes": "0",
+            "ignore_discounts": "0",
+            "in_stock": "2",
+            "cuisine": [],
+            "variation_groupname": "",
+            "variation": [],
+            "addon": [
+                {
+                    "addon_group_id": "11425",
+                    "addon_item_selection_min": "1",
+                    "addon_item_selection_max": "1"
+                }
+            ],
+            "is_recommend": "0",
+            "itemname": "Potter 5",
+            "item_attributeid": "1",
+            "itemdescription": "chicken fillet  nuggets come with a sauce of your choice (nugget\/garlic sauce). Bite-sized pieces of tender all breast chicken fillets, marinated in our unique & signature blend, breaded and seasoned to perfection, then deep-fried until deliciously tender, crispy with a golden crust",
+            "minimumpreparationtime": "",
+            "price": "3159.00",
+            "active": "1",
+            "item_image_url": "",
+            "item_tax": "2524,2525",
+            "gst_type": "services"
+        }
+    ],
+    "variations": [],
+    "addongroups": [],
+    "attributes": [
+        {
+            "attributeid": "1",
+            "attribute": "veg",
+            "active": "1"
+        },
+        {
+            "attributeid": "2",
+            "attribute": "non-veg",
+            "active": "1"
+        }
+    ],
+    "taxes": [
+        {
+            "taxid": "2524",
+            "taxname": "CGST",
+            "tax": "2.5",
+            "taxtype": "1",
+            "tax_ordertype": "",
+            "active": "1",
+            "tax_coreortotal": "2",
+            "tax_taxtype": "1",
+            "rank": "1",
+            "consider_in_core_amount": "0",
+            "description": ""
+        },
+        {
+            "taxid": "2525",
+            "taxname": "SGST",
+            "tax": "2.5",
+            "taxtype": "1",
+            "tax_ordertype": "",
+            "active": "1",
+            "tax_coreortotal": "2",
+            "tax_taxtype": "1",
+            "rank": "2",
+            "consider_in_core_amount": "0",
+            "description": ""
+        }
+    ],
+    "discounts": [],
+    "serverdatetime": "2024-08-05 16:40:42",
+    "db_version": "1.0",
+    "application_version": "4.0",
+    "http_code": 200,
+    "error": ""
+}

--- a/tests/unit_test/action/action_test.py
+++ b/tests/unit_test/action/action_test.py
@@ -3327,7 +3327,8 @@ class TestActions:
                                 'content_importer_limit_per_day': 5,
                                 'integrations_per_user_limit': 3,
                                 'live_agent_enabled': False,
-                                'retry_broadcasting_limit': 3}
+                                'retry_broadcasting_limit': 3,
+                                'catalog_sync_limit_per_day': 5}
 
     def test_prompt_action_not_exists(self):
         with pytest.raises(ActionFailure, match="Faq feature is disabled for the bot! Please contact support."):
@@ -4629,7 +4630,8 @@ class TestActions:
                                 'cognition_columns_per_collection_limit': 5,
                                 'integrations_per_user_limit': 3,
                                 'live_agent_enabled': False,
-                                'retry_broadcasting_limit': 3}
+                                'retry_broadcasting_limit': 3,
+                                'catalog_sync_limit_per_day': 5}
 
 
     def test_get_prompt_action_config_2(self):

--- a/tests/unit_test/data_processor/catalog_sync_log_processor_test.py
+++ b/tests/unit_test/data_processor/catalog_sync_log_processor_test.py
@@ -120,13 +120,6 @@ class TestCatalogSyncLogProcessor:
         bot = 'test'
         logs = list(CatalogSyncLogProcessor.get_logs(bot))
         assert len(logs) == 4
-        # bot_settings = BotSettings.objects(bot=bot).get()
-        # bot_settings.catalog_sync_limit_per_day = 3
-        # print(bot_settings.to_mongo().to_dict())
-        # bot_settings.save()
-        # logs = list(CatalogSyncLogProcessor.get_logs(bot))
-        # print(logs)
-        # assert CatalogSyncLogProcessor.is_limit_exceeded(bot, False)
 
     def test_is_limit_exceeded_exception(self, monkeypatch):
         bot = 'test'
@@ -146,10 +139,7 @@ class TestCatalogSyncLogProcessor:
             bot_settings.catalog_sync_limit_per_day = 3
         except:
             bot_settings = BotSettings(bot=bot, catalog_sync_limit_per_day=0, user="test")
-        print(bot_settings.to_mongo().to_dict())
         bot_settings.save()
-        logs = list(CatalogSyncLogProcessor.get_logs(bot))
-        print(logs)
         assert CatalogSyncLogProcessor.is_limit_exceeded(bot, False)
 
     def test_is_limit_exceeded_false(self, monkeypatch):

--- a/tests/unit_test/data_processor/catalog_sync_log_processor_test.py
+++ b/tests/unit_test/data_processor/catalog_sync_log_processor_test.py
@@ -1,0 +1,585 @@
+import json
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+from babel.messages.jslexer import uni_escape_re
+from mongoengine import connect
+
+from kairon import Utility
+from kairon.exceptions import AppException
+from kairon.shared.catalog_sync.catalog_sync_log_processor import CatalogSyncLogProcessor
+from kairon.shared.catalog_sync.data_objects import CatalogSyncLogs
+from kairon.shared.cognition.data_objects import CognitionSchema, CollectionData
+from kairon.shared.cognition.processor import CognitionDataProcessor
+from kairon.shared.data.constant import SYNC_STATUS, SyncType
+from kairon.shared.data.data_objects import BotSettings, BotSyncConfig
+
+
+class TestCatalogSyncLogProcessor:
+
+    @pytest.fixture(scope='session', autouse=True)
+    def init(self):
+        os.environ["system_file"] = "./tests/testing_data/system.yaml"
+        Utility.load_environment()
+        connect(**Utility.mongoengine_connection(Utility.environment['database']["url"]))
+
+
+    def test_add_log(self):
+        bot = 'test'
+        user = 'test'
+        provider = "petpooja"
+        sync_type = "push_menu"
+        CatalogSyncLogProcessor.add_log(bot, user, provider = provider, sync_type = sync_type,raw_payload={"item":"Test raw payload"})
+        log = CatalogSyncLogs.objects(bot=bot).get().to_mongo().to_dict()
+        assert not log.get('exception')
+        assert log['execution_id']
+        assert log['raw_payload']
+        assert log['sync_type']
+        assert log['start_timestamp']
+        assert not log.get('end_timestamp')
+        assert not log.get('processed_payload')
+        assert log['sync_status'] == SYNC_STATUS.INITIATED.value
+
+    def test_add_log_exception(self):
+        bot = 'test'
+        user = 'test'
+        CatalogSyncLogProcessor.add_log(bot, user, sync_status=SYNC_STATUS.FAILED.value,
+                                        exception="Push menu processing is disabled for this bot",
+                                        status="Failure")
+        log = CatalogSyncLogs.objects(bot=bot).get().to_mongo().to_dict()
+        assert log.get('exception') == "Push menu processing is disabled for this bot"
+        assert log['execution_id']
+        assert log['raw_payload']
+        assert log['sync_type']
+        assert log['start_timestamp']
+        assert log.get('end_timestamp')
+        assert log['sync_status'] == SYNC_STATUS.FAILED.value
+
+
+    def test_add_log_validation_errors(self):
+        bot = 'test'
+        user = 'test'
+        provider = "petpooja"
+        sync_type = "push_menu"
+        CatalogSyncLogProcessor.add_log(bot, user, provider = provider, sync_type = sync_type,raw_payload={"item":"Test raw payload"},
+                                        sync_status=SYNC_STATUS.FAILED.value,
+                                        exception="Validation Failed",
+                                        status="Failure",
+                                        validation_errors={
+                                            "Header mismatch": "Expected headers ['order_id', 'order_priority', 'sales', 'profit'] but found ['order_id', 'order_priority', 'revenue', 'sales'].",
+                                            "Missing columns": "{'profit'}.",
+                                            "Extra columns": "{'revenue'}."
+                                        }
+                                        )
+        log = list(CatalogSyncLogProcessor.get_logs(bot))
+        assert log[0].get('exception') == "Validation Failed"
+        assert log[0]['execution_id']
+        assert log[0]['raw_payload']
+        assert log[0]['sync_type']
+        assert log[0]['start_timestamp']
+        assert log[0]["validation_errors"]
+        assert log[0].get('end_timestamp')
+        assert log[0]['sync_status'] == SYNC_STATUS.FAILED.value
+
+    def test_add_log_success(self):
+        bot = 'test'
+        user = 'test'
+        provider = "petpooja"
+        sync_type = "push_menu"
+        CatalogSyncLogProcessor.add_log(bot, user, provider = provider, sync_type = sync_type,raw_payload={"item":"Test raw payload"})
+        CatalogSyncLogProcessor.add_log(bot, user, sync_status=SYNC_STATUS.COMPLETED.value, status="Success")
+        log = list(CatalogSyncLogProcessor.get_logs(bot))
+        assert not log[0].get('exception')
+        assert log[0]['execution_id']
+        assert log[0]['raw_payload']
+        assert log[0]['sync_type']
+        assert log[0]['start_timestamp']
+        assert not log[0]["validation_errors"]
+        assert log[0]["status"] == 'Success'
+        assert log[0]['sync_status'] == SYNC_STATUS.COMPLETED.value
+
+    def test_is_event_in_progress_false(self):
+        bot = 'test'
+        assert not CatalogSyncLogProcessor.is_sync_in_progress(bot)
+
+    def test_is_event_in_progress_true(self):
+        bot = 'test'
+        user = 'test'
+        provider = "petpooja"
+        sync_type = "push_menu"
+        CatalogSyncLogProcessor.add_log(bot, user, provider=provider, sync_type=sync_type,
+                                        raw_payload={"item": "Test raw payload"})
+        assert CatalogSyncLogProcessor.is_sync_in_progress(bot, False)
+
+        with pytest.raises(Exception):
+            CatalogSyncLogProcessor.is_sync_in_progress(bot)
+
+    def test_get_logs(self):
+        bot = 'test'
+        logs = list(CatalogSyncLogProcessor.get_logs(bot))
+        assert len(logs) == 4
+        # bot_settings = BotSettings.objects(bot=bot).get()
+        # bot_settings.catalog_sync_limit_per_day = 3
+        # print(bot_settings.to_mongo().to_dict())
+        # bot_settings.save()
+        # logs = list(CatalogSyncLogProcessor.get_logs(bot))
+        # print(logs)
+        # assert CatalogSyncLogProcessor.is_limit_exceeded(bot, False)
+
+    def test_is_limit_exceeded_exception(self, monkeypatch):
+        bot = 'test'
+        try:
+            bot_settings = BotSettings.objects(bot=bot).get()
+            bot_settings.catalog_sync_limit_per_day = 0
+        except:
+            bot_settings = BotSettings(bot=bot, catalog_sync_limit_per_day=0, user="test")
+        bot_settings.save()
+        with pytest.raises(Exception):
+            assert CatalogSyncLogProcessor.is_limit_exceeded(bot)
+
+    def test_is_limit_exceeded(self, monkeypatch):
+        bot = 'test'
+        try:
+            bot_settings = BotSettings.objects(bot=bot).get()
+            bot_settings.catalog_sync_limit_per_day = 3
+        except:
+            bot_settings = BotSettings(bot=bot, catalog_sync_limit_per_day=0, user="test")
+        print(bot_settings.to_mongo().to_dict())
+        bot_settings.save()
+        logs = list(CatalogSyncLogProcessor.get_logs(bot))
+        print(logs)
+        assert CatalogSyncLogProcessor.is_limit_exceeded(bot, False)
+
+    def test_is_limit_exceeded_false(self, monkeypatch):
+        bot = 'test'
+        bot_settings = BotSettings.objects(bot=bot).get()
+        bot_settings.catalog_sync_limit_per_day = 6
+        bot_settings.save()
+        assert not CatalogSyncLogProcessor.is_limit_exceeded(bot)
+
+    def test_catalog_collection_exists_true(self):
+        bot = "test"
+        user = "test"
+
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch A",
+            branch_bot=bot,
+            user=user
+        ).save()
+
+        expected_collection = "test_restaurant_branch_a_catalog"
+
+        CognitionSchema(
+            bot=bot,
+            user=user,
+            collection_name=expected_collection
+        ).save()
+
+        assert CatalogSyncLogProcessor.is_catalog_collection_exists(bot) is True
+
+        BotSyncConfig.objects.delete()
+        CognitionSchema.objects.delete()
+
+    def test_catalog_collection_exists_false(self):
+        bot = "test"
+        user = "test"
+
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch A",
+            branch_bot=bot,
+            user=user
+        ).save()
+
+        assert CatalogSyncLogProcessor.is_catalog_collection_exists(bot) is False
+
+        BotSyncConfig.objects.delete()
+        CognitionSchema.objects.delete()
+
+    def test_create_catalog_collection(self):
+        bot = "test_bot"
+        user = "test_user"
+
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo_provider",
+            branch_name="Test Branch",
+            branch_bot=bot,
+            user=user
+        ).save()
+
+        BotSettings(
+            bot=bot,
+            user=user,
+            cognition_columns_per_collection_limit=5,
+            llm_settings={'enable_faq': True}
+        ).save()
+
+        metadata_id = CatalogSyncLogProcessor.create_catalog_collection(bot, user)
+
+        assert metadata_id is not None
+
+        catalog_name = "test_restaurant_test_branch_catalog"
+        created_schema = CognitionSchema.objects(collection_name=catalog_name).first()
+        assert created_schema is not None
+        assert created_schema.collection_name == catalog_name
+
+        BotSyncConfig.objects.delete()
+        BotSettings.objects.delete()
+        CognitionSchema.objects.delete()
+
+    def test_validate_item_ids(self):
+        push_menu_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_push_menu_payload.json")
+
+        with push_menu_payload_path.open("r", encoding="utf-8") as f:
+            push_menu_payload = json.load(f)
+
+        try:
+            CatalogSyncLogProcessor.validate_item_ids(push_menu_payload)
+            itemid_missing = False
+        except Exception as e:
+            itemid_missing = True
+
+        assert itemid_missing is False
+
+    def test_validate_item_ids_missing_itemid(self):
+        push_menu_payload_path = Path("tests/testing_data/catalog_sync/catalog_sync_push_menu_payload_invalid.json")
+
+        with push_menu_payload_path.open("r", encoding="utf-8") as f:
+            push_menu_payload = json.load(f)
+
+        with pytest.raises(Exception):
+            CatalogSyncLogProcessor.validate_item_ids(push_menu_payload)
+
+    def test_validate_item_toggle_request_valid(self):
+        file_path = Path("tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload.json")
+        with file_path.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+
+        CatalogSyncLogProcessor.validate_item_toggle_request(payload)
+
+    def test_validate_item_toggle_request_missing_instock(self):
+        file_path = Path("tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload_invalid_missing_instock.json")
+        with file_path.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+
+        with pytest.raises(Exception, match="Missing required field: 'inStock'"):
+            CatalogSyncLogProcessor.validate_item_toggle_request(payload)
+
+    def test_validate_item_toggle_request_nonboolean_instock(self):
+        file_path = Path("tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload_invalid_nonboolean_instock.json")
+        with file_path.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+
+        with pytest.raises(Exception, match="'inStock' must be a boolean"):
+            CatalogSyncLogProcessor.validate_item_toggle_request(payload)
+
+    def test_validate_item_toggle_request_missing_itemid(self):
+        file_path = Path("tests/testing_data/catalog_sync/catalog_sync_item_toggle_payload_invalid_missing_itemid.json")
+        with file_path.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+
+        with pytest.raises(Exception, match="Missing required field: 'itemID'"):
+            CatalogSyncLogProcessor.validate_item_toggle_request(payload)
+
+    def test_sync_type_allowed_valid_push_menu(self):
+        bot = "test_bot"
+        user = "test_user"
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch",
+            branch_bot=bot,
+            user=user,
+            process_push_menu=True,
+            process_item_toggle=False
+        ).save()
+
+        CatalogSyncLogProcessor.is_sync_type_allowed(bot, SyncType.push_menu)
+
+        BotSyncConfig.objects.delete()
+
+    def test_sync_type_allowed_valid_item_toggle(self):
+        bot = "test_bot"
+        user = "test_user"
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch",
+            branch_bot=bot,
+            user=user,
+            process_push_menu=False,
+            process_item_toggle=True
+        ).save()
+
+        CatalogSyncLogProcessor.is_sync_type_allowed(bot, SyncType.item_toggle)
+
+        BotSyncConfig.objects.delete()
+
+    def test_sync_type_push_menu_not_allowed(self):
+        bot = "test_bot"
+        user = "test_user"
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch",
+            branch_bot=bot,
+            user=user,
+            process_push_menu=False,
+            process_item_toggle=True
+        ).save()
+
+        with pytest.raises(Exception, match="Push menu processing is disabled for this bot"):
+            CatalogSyncLogProcessor.is_sync_type_allowed(bot, SyncType.push_menu)
+
+        BotSyncConfig.objects.delete()
+
+    def test_sync_type_item_toggle_not_allowed(self):
+        bot = "test_bot"
+        user = "test_user"
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch",
+            branch_bot=bot,
+            user=user,
+            process_push_menu=True,
+            process_item_toggle=False
+        ).save()
+
+        with pytest.raises(Exception, match="Item toggle is disabled for this bot"):
+            CatalogSyncLogProcessor.is_sync_type_allowed(bot, SyncType.item_toggle)
+
+        BotSyncConfig.objects.delete()
+
+    def test_sync_type_config_missing(self):
+        bot = "test_bot"
+        BotSyncConfig.objects.delete()
+
+        with pytest.raises(Exception, match="No bot sync config found for bot"):
+            CatalogSyncLogProcessor.is_sync_type_allowed(bot, SyncType.push_menu)
+
+    def test_ai_enabled_true(self):
+        bot = "test_bot"
+        user = "test_user"
+
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch",
+            branch_bot=bot,
+            user=user,
+            ai_enabled=True
+        ).save()
+
+        result = CatalogSyncLogProcessor.is_ai_enabled(bot)
+        assert result is True
+
+        BotSyncConfig.objects.delete()
+
+    def test_ai_enabled_false(self):
+        bot = "test_bot"
+        user = "test_user"
+
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch",
+            branch_bot=bot,
+            user=user,
+            ai_enabled=False
+        ).save()
+
+        result = CatalogSyncLogProcessor.is_ai_enabled(bot)
+        assert result is False
+
+        BotSyncConfig.objects.delete()
+
+    def test_ai_enabled_no_config(self):
+        bot = "test_bot"
+        BotSyncConfig.objects.delete()
+
+        with pytest.raises(Exception, match="No bot sync config found for bot"):
+            CatalogSyncLogProcessor.is_ai_enabled(bot)
+
+    def test_meta_enabled_true(self):
+        bot = "test_bot"
+        user = "test_user"
+
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch",
+            branch_bot=bot,
+            user=user,
+            meta_enabled=True
+        ).save()
+
+        result = CatalogSyncLogProcessor.is_meta_enabled(bot)
+        assert result is True
+
+        BotSyncConfig.objects.delete()
+
+    def test_meta_enabled_false(self):
+        bot = "test_bot"
+        user = "test_user"
+
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo",
+            branch_name="Branch",
+            branch_bot=bot,
+            user=user,
+            meta_enabled=False
+        ).save()
+
+        result = CatalogSyncLogProcessor.is_meta_enabled(bot)
+        assert result is False
+
+        BotSyncConfig.objects.delete()
+
+    def test_meta_enabled_no_config(self):
+        bot = "test_bot"
+        BotSyncConfig.objects.delete()
+
+        with pytest.raises(Exception, match="No bot sync config found for bot"):
+            CatalogSyncLogProcessor.is_meta_enabled(bot)
+
+    def test_get_execution_id_for_bot_returns_latest_pending(self):
+        bot = "test_bot"
+        user = "test_user"
+
+        CatalogSyncLogs(
+            execution_id="completed_1",
+            raw_payload={"item":"Test raw payload"},
+            bot=bot,
+            user=user,
+            provider="demo",
+            sync_type="push_menu",
+            sync_status=SYNC_STATUS.COMPLETED.value,
+            start_timestamp=datetime.utcnow() - timedelta(minutes=10)
+        ).save()
+
+        CatalogSyncLogs(
+            execution_id="failed_1",
+            raw_payload={"item":"Test raw payload"},
+            bot=bot,
+            user=user,
+            provider="demo",
+            sync_type="push_menu",
+            sync_status=SYNC_STATUS.FAILED.value,
+            start_timestamp=datetime.utcnow() - timedelta(minutes=5)
+        ).save()
+
+        CatalogSyncLogs(
+            execution_id="valid_pending_1",
+            raw_payload={"item":"Test raw payload"},
+            bot=bot,
+            user=user,
+            provider="demo",
+            sync_type="push_menu",
+            sync_status=SYNC_STATUS.PREPROCESSING.value,
+            start_timestamp=datetime.utcnow()
+        ).save()
+
+        execution_id = CatalogSyncLogProcessor.get_execution_id_for_bot(bot)
+        assert execution_id == "valid_pending_1"
+
+        CatalogSyncLogs.objects.delete()
+
+    def test_get_execution_id_for_bot_returns_none_if_all_completed_or_failed(self):
+        bot = "test_bot"
+        user = "test_user"
+
+        CatalogSyncLogs(
+            execution_id="completed_2",
+            raw_payload={"item":"Test raw payload"},
+            bot=bot,
+            user=user,
+            provider="demo",
+            sync_type="push_menu",
+            sync_status=SYNC_STATUS.COMPLETED.value,
+            start_timestamp=datetime.utcnow()
+        ).save()
+
+        CatalogSyncLogs(
+            execution_id="failed_2",
+            raw_payload={"item":"Test raw payload"},
+            bot=bot,
+            user=user,
+            provider="demo",
+            sync_type="push_menu",
+            sync_status=SYNC_STATUS.FAILED.value,
+            start_timestamp=datetime.utcnow()
+        ).save()
+
+        execution_id = CatalogSyncLogProcessor.get_execution_id_for_bot(bot)
+        assert execution_id is None
+
+        CatalogSyncLogs.objects.delete()
+
+    def test_validate_image_configurations_when_catalog_images_exists(self):
+        bot = "test_bot"
+        user = "test_user"
+
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo_provider",
+            branch_name="Test Branch",
+            branch_bot=bot,
+            user=user
+        ).save()
+
+        CollectionData(
+            collection_name="test_restaurant_test_branch_catalog_images",
+            data={
+                "image_type": "global",
+                "image_url": "http://example.com/global_fallback.jpg",
+                "image_base64": ""
+            },
+            user=user,
+            bot=bot,
+            status=True,
+            timestamp=datetime.utcnow()
+        ).save()
+
+        CatalogSyncLogProcessor.validate_image_configurations(bot, user)
+
+        BotSyncConfig.objects.delete()
+        CollectionData.objects.delete()
+
+    def test_validate_image_configurations_when_catalog_images_missing_global_fallback(self):
+        bot = "test_bot"
+        user = "test_user"
+
+        BotSyncConfig(
+            parent_bot=bot,
+            restaurant_name="Test Restaurant",
+            provider="demo_provider",
+            branch_name="Test Branch",
+            branch_bot=bot,
+            user=user
+        ).save()
+
+        with pytest.raises(Exception, match="Global fallback image URL not found"):
+            CatalogSyncLogProcessor.validate_image_configurations(bot, user)
+
+        BotSyncConfig.objects.delete()
+        CollectionData.objects.delete()

--- a/tests/unit_test/data_processor/data_processor_test.py
+++ b/tests/unit_test/data_processor/data_processor_test.py
@@ -15763,8 +15763,6 @@ class TestMongoProcessor:
         processor.update_multiflow_story(pytest.multiflow_story_id, story_dict, "test")
         story = MultiflowStories.objects(block_name="updated_story", bot="test").get()
         assert story.events[0]['connections'][0]['name'] == "utter_time"
-        # print(story.events[1].name)
-        # assert story.events[1].name == "utter_nonsense"
 
     def test_update_multiflow_story_with_same_events(self):
         processor = MongoProcessor()

--- a/tests/unit_test/meta/meta_processor_test.py
+++ b/tests/unit_test/meta/meta_processor_test.py
@@ -1,0 +1,439 @@
+import json
+import os
+from urllib.parse import unquote, urlparse, parse_qs
+
+import pytest
+import requests
+from mongoengine import connect
+from unittest.mock import patch, Mock
+from kairon import Utility
+from kairon.meta.processor import MetaProcessor
+from kairon.shared.catalog_sync.data_objects import CatalogProviderMapping
+
+os.environ["system_file"] = "./tests/testing_data/system.yaml"
+Utility.load_environment()
+Utility.load_system_metadata()
+
+class TestMetaProcessor:
+
+    @pytest.fixture(autouse=True, scope='class')
+    def init_connection(self):
+        connect(**Utility.mongoengine_connection())
+
+    def test_preprocess_data_create_success(self):
+        bot = "test_bot"
+        method = "CREATE"
+        catalog_id = "12345"
+        access_token = "test_token"
+        provider = "petpooja"
+
+        CatalogProviderMapping(
+            provider=provider,
+            meta_mappings={
+                "name": {"source": "itemname", "default": "No title"},
+                "description": {"source": "itemdescription", "default": "No description available"},
+                "price": {"source": "price", "default": 0.0},
+                "availability": {"source": "in_stock", "default": "out of stock"},
+                "image_url": {"source": "item_image_url", "default": "https://www.kairon.com/default-image.jpg"},
+                "url": {"source": None, "default": "https://www.kairon.com/"},
+                "brand": {"source": None, "default": "Sattva"},
+                "condition": {"source": None, "default": "new"}
+            },
+            kv_mappings={
+                "title": {"source": "itemname", "default": "No title"},
+                "description": {"source": "itemdescription", "default": "No description available"},
+                "price": {"source": "price", "default": 0.0},
+                "facebook_product_category": {"source": "item_categoryid", "default": "Food and drink > General"},
+                "availability": {"source": "in_stock", "default": "out of stock"}
+            }
+        ).save()
+
+        payload_data = [
+            {
+                "id": "10539634",
+                "name": "Potter 4",
+                "description": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                "price": 8700,
+                "availability": "in stock",
+                "image_url": "https://picsum.photos/id/237/200/300",
+                "url": "https://www.kairon.com/",
+                "brand": "Test Restaurant",
+                "condition": "new"
+            },
+            {
+                "id": "10539699",
+                "name": "Potter 99",
+                "description": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                "price": 3426,
+                "availability": "in stock",
+                "image_url": "https://picsum.photos/id/237/200/300",
+                "url": "https://www.kairon.com/",
+                "brand": "Test Restaurant",
+                "condition": "new"
+            },
+            {
+                "id": "10539580",
+                "name": "Potter 5",
+                "description": "chicken fillet  nuggets come with a sauce of your choice (nugget/garlic sauce). Bite-sized pieces of tender all breast chicken fillets, marinated in our unique & signature blend, breaded and seasoned to perfection, then deep-fried until deliciously tender, crispy with a golden crust",
+                "price": 3159,
+                "availability": "in stock",
+                "image_url": "https://picsum.photos/id/237/200/300",
+                "url": "https://www.kairon.com/",
+                "brand": "Test Restaurant",
+                "condition": "new"
+            }
+        ]
+
+        processor  = MetaProcessor(catalog_id=catalog_id, access_token=access_token)
+        processed_data = processor.preprocess_data(bot, payload_data, method, provider)
+        expected_processed_data = [
+            {
+                "retailer_id": "10539634",
+                "data": {
+                    "currency": "INR",
+                    "name": "Potter 4",
+                    "description": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                    "price": 8700,
+                    "availability": "in stock",
+                    "image_url": "https://picsum.photos/id/237/200/300",
+                    "url": "https://www.kairon.com/",
+                    "brand": "Test Restaurant",
+                    "condition": "new"
+                },
+                "method": "CREATE",
+                "item_type": "PRODUCT_ITEM"
+            },
+            {
+                "retailer_id": "10539699",
+                "data": {
+                    "currency": "INR",
+                    "name": "Potter 99",
+                    "description": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                    "price": 3426,
+                    "availability": "in stock",
+                    "image_url": "https://picsum.photos/id/237/200/300",
+                    "url": "https://www.kairon.com/",
+                    "brand": "Test Restaurant",
+                    "condition": "new"
+                },
+                "method": "CREATE",
+                "item_type": "PRODUCT_ITEM"
+            },
+            {
+                "retailer_id": "10539580",
+                "data": {
+                    "currency": "INR",
+                    "name": "Potter 5",
+                    "description": "chicken fillet  nuggets come with a sauce of your choice (nugget/garlic sauce). Bite-sized pieces of tender all breast chicken fillets, marinated in our unique & signature blend, breaded and seasoned to perfection, then deep-fried until deliciously tender, crispy with a golden crust",
+                    "price": 3159,
+                    "availability": "in stock",
+                    "image_url": "https://picsum.photos/id/237/200/300",
+                    "url": "https://www.kairon.com/",
+                    "brand": "Test Restaurant",
+                    "condition": "new"
+                },
+                "method": "CREATE",
+                "item_type": "PRODUCT_ITEM"
+            }
+        ]
+
+        assert processed_data == expected_processed_data
+        CatalogProviderMapping.objects.delete()
+
+
+    def test_preprocess_data_update_success(self):
+        bot = "test_bot"
+        method = "UPDATE"
+        catalog_id = "12345"
+        access_token = "test_token"
+        provider = "petpooja"
+
+        CatalogProviderMapping(
+            provider=provider,
+            meta_mappings={
+                "name": {"source": "itemname", "default": "No title"},
+                "description": {"source": "itemdescription", "default": "No description available"},
+                "price": {"source": "price", "default": 0.0},
+                "availability": {"source": "in_stock", "default": "out of stock"},
+                "image_url": {"source": "item_image_url", "default": "https://www.kairon.com/default-image.jpg"},
+                "url": {"source": None, "default": "https://www.kairon.com/"},
+                "brand": {"source": None, "default": "Test Restaurant"},
+                "condition": {"source": None, "default": "new"}
+            },
+            kv_mappings={
+                "title": {"source": "itemname", "default": "No title"},
+                "description": {"source": "itemdescription", "default": "No description available"},
+                "price": {"source": "price", "default": 0.0},
+                "facebook_product_category": {"source": "item_categoryid", "default": "Food and drink > General"},
+                "availability": {"source": "in_stock", "default": "out of stock"}
+            }
+        ).save()
+
+        payload_data = [
+            {"id": "10539580", "availability": "out of stock"},
+            {"id": "10539634", "availability": "out of stock"},
+        ]
+
+        processor  = MetaProcessor(catalog_id=catalog_id, access_token=access_token)
+        processed_data = processor.preprocess_data(bot, payload_data, method, provider)
+        expected_processed_data = [
+            {
+                "retailer_id": "10539580",
+                "data": {
+                    "availability": "out of stock"
+                },
+                "method": "UPDATE",
+                "item_type": "PRODUCT_ITEM"
+            },
+            {
+                "retailer_id": "10539634",
+                "data": {
+                    "availability": "out of stock"
+                },
+                "method": "UPDATE",
+                "item_type": "PRODUCT_ITEM"
+            }
+        ]
+
+        assert processed_data == expected_processed_data
+        CatalogProviderMapping.objects.delete()
+
+    def test_preprocess_delete_data_success(self):
+        catalog_id = "12345"
+        access_token = "test_token"
+
+        payload_data = ['10539580','10539634']
+
+        processor  = MetaProcessor(catalog_id=catalog_id, access_token=access_token)
+        processed_data = processor.preprocess_delete_data(payload_data)
+        expected_processed_data = [
+            {'retailer_id': '10539580', 'method': 'DELETE'},
+            {'retailer_id': '10539634', 'method': 'DELETE'}
+        ]
+
+        assert processed_data == expected_processed_data
+        CatalogProviderMapping.objects.delete()
+
+    @pytest.mark.asyncio
+    async def test_push_meta_catalog_success(self):
+        access_token = "test_token"
+        catalog_id = "12345"
+
+        processor = MetaProcessor(access_token=access_token, catalog_id=catalog_id)
+
+        processor.processed_data = [
+            {
+                "retailer_id": "10539634",
+                "data": {
+                    "currency": "INR",
+                    "name": "Potter 4",
+                    "description": "Tasty item",
+                    "price": 8700,
+                    "availability": "in stock",
+                    "image_url": "https://picsum.photos/id/237/200/300",
+                    "url": "https://www.kairon.com/",
+                    "brand": "Test Restaurant",
+                    "condition": "new"
+                },
+                "method": "CREATE",
+                "item_type": "PRODUCT_ITEM"
+            },
+            {
+                "retailer_id": "1053963",
+                "data": {
+                    "currency": "INR",
+                    "name": "Potter 4",
+                    "description": "Tasty item",
+                    "price": 8700,
+                    "availability": "in stock",
+                    "image_url": "https://picsum.photos/id/237/200/300",
+                    "url": "https://www.kairon.com/",
+                    "brand": "Test Restaurant",
+                    "condition": "new"
+                },
+                "method": "CREATE",
+                "item_type": "PRODUCT_ITEM"
+            }
+        ]
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {'handles': ['Acy4vFScxA7q5jquK1vKf20tlbWuXEW0dqxj3aSHY68QLMZriJaMuojJummx1sZhqlfj5DdKxqBw09YQ9DWVT2-6']}
+
+        with patch("kairon.meta.processor.requests.post", return_value=mock_response) as mock_post:
+            await processor.push_meta_catalog()
+
+            assert mock_post.called is True
+            called_url = mock_post.call_args[0][0]
+            assert f"https://graph.facebook.com/v21.0/{catalog_id}/batch" in called_url
+
+            data_arg = mock_post.call_args[1]["data"]
+            assert data_arg["access_token"] == access_token
+
+            called_url = mock_post.call_args[0][0]
+            query_params = parse_qs(urlparse(called_url).query)
+            encoded_requests = query_params.get("requests")[0]
+            decoded_requests = json.loads(unquote(encoded_requests))
+
+            assert any(item.get("method") == "CREATE" for item in decoded_requests)
+
+    @pytest.mark.asyncio
+    async def test_push_meta_catalog_failure(self):
+        access_token = "test_token"
+        catalog_id = "12345"
+
+        processor = MetaProcessor(access_token=access_token, catalog_id=catalog_id)
+
+        processor.processed_data = [
+            {
+                "retailer_id": "10539634",
+                "data": {
+                    "currency": "INR",
+                    "name": "Potter 4",
+                    "price": 8700,
+                },
+                "method": "CREATE",
+                "item_type": "PRODUCT_ITEM"
+            }
+        ]
+
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "400 Client Error: Bad Request for url")
+
+        with patch("kairon.meta.processor.requests.post", return_value=mock_response):
+            with patch("kairon.meta.processor.logger") as mock_logger:
+                with pytest.raises(requests.exceptions.HTTPError):
+                    await processor.push_meta_catalog()
+
+                assert mock_logger.exception.called
+                log_message = mock_logger.exception.call_args[0][0]
+                assert "Error syncing product items to Meta catalog for push menu" in log_message
+
+    @pytest.mark.asyncio
+    async def test_update_meta_catalog_success(self):
+        access_token = "test_token"
+        catalog_id = "12345"
+
+        processor = MetaProcessor(access_token=access_token, catalog_id=catalog_id)
+
+        processor.processed_data = [
+            {
+                "retailer_id": "10539580",
+                "data": {
+                    "availability": "out of stock"
+                },
+                "method": "UPDATE",
+                "item_type": "PRODUCT_ITEM"
+            }
+        ]
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {'handles': ['Acy4vFScxA7q5jquK1vKf20tlbWuXEW0dqxj3aSHY68QLMZriJaMuojJummx1sZhqlfj5DdKxqBw09YQ9DWVT2-6']}
+
+        with patch("kairon.meta.processor.requests.post", return_value=mock_response) as mock_post:
+            await processor.update_meta_catalog()
+
+            assert mock_post.called is True
+            called_url = mock_post.call_args[0][0]
+            assert f"https://graph.facebook.com/v21.0/{catalog_id}/batch" in called_url
+
+            data_arg = mock_post.call_args[1]["data"]
+            assert data_arg["access_token"] == access_token
+
+            called_url = mock_post.call_args[0][0]
+            query_params = parse_qs(urlparse(called_url).query)
+            encoded_requests = query_params.get("requests")[0]
+            decoded_requests = json.loads(unquote(encoded_requests))
+
+            assert any(item.get("method") == "UPDATE" for item in decoded_requests)
+
+    @pytest.mark.asyncio
+    async def test_update_meta_catalog_failure(self):
+        access_token = "test_token"
+        catalog_id = "12345"
+
+        processor = MetaProcessor(access_token=access_token, catalog_id=catalog_id)
+
+        processor.processed_data = [
+            {
+                "retailer_id": "10539580",
+                "data": {
+                    "availability": "out of stock"
+                },
+                "method": "UPDATE",
+                "item_type": "PRODUCT_ITEM"
+            }
+        ]
+
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "400 Client Error: Bad Request for url")
+
+        with patch("kairon.meta.processor.requests.post", return_value=mock_response):
+            with patch("kairon.meta.processor.logger") as mock_logger:
+                with pytest.raises(requests.exceptions.HTTPError):
+                    await processor.update_meta_catalog()
+
+                assert mock_logger.exception.called
+                log_message = mock_logger.exception.call_args[0][0]
+                assert "Error syncing product items to Meta catalog for item toggle" in log_message
+
+    @pytest.mark.asyncio
+    async def test_delete_meta_catalog_success(self):
+        access_token = "test_token"
+        catalog_id = "12345"
+
+        processor = MetaProcessor(access_token=access_token, catalog_id=catalog_id)
+
+        delete_payload = [
+            {'retailer_id': '10539580', 'method': 'DELETE'},
+            {'retailer_id': '10539634', 'method': 'DELETE'}
+        ]
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {'handles': ['Acy4vFScxA7q5jquK1vKf20tlbWuXEW0dqxj3aSHY68QLMZriJaMuojJummx1sZhqlfj5DdKxqBw09YQ9DWVT2-6']}
+
+        with patch("kairon.meta.processor.requests.post", return_value=mock_response) as mock_post:
+            await processor.delete_meta_catalog(delete_payload)
+
+            assert mock_post.called is True
+            called_url = mock_post.call_args[0][0]
+            assert f"https://graph.facebook.com/v21.0/{catalog_id}/batch" in called_url
+
+            data_arg = mock_post.call_args[1]["data"]
+            assert data_arg["access_token"] == access_token
+
+            called_url = mock_post.call_args[0][0]
+            query_params = parse_qs(urlparse(called_url).query)
+            encoded_requests = query_params.get("requests")[0]
+            decoded_requests = json.loads(unquote(encoded_requests))
+
+            assert any(item.get("method") == "DELETE" for item in decoded_requests)
+
+    @pytest.mark.asyncio
+    async def test_delete_meta_catalog_failure(self):
+        access_token = "test_token"
+        catalog_id = "12345"
+
+        processor = MetaProcessor(access_token=access_token, catalog_id=catalog_id)
+
+        delete_payload = [
+            {'retailer_id': '10539580', 'method': 'DELETE'},
+            {'retailer_id': '10539634', 'method': 'DELETE'}
+        ]
+
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "400 Client Error: Bad Request for url")
+
+        with patch("kairon.meta.processor.requests.post", return_value=mock_response):
+            with patch("kairon.meta.processor.logger") as mock_logger:
+                with pytest.raises(requests.exceptions.HTTPError):
+                    await processor.delete_meta_catalog(delete_payload)
+
+                assert mock_logger.exception.called
+                log_message = mock_logger.exception.call_args[0][0]
+                assert "Error deleting data from meta" in log_message


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced comprehensive catalog synchronization for bots with external providers like Petpooja, supporting menu and item stock updates.
  - Added new API endpoints for catalog sync data ingestion, rerun sync, POS integration configuration, and catalog sync logs retrieval.
  - Implemented detailed catalog sync logging, status tracking, daily sync limits, and bot sync configuration management.
  - Integrated Meta (Facebook) product catalog synchronization with batch processing and asynchronous API calls.
  - Added new email templates and notifications for catalog sync status updates.
  - Added support for generating integration tokens and endpoints for secure data integrations.

- **Bug Fixes**
  - Enhanced validation and error handling for catalog sync payloads, including item toggle requests and sync type enforcement.

- **Documentation**
  - Added catalog provider mapping schema and configuration files for integration support.

- **Tests**
  - Added extensive unit and async tests covering catalog sync processing, logging, validation, Meta integration, and email notifications.

- **Chores**
  - Updated system properties, environment configurations, and test data to support catalog synchronization features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->