### PR TITLE
Deleting crud data while deleting chathistory

### DIFF
--- a/kairon/events/definitions/history_delete.py
+++ b/kairon/events/definitions/history_delete.py
@@ -56,7 +56,6 @@ class DeleteHistoryEvent(EventsBase):
         Execute the event.
         """
         from kairon.history.processor import HistoryProcessor
-        from datetime import datetime
         today = datetime.today().date()
         try:
             HistoryDeletionLogProcessor.add_log(

--- a/kairon/events/definitions/history_delete.py
+++ b/kairon/events/definitions/history_delete.py
@@ -4,6 +4,7 @@ from loguru import logger
 from kairon import Utility
 from kairon.events.definitions.base import EventsBase
 from kairon.shared.constants import EventClass
+from kairon.shared.data.collection_processor import DataProcessor
 from kairon.shared.data.constant import EVENT_STATUS
 from kairon.shared.data.history_log_processor import HistoryDeletionLogProcessor
 from kairon.shared.data.utils import ChatHistoryUtils
@@ -55,6 +56,8 @@ class DeleteHistoryEvent(EventsBase):
         Execute the event.
         """
         from kairon.history.processor import HistoryProcessor
+        from datetime import datetime
+        today = datetime.today().date()
         try:
             HistoryDeletionLogProcessor.add_log(
                 self.bot, self.user, self.till_date,
@@ -62,6 +65,8 @@ class DeleteHistoryEvent(EventsBase):
             )
             if not Utility.check_empty_string(self.sender_id):
                 HistoryProcessor.delete_user_history(self.bot, self.sender_id, self.till_date)
+                if self.till_date == today:
+                    DataProcessor.delete_collection_data_with_user(self.bot, self.sender_id)
             else:
                 HistoryProcessor.delete_bot_history(self.bot, self.till_date)
             HistoryDeletionLogProcessor.add_log(

--- a/kairon/shared/data/collection_processor.py
+++ b/kairon/shared/data/collection_processor.py
@@ -102,6 +102,12 @@ class DataProcessor:
             raise AppException("Collection Data does not exists!")
 
     @staticmethod
+    def delete_collection_data_with_user( bot: Text, user: Text):
+        collection_count = CollectionData.objects(bot=bot, user=user).delete()
+        if collection_count == 0:
+            raise AppException("Collection data for user does not exists!")
+
+    @staticmethod
     def list_collection_data(bot: Text):
         """
         fetches collection data

--- a/tests/unit_test/data_processor/data_processor2_test.py
+++ b/tests/unit_test/data_processor/data_processor2_test.py
@@ -1266,10 +1266,10 @@ def test_delete_collection_not_found():
 def test_delete_collection_data_success():
     with patch('kairon.shared.cognition.data_objects.CollectionData.objects') as mock_collection_data:
         mock_query = MagicMock()
-        mock_query.delete.return_value = 1  # simulate 1 records deleted
+        mock_query.delete.return_value = 1
         mock_collection_data.return_value = mock_query
 
-        # Call the function
+
         DataProcessor.delete_collection_data_with_user(bot="test_bot", user="test_user_1")
 
         mock_collection_data.assert_called_once_with(bot="test_bot", user="test_user_1")
@@ -1280,7 +1280,7 @@ def test_delete_collection_data_success():
 def test_delete_collection_data_no_records():
     with patch('kairon.shared.cognition.data_objects.CollectionData.objects') as mock_collection_data:
         mock_query = MagicMock()
-        mock_query.delete.return_value = 0  # simulate 0 records deleted
+        mock_query.delete.return_value = 0
         mock_collection_data.return_value = mock_query
 
         with pytest.raises(AppException) as exc_info:

--- a/tests/unit_test/data_processor/data_processor2_test.py
+++ b/tests/unit_test/data_processor/data_processor2_test.py
@@ -1261,3 +1261,33 @@ def test_delete_collection_not_found():
         mock_query.delete.assert_called_once()
         assert result == ["Collection nonexistent_collection does not exist!", 0]
 
+
+
+def test_delete_collection_data_success():
+    with patch('kairon.shared.cognition.data_objects.CollectionData.objects') as mock_collection_data:
+        mock_query = MagicMock()
+        mock_query.delete.return_value = 1  # simulate 1 records deleted
+        mock_collection_data.return_value = mock_query
+
+        # Call the function
+        DataProcessor.delete_collection_data_with_user(bot="test_bot", user="test_user_1")
+
+        mock_collection_data.assert_called_once_with(bot="test_bot", user="test_user_1")
+        mock_query.delete.assert_called_once()
+
+
+
+def test_delete_collection_data_no_records():
+    with patch('kairon.shared.cognition.data_objects.CollectionData.objects') as mock_collection_data:
+        mock_query = MagicMock()
+        mock_query.delete.return_value = 0  # simulate 0 records deleted
+        mock_collection_data.return_value = mock_query
+
+        with pytest.raises(AppException) as exc_info:
+            DataProcessor.delete_collection_data_with_user(bot="test_bot", user="test_user_1")
+
+        assert str(exc_info.value) == "Collection data for user does not exists!"
+        mock_collection_data.assert_called_once_with(bot="test_bot", user="test_user_1")
+        mock_query.delete.assert_called_once()
+
+

--- a/tests/unit_test/events/definitions_test.py
+++ b/tests/unit_test/events/definitions_test.py
@@ -24,6 +24,7 @@ from kairon.exceptions import AppException
 from kairon.multilingual.processor import MultilingualTranslator
 from kairon.shared.account.processor import AccountProcessor
 from kairon.shared.chat.broadcast.processor import MessageBroadcastProcessor
+from kairon.shared.cognition.data_objects import CollectionData
 from kairon.shared.constants import EventClass, EventRequestType
 from kairon.shared.data.constant import EVENT_STATUS
 from kairon.shared.data.data_objects import EndPointHistory, Endpoints, BotSettings
@@ -48,6 +49,16 @@ class TestEventDefinitions:
         BotSettings(bot="test_definitions", user="test_user").save()
         BotSettings(bot="test_definitions_bot", user="test_user").save()
         BotSettings(bot="test_faq", user="test_user").save()
+        CollectionData(bot="test_bot", user="test_user_1", collection_name="test_collection_1").save()
+        CollectionData(bot="test_bot", user="test_user_2", collection_name="test_collection_1").save()
+        CollectionData(bot="test_bot", user="test_user_1", collection_name="test_collection_2").save()
+        CollectionData(bot="test_bot", user="test_user_3", collection_name="test_collection_3").save()
+        CollectionData(bot="test_bot", user="test_user_1", collection_name="test_collection_3").save()
+        CollectionData(bot="test_bot_2", user="test_user_1", collection_name="test_collection_1").save()
+        CollectionData(bot="test_bot_2", user="test_user_2", collection_name="test_collection_1").save()
+        CollectionData(bot="test_bot_2", user="test_user_1", collection_name="test_collection_2").save()
+        CollectionData(bot="test_bot_2", user="test_user_2", collection_name="test_collection_2").save()
+
 
     def test_data_importer_presteps_no_training_files(self):
         bot = 'test_definitions'
@@ -1351,3 +1362,25 @@ class TestEventDefinitions:
         result = event.validate()
         assert result is None
         mock_flow_exists.assert_not_called()
+
+
+    @patch("kairon.shared.data.collection_processor.DataProcessor.delete_collection_data_with_user")
+    def test_delete_data_called_when_till_date_is_today(self, mock_delete_data):
+        from datetime import datetime
+        today = datetime.today().date()
+
+        event = DeleteHistoryEvent(bot="test_bot", user="test_user_1", till_date=today, sender_id="aniket.kharkia@nimblework.com")
+        event.execute()
+
+        mock_delete_data.assert_called_once_with("test_bot", "aniket.kharkia@nimblework.com")
+
+
+    @patch("kairon.shared.data.collection_processor.DataProcessor.delete_collection_data_with_user")
+    def test_delete_data_not_called_when_till_date_is_past(self, mock_delete_data):
+        from datetime import datetime, timedelta
+        past_date = datetime.today().date() - timedelta(days=3)
+
+        event = DeleteHistoryEvent(bot="test_bot", user="test_user_1", till_date=past_date, sender_id="aniket.kharkia@nimblework.com")
+        event.execute()
+
+        mock_delete_data.assert_not_called()

--- a/tests/unit_test/events/definitions_test.py
+++ b/tests/unit_test/events/definitions_test.py
@@ -1365,7 +1365,8 @@ class TestEventDefinitions:
 
 
     @patch("kairon.shared.data.collection_processor.DataProcessor.delete_collection_data_with_user")
-    def test_delete_data_called_when_till_date_is_today(self, mock_delete_data):
+    @patch("kairon.history.processor.HistoryProcessor.delete_user_history")
+    def test_delete_data_called_when_till_date_is_today(self, mock_delete_conversation, mock_delete_data):
         from datetime import datetime
         today = datetime.today().date()
 
@@ -1373,10 +1374,12 @@ class TestEventDefinitions:
         event.execute()
 
         mock_delete_data.assert_called_once_with("test_bot", "aniket.kharkia@nimblework.com")
+        mock_delete_conversation.assert_called_once_with("test_bot", "aniket.kharkia@nimblework.com", today)
 
 
     @patch("kairon.shared.data.collection_processor.DataProcessor.delete_collection_data_with_user")
-    def test_delete_data_not_called_when_till_date_is_past(self, mock_delete_data):
+    @patch("kairon.history.processor.HistoryProcessor.delete_user_history")
+    def test_delete_data_not_called_when_till_date_is_past(self, mock_delete_conversation, mock_delete_data):
         from datetime import datetime, timedelta
         past_date = datetime.today().date() - timedelta(days=3)
 
@@ -1384,3 +1387,4 @@ class TestEventDefinitions:
         event.execute()
 
         mock_delete_data.assert_not_called()
+        mock_delete_conversation.assert_called_once_with("test_bot", "aniket.kharkia@nimblework.com", past_date)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved user history deletion to also remove associated collection data when deleting history for today.

* **Tests**
  * Added tests to verify collection data deletion for a user, including both successful deletion and error scenarios.
  * Added tests to confirm collection data is only deleted when the deletion date is today.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->