### PR TITLE
create callback changes

### DIFF
--- a/kairon/shared/pyscript/callback_pyscript_utils.py
+++ b/kairon/shared/pyscript/callback_pyscript_utils.py
@@ -305,7 +305,9 @@ class CallbackScriptUtility:
 
     @staticmethod
     def create_callback(callback_name: str, metadata: dict, bot: str, sender_id: str, channel: str,
-                        name: str = 'callback_pyscript'):
+                        name: str = None):
+        if not name:
+            name=callback_name
         callback_url, identifier, standalone = CallbackData.create_entry(
             name=name,
             callback_config_name=callback_name,

--- a/kairon/shared/pyscript/callback_pyscript_utils.py
+++ b/kairon/shared/pyscript/callback_pyscript_utils.py
@@ -26,7 +26,6 @@ from cryptography.hazmat.primitives.asymmetric import padding as asym_padding
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from kairon.shared.callback.data_objects import CallbackConfig, CallbackData
 import json as jsond
-from kairon.exceptions import AppException
 
 from kairon.shared.chat.user_media import UserMedia
 

--- a/kairon/shared/pyscript/callback_pyscript_utils.py
+++ b/kairon/shared/pyscript/callback_pyscript_utils.py
@@ -306,9 +306,7 @@ class CallbackScriptUtility:
     @staticmethod
     def create_callback(callback_name: str, metadata: dict, bot: str, sender_id: str, channel: str,
                         name: str = None):
-        if not callback_name:
-            raise ValueError("'callback name' must be provided and cannot be empty")
-
+        
         if not name:
             name=callback_name
         callback_url, identifier, standalone = CallbackData.create_entry(

--- a/kairon/shared/pyscript/callback_pyscript_utils.py
+++ b/kairon/shared/pyscript/callback_pyscript_utils.py
@@ -26,6 +26,7 @@ from cryptography.hazmat.primitives.asymmetric import padding as asym_padding
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from kairon.shared.callback.data_objects import CallbackConfig, CallbackData
 import json as jsond
+from kairon.exceptions import AppException
 
 from kairon.shared.chat.user_media import UserMedia
 
@@ -307,7 +308,7 @@ class CallbackScriptUtility:
     def create_callback(callback_name: str, metadata: dict, bot: str, sender_id: str, channel: str,
                         name: str = None):
         if not callback_name:
-            raise ValueError("'callback name' must be provided and cannot be empty")
+            raise AppException("'callback name' must be provided and cannot be empty")
 
         if not name:
             name=callback_name

--- a/kairon/shared/pyscript/callback_pyscript_utils.py
+++ b/kairon/shared/pyscript/callback_pyscript_utils.py
@@ -306,7 +306,9 @@ class CallbackScriptUtility:
     @staticmethod
     def create_callback(callback_name: str, metadata: dict, bot: str, sender_id: str, channel: str,
                         name: str = None):
-        
+        if not callback_name:
+            raise ValueError("'callback name' must be provided and cannot be empty")
+
         if not name:
             name=callback_name
         callback_url, identifier, standalone = CallbackData.create_entry(

--- a/kairon/shared/pyscript/callback_pyscript_utils.py
+++ b/kairon/shared/pyscript/callback_pyscript_utils.py
@@ -306,6 +306,9 @@ class CallbackScriptUtility:
     @staticmethod
     def create_callback(callback_name: str, metadata: dict, bot: str, sender_id: str, channel: str,
                         name: str = None):
+        if not callback_name:
+            raise ValueError("'callback name' must be provided and cannot be empty")
+
         if not name:
             name=callback_name
         callback_url, identifier, standalone = CallbackData.create_entry(

--- a/tests/unit_test/callback/pyscript_handler_test.py
+++ b/tests/unit_test/callback/pyscript_handler_test.py
@@ -2744,6 +2744,63 @@ def test_pyscript_handler_create_callback_in_pyscript():
     assert len(bot_response) > 32
     CallbackConfig.objects(bot='test_bot', name='callback_py_1').delete()
 
+from unittest.mock import patch, MagicMock
+
+@patch("kairon.shared.callback.data_objects.CallbackData.create_entry")
+def test_create_callback_defaults_name_to_callback_name(mock_create_entry):
+    # Arrange
+    mock_create_entry.return_value = ("http://callback.url", "some-id", False)
+
+    callback_name = "my_callback"
+    data = {
+        "callback_name": callback_name,
+        "metadata": {},
+        "bot": "test_bot",
+        "sender_id": "sender_123",
+        "channel": "test_channel",
+        # 'name' is intentionally omitted to test the default behavior
+    }
+
+    # Act
+    CallbackScriptUtility.create_callback(**data)
+
+    # Assert
+    mock_create_entry.assert_called_once()
+    args, kwargs = mock_create_entry.call_args
+
+    # We're checking that 'name' passed to create_entry is the same as callback_name
+    assert kwargs["name"] == callback_name
+
+from unittest.mock import patch, MagicMock
+
+@patch("kairon.shared.callback.data_objects.CallbackData.create_entry")
+def test_create_callback_passing_name_to_callback_name(mock_create_entry):
+    # Arrange
+    mock_create_entry.return_value = ("http://callback.url", "some-id", False)
+
+    callback_name = "my_callback"
+    data = {
+        "callback_name": callback_name,
+        "metadata": {},
+        "bot": "test_bot",
+        "sender_id": "sender_123",
+        "channel": "test_channel",
+        "name":"ganesh"
+        # 'name' is intentionally omitted to test the default behavior
+    }
+
+    # Act
+    CallbackScriptUtility.create_callback(**data)
+
+    # Assert
+    mock_create_entry.assert_called_once()
+    args, kwargs = mock_create_entry.call_args
+
+    # We're checking that 'name' passed to create_entry is the same as callback_name
+    assert kwargs["name"] != callback_name
+
+
+
 
 def test_pyscript_handler_create_callback_in_pyscript_standalone():
     CallbackConfig.create_entry(bot='test_bot',

--- a/tests/unit_test/callback/pyscript_handler_test.py
+++ b/tests/unit_test/callback/pyscript_handler_test.py
@@ -20,6 +20,7 @@ from pymongo import MongoClient
 
 from kairon import Utility
 from kairon.events.executors.factory import ExecutorFactory
+from kairon.exceptions import AppException
 from kairon.shared.actions.data_objects import EmailActionConfig
 from kairon.shared.actions.utils import ActionUtility
 from kairon.shared.callback.data_objects import CallbackConfig, encrypt_secret
@@ -2747,7 +2748,7 @@ def test_pyscript_handler_create_callback_in_pyscript():
 
 @patch("kairon.shared.callback.data_objects.CallbackData.create_entry")
 def test_create_callback_defaults_name_to_callback_name(mock_create_entry):
-    # Arrange
+
     mock_create_entry.return_value = ("http://callback.url", "some-id", False)
 
     callback_name = "my_callback"
@@ -2757,23 +2758,17 @@ def test_create_callback_defaults_name_to_callback_name(mock_create_entry):
         "bot": "test_bot",
         "sender_id": "sender_123",
         "channel": "test_channel",
-        # 'name' is intentionally omitted to test the default behavior
     }
 
-    # Act
     CallbackScriptUtility.create_callback(**data)
-
-    # Assert
     mock_create_entry.assert_called_once()
     args, kwargs = mock_create_entry.call_args
 
-    # We're checking that 'name' passed to create_entry is the same as callback_name
     assert kwargs["name"] == callback_name
 
 
 @patch("kairon.shared.callback.data_objects.CallbackData.create_entry")
 def test_create_callback_passing_name_to_callback_name(mock_create_entry):
-    # Arrange
     mock_create_entry.return_value = ("http://callback.url", "some-id", False)
 
     callback_name = "my_callback"
@@ -2784,30 +2779,24 @@ def test_create_callback_passing_name_to_callback_name(mock_create_entry):
         "sender_id": "sender_123",
         "channel": "test_channel",
         "name":"ganesh"
-        # 'name' is intentionally omitted to test the default behavior
     }
 
-    # Act
     CallbackScriptUtility.create_callback(**data)
-
-    # Assert
     mock_create_entry.assert_called_once()
     args, kwargs = mock_create_entry.call_args
-
-    # We're checking that 'name' passed to create_entry is the same as callback_name
     assert kwargs["name"] != callback_name
 
 @patch("kairon.shared.callback.data_objects.CallbackData.create_entry")
 def test_create_callback_raises_if_callback_name_missing(mock_create_entry):
     data = {
-        "callback_name": None,  # Missing value
+        "callback_name": None,
         "metadata": {},
         "bot": "test_bot",
         "sender_id": "sender_123",
         "channel": "test_channel",
     }
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(AppException) as excinfo:
         CallbackScriptUtility.create_callback(**data)
 
     assert "'callback name' must be provided and cannot be empty" in str(excinfo.value)

--- a/tests/unit_test/callback/pyscript_handler_test.py
+++ b/tests/unit_test/callback/pyscript_handler_test.py
@@ -2749,7 +2749,7 @@ def test_pyscript_handler_create_callback_in_pyscript():
 @patch("kairon.shared.callback.data_objects.CallbackData.create_entry")
 def test_create_callback_defaults_name_to_callback_name(mock_create_entry):
 
-    mock_create_entry.return_value = ("http://callback.url", "some-id", False)
+    mock_create_entry.return_value = ("http://callback.url", "test-id", False)
 
     callback_name = "my_callback"
     data = {
@@ -2769,7 +2769,7 @@ def test_create_callback_defaults_name_to_callback_name(mock_create_entry):
 
 @patch("kairon.shared.callback.data_objects.CallbackData.create_entry")
 def test_create_callback_passing_name_to_callback_name(mock_create_entry):
-    mock_create_entry.return_value = ("http://callback.url", "some-id", False)
+    mock_create_entry.return_value = ("http://callback.url", "test-id", False)
 
     callback_name = "my_callback"
     data = {

--- a/tests/unit_test/callback/pyscript_handler_test.py
+++ b/tests/unit_test/callback/pyscript_handler_test.py
@@ -2744,7 +2744,6 @@ def test_pyscript_handler_create_callback_in_pyscript():
     assert len(bot_response) > 32
     CallbackConfig.objects(bot='test_bot', name='callback_py_1').delete()
 
-from unittest.mock import patch, MagicMock
 
 @patch("kairon.shared.callback.data_objects.CallbackData.create_entry")
 def test_create_callback_defaults_name_to_callback_name(mock_create_entry):
@@ -2771,7 +2770,6 @@ def test_create_callback_defaults_name_to_callback_name(mock_create_entry):
     # We're checking that 'name' passed to create_entry is the same as callback_name
     assert kwargs["name"] == callback_name
 
-from unittest.mock import patch, MagicMock
 
 @patch("kairon.shared.callback.data_objects.CallbackData.create_entry")
 def test_create_callback_passing_name_to_callback_name(mock_create_entry):
@@ -2800,6 +2798,22 @@ def test_create_callback_passing_name_to_callback_name(mock_create_entry):
     assert kwargs["name"] != callback_name
 
 
+
+@patch("kairon.shared.callback.data_objects.CallbackData.create_entry")
+def test_create_callback_raises_if_callback_name_missing(mock_create_entry):
+    data = {
+        "callback_name": None,  # Missing value
+        "metadata": {},
+        "bot": "test_bot",
+        "sender_id": "sender_123",
+        "channel": "test_channel",
+    }
+
+    with pytest.raises(ValueError) as excinfo:
+        CallbackScriptUtility.create_callback(**data)
+
+    assert "'callback name' must be provided and cannot be empty" in str(excinfo.value)
+    mock_create_entry.assert_not_called()
 
 
 def test_pyscript_handler_create_callback_in_pyscript_standalone():

--- a/tests/unit_test/callback/pyscript_handler_test.py
+++ b/tests/unit_test/callback/pyscript_handler_test.py
@@ -2797,7 +2797,21 @@ def test_create_callback_passing_name_to_callback_name(mock_create_entry):
     # We're checking that 'name' passed to create_entry is the same as callback_name
     assert kwargs["name"] != callback_name
 
+@patch("kairon.shared.callback.data_objects.CallbackData.create_entry")
+def test_create_callback_raises_if_callback_name_missing(mock_create_entry):
+    data = {
+        "callback_name": None,  # Missing value
+        "metadata": {},
+        "bot": "test_bot",
+        "sender_id": "sender_123",
+        "channel": "test_channel",
+    }
 
+    with pytest.raises(ValueError) as excinfo:
+        CallbackScriptUtility.create_callback(**data)
+
+    assert "'callback name' must be provided and cannot be empty" in str(excinfo.value)
+    mock_create_entry.assert_not_called()
 
 
 

--- a/tests/unit_test/callback/pyscript_handler_test.py
+++ b/tests/unit_test/callback/pyscript_handler_test.py
@@ -2799,21 +2799,6 @@ def test_create_callback_passing_name_to_callback_name(mock_create_entry):
 
 
 
-@patch("kairon.shared.callback.data_objects.CallbackData.create_entry")
-def test_create_callback_raises_if_callback_name_missing(mock_create_entry):
-    data = {
-        "callback_name": None,  # Missing value
-        "metadata": {},
-        "bot": "test_bot",
-        "sender_id": "sender_123",
-        "channel": "test_channel",
-    }
-
-    with pytest.raises(ValueError) as excinfo:
-        CallbackScriptUtility.create_callback(**data)
-
-    assert "'callback name' must be provided and cannot be empty" in str(excinfo.value)
-    mock_create_entry.assert_not_called()
 
 
 def test_pyscript_handler_create_callback_in_pyscript_standalone():


### PR DESCRIPTION
…he name is always logged as 'callback_pyscript'" and i removed the default_name and set to none and two lines of code and write test cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Callback creation now defaults the display name to the provided callback identifier when no name is given, and enforces a non-empty callback name with a clearer validation error.

* **Tests**
  * Added unit tests covering defaulting behavior, explicit name override, and validation when the callback name is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->