### PR TITLE
on chat server startup load billable bots

### DIFF
--- a/kairon/chat/server.py
+++ b/kairon/chat/server.py
@@ -72,6 +72,11 @@ async def lifespan(app: FastAPI):
     """ MongoDB is connected on the bot trainer startup """
     config: dict = Utility.mongoengine_connection(Utility.environment['database']["url"])
     connect(**config)
+    load_isbilled_models = Utility.environment.get("model")['load_isbilled_models']
+    if load_isbilled_models:
+        from threading import Thread
+        t = Thread(target=Utility.load_billablebots_onstartup, daemon=True)
+        t.start()
     yield
     disconnect()
 

--- a/kairon/shared/utils.py
+++ b/kairon/shared/utils.py
@@ -2273,6 +2273,18 @@ class Utility:
             return []
         return [item.strip() for item in dilim_sep_string.split(delimilter) if item.strip()]
 
+    @staticmethod
+    def load_billablebots_onstartup():
+        from kairon.chat.agent_processor import AgentProcessor
+        from kairon.shared.data.data_objects import BotSettings
+        bot_list = BotSettings.objects(is_billed=True).only("bot")
+        logger.info(f"Total number of billable bots {len(bot_list)}")
+        for botObj in bot_list:
+            try:
+                AgentProcessor.reload(botObj.bot)
+                logger.info(f"Model loaded onStartup for botid: {botObj.bot}")
+            except Exception as ex:
+                logger.exception(f"Failure while loadig model: {ex}")
 
 class StoryValidator:
     @staticmethod

--- a/system.yaml
+++ b/system.yaml
@@ -82,6 +82,7 @@ model:
     custom:
       - kairon.shared.nlu.classifier.openai.OpenAIClassifier
       - kairon.shared.nlu.featurizer.openai.OpenAIFeaturizer
+  load_isbilled_models: true
 
 
 action:


### PR DESCRIPTION
On chat server startup, we need to load billable models. Thus spawing a new thread within lifespan method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an option to automatically load models for billable bots during application startup, configurable via a new setting.
* **Configuration**
  * Added a new configuration property to enable or disable automatic loading of billable bot models at startup.
* **Tests**
  * Added tests to verify both successful and failed loading of billable bot models during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->