### PR TITLE
fixed get logs api timestamp issue

### DIFF
--- a/kairon/shared/log_system/base.py
+++ b/kairon/shared/log_system/base.py
@@ -76,8 +76,5 @@ class BaseLogHandler(ABC):
                 log_dict["_id"] = str(log_dict["_id"])
             if "data" in log_dict and log_dict["data"] and "_id" in log_dict["data"]:
                 log_dict["data"]["_id"] = str(log_dict["data"]["_id"])
-            for ts_key in ["timestamp", "start_timestamp", "end_timestamp"]:
-                if isinstance(log_dict.get(ts_key), datetime):
-                    log_dict[ts_key] = log_dict[ts_key].isoformat()
             logs.append(log_dict)
         return logs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the handling of timestamp fields in log data to retain their original format rather than converting them to ISO 8601 strings. No changes to the visible interface or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->