### PR TITLE
CLI command handler to sync catalog content

### DIFF
--- a/kairon/__init__.py
+++ b/kairon/__init__.py
@@ -45,7 +45,7 @@ Usage:
 
 def create_argument_parser():
     from kairon.cli import importer, training, testing, conversations_deletion, translator, delete_logs,\
-        message_broadcast,content_importer, mail_channel_read, agentic_flow
+        message_broadcast,content_importer, mail_channel_read, agentic_flow, catalog_sync
 
     parser = ArgumentParser(
         prog="kairon",
@@ -63,6 +63,7 @@ def create_argument_parser():
     delete_logs.add_subparser(subparsers, parents=parent_parsers)
     message_broadcast.add_subparser(subparsers, parents=parent_parsers)
     content_importer.add_subparser(subparsers, parents=parent_parsers)
+    catalog_sync.add_subparser(subparsers, parents=parent_parsers)
     mail_channel_read.add_subparser(subparsers, parents=parent_parsers)
     agentic_flow.add_subparser(subparsers, parents=parent_parsers)
 

--- a/kairon/cli/catalog_sync.py
+++ b/kairon/cli/catalog_sync.py
@@ -1,0 +1,80 @@
+import asyncio
+import json
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+from typing import List
+
+from loguru import logger
+from rasa.cli import SubParsersAction
+
+from kairon.events.definitions.catalog_sync import CatalogSync
+
+
+def sync_catalog_content(args):
+    """
+    CLI command handler to sync catalog content.
+    """
+    logger.info("bot: {}", args.bot)
+    logger.info("user: {}", args.user)
+    logger.info("provider: {}", args.provider)
+    logger.info("sync_type: {}", args.sync_type)
+    logger.info("token: {}", args.token)
+    logger.info("data: {}", args.data)
+
+    try:
+        data = json.loads(args.data)
+    except json.JSONDecodeError as e:
+        logger.error("Invalid JSON provided in --data: {}", e)
+        return
+
+    event = CatalogSync(
+        bot=args.bot,
+        user=args.user,
+        provider=args.provider,
+        sync_type=args.sync_type,
+        token=args.token
+    )
+
+    asyncio.run(event.execute(data=data))
+
+
+def add_subparser(subparsers: SubParsersAction, parents: List[ArgumentParser]):
+    """
+    Add subparser for the 'catalog-sync' CLI command.
+    """
+    catalog_sync_parser = subparsers.add_parser(
+        "catalog-sync",
+        conflict_handler="resolve",
+        formatter_class=ArgumentDefaultsHelpFormatter,
+        parents=parents,
+        help="Sync catalog content from POS(e.g., Petpooja) to Meta"
+    )
+
+    catalog_sync_parser.add_argument('bot',
+                                     type=str,
+                                     help="Bot ID for which the sync is performed",
+                                     action='store')
+    catalog_sync_parser.add_argument('user',
+                                     type=str,
+                                     help="Kairon user triggering the sync",
+                                     action='store')
+    catalog_sync_parser.add_argument('provider',
+                                     type=str,
+                                     help="Catalog provider name (e.g., petpooja)",
+                                     action='store')
+    catalog_sync_parser.add_argument('--sync_type',
+                                     default="item_toggle",
+                                     type=str,
+                                     help="Type of sync to perform (default: item_toggle)",
+                                     action='store')
+    catalog_sync_parser.add_argument('--token',
+                                     default="",
+                                     type=str,
+                                     help="Token for authentication",
+                                     action='store')
+    catalog_sync_parser.add_argument('--data',
+                                     type=str,
+                                     required=True,
+                                     help="JSON-formatted catalog data to be synced",
+                                     action='store')
+
+    catalog_sync_parser.set_defaults(func=sync_catalog_content)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `catalog-sync` command to the command-line interface for catalog synchronization, allowing users to specify bot, user, provider, sync type, token, and JSON data.

- **Tests**
  - Added unit tests to verify the functionality and error handling of the new `catalog-sync` CLI command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->