### PR TITLE
fix for row count mistmatch

### DIFF
--- a/kairon/api/app/routers/bot/bot.py
+++ b/kairon/api/app/routers/bot/bot.py
@@ -832,7 +832,7 @@ async def get_action_server_logs(start_idx: int = 0, page_size: int = 10,
     Retrieves action server logs for the bot.
     """
     logs = list(mongo_processor.get_action_server_logs(current_user.get_bot(), start_idx, page_size))
-    row_cnt = mongo_processor.get_row_count(ActionServerLogs, current_user.get_bot())
+    row_cnt = mongo_processor.get_row_count(ActionServerLogs, current_user.get_bot(),trigger_info__trigger_id="")
     data = {
         "logs": logs,
         "total": row_cnt

--- a/kairon/shared/data/processor.py
+++ b/kairon/shared/data/processor.py
@@ -5035,7 +5035,7 @@ class MongoProcessor:
         """
         query = {
             "bot": bot,
-            "trigger_info.trigger_type": "implicit"
+            "trigger_info.trigger_id": ""
         }
 
         for log in (

--- a/tests/unit_test/data_processor/data_processor_test.py
+++ b/tests/unit_test/data_processor/data_processor_test.py
@@ -2179,7 +2179,8 @@ class TestMongoProcessor:
             request_params=request_params,
             api_response="Response",
             bot_response="Bot Response",
-            bot=bot
+            bot=bot,
+            trigger_info=TriggerInfo(trigger_id="123456", trigger_name="parallel_action", trigger_type="parallel_action")
         )
         log_implicit.save()
 
@@ -2194,7 +2195,7 @@ class TestMongoProcessor:
             bot_response="Bot Response",
             bot=bot,
             status="FAILURE",
-            trigger_info=TriggerInfo(trigger_name="explicit_action", trigger_type="parallel_action")
+            trigger_info=TriggerInfo(trigger_id="",trigger_name="explicit_action", trigger_type="parallel_action")
         ).save()
 
         processor = MongoProcessor()
@@ -2202,12 +2203,9 @@ class TestMongoProcessor:
 
         # Only the first one should be returned
         assert len(logs) == 1
-        assert logs[0]['action'] == "http_action"
-        assert logs[0]['_id'] == str(log_implicit.id)
+        assert logs[0]['action'] == "http_action2"
         ActionServerLogs.objects(action="http_action").delete()
         ActionServerLogs.objects(action="http_action2").delete()
-
-    from bson import ObjectId
 
     def test_fetch_action_logs_for_parallel_action_by_id(self):
         bot = "test_bot_parallel"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted action server log retrieval to display only logs with an empty trigger ID, ensuring more accurate log filtering in the action logs view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->