### PR TITLE
added crud in prompt action

### DIFF
--- a/kairon/shared/actions/data_objects.py
+++ b/kairon/shared/actions/data_objects.py
@@ -789,6 +789,7 @@ class LlmPrompt(EmbeddedDocument):
             LlmPromptSource.bot_content.value,
             LlmPromptSource.action.value,
             LlmPromptSource.slot.value,
+            LlmPromptSource.crud.value,
         ],
         default=LlmPromptSource.static.value,
     )

--- a/kairon/shared/data/processor.py
+++ b/kairon/shared/data/processor.py
@@ -109,6 +109,7 @@ from kairon.shared.models import (
 )
 from kairon.shared.plugins.factory import PluginFactory
 from kairon.shared.utils import Utility, StoryValidator
+from .collection_processor import DataProcessor
 from .constant import (
     DOMAIN,
     SESSION_CONFIG,
@@ -7963,6 +7964,11 @@ class MongoProcessor:
                 )
                 ):
                     raise AppException(f'Action with name {prompt["data"]} not found!')
+
+            if prompt["source"] == "crud":
+                collections_list= DataProcessor.get_all_collections(bot)
+                if not any(item['collection_name'] == prompt['data'] for item in collections_list):
+                    raise AppException(f'Collection with name {prompt["data"]} not found!')
 
     def edit_prompt_action(
             self, prompt_action_id: str, request_data: dict, bot: Text, user: Text

--- a/kairon/shared/models.py
+++ b/kairon/shared/models.py
@@ -99,6 +99,7 @@ class LlmPromptSource(str, Enum):
     action = "action"
     history = "history"
     tag = "tag"
+    crud="crud"
     bot_content = "bot_content"
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for using CRUD collections as a dynamic source for LLM prompts, allowing prompt context to include data fetched based on the sender.
- **Bug Fixes**
  - Improved validation to ensure referenced CRUD collections in prompts exist, providing clearer error handling for missing collections.
- **Other Changes**
  - Expanded available prompt source options to include "crud" in relevant settings and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->