### PR TITLE
delete history fix

### DIFF
--- a/kairon/shared/utils.py
+++ b/kairon/shared/utils.py
@@ -745,11 +745,11 @@ class Utility:
 
     @staticmethod
     def get_to_date(request: Request):
-        key = "to_date"
-        if not request.query_params.get(key):
+        date_str = request.query_params.get("till_date") or request.query_params.get("to_date")
+        if not date_str:
             return date.today()
         else:
-            return date.fromisoformat(request.query_params.get(key))
+            return date.fromisoformat(date_str)
 
     @staticmethod
     def validate_from_date_and_to_date(from_date: date, to_date: date):


### PR DESCRIPTION
made changes in delete history where delete history deleting history till today even though we specified custom date

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Chat history deletion now accepts either "till_date" or "to_date" (prefers "till_date" if both provided).
  * If no date is provided, deletion defaults to today.
  * Supports deleting history up to a past date for both user-specific and bot-wide histories.
  * Clear initiation messages confirm the deletion has started.

* **Tests**
  * Added integration tests validating user and bot history deletion up to a past date and correct event payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->