### PR TITLE
disptach resonse fix in callback pyscript

### DIFF
--- a/kairon/async_callback/processor.py
+++ b/kairon/async_callback/processor.py
@@ -56,7 +56,8 @@ class CallbackProcessor:
         bot_response = data.get('bot_response')
         state = data.get('state')
         invalidate = data.get('invalidate')
-        return bot_response, state, invalidate
+        dispatch_bot_response=data.get('dispatch_bot_response', False)
+        return bot_response, state, invalidate, dispatch_bot_response
 
     @staticmethod
     def run_pyscript_async(script: str, predefined_objects: dict, callback: Any):
@@ -82,14 +83,14 @@ class CallbackProcessor:
             raise AppException(f"Error while executing pyscript: {str(e)}")
 
     @staticmethod
-    async def async_callback(obj: dict, ent: dict, cb: dict, c_src: str, bot_id: str, sid: str, chnl: str, dispatch_response: bool, rd: dict):
+    async def async_callback(obj: dict, ent: dict, cb: dict, c_src: str, bot_id: str, sid: str, chnl: str, rd: dict):
         try:
             if not obj:
                 raise AppException("No response received from callback script")
             elif res := obj.get('result'):
-                bot_response, state, invalidate = CallbackProcessor.parse_pyscript_data(res)
+                bot_response, state, invalidate, dispatch_bot_response = CallbackProcessor.parse_pyscript_data(res)
                 CallbackData.update_state(ent['bot'], ent['identifier'], state, invalidate)
-                if dispatch_response:
+                if dispatch_bot_response and bot_response:
                     await ChannelMessageDispatcher.dispatch_message(bot_id, sid, bot_response, chnl)
                 CallbackLog.create_success_entry(name=ent.get("action_name"),
                                                  bot=bot_id,
@@ -139,9 +140,6 @@ class CallbackProcessor:
         entry, callback = CallbackData.validate_entry(token, identifier, request_data.get('body'))
         predefined_objects.update(entry)
         bot = entry.get("bot")
-        action_name = entry.get("action_name")
-        callback_action_config = MongoProcessor.get_callback_action(bot, action_name)
-        dispatch_response = callback_action_config.get("dispatch_bot_response")
         execution_mode = callback.get("execution_mode")
         response_type = callback.get("response_type", CallbackResponseType.KAIRON_JSON.value)
         try:
@@ -149,7 +147,7 @@ class CallbackProcessor:
                 logger.info(f"Executing async callback. Identifier: {entry.get('identifier')}")
 
                 async def callback_function(rsp: dict):
-                    copied_func = functools.partial(CallbackProcessor.async_callback, rsp, entry, callback, callback_source, bot, entry.get("sender_id"), entry.get("channel"), dispatch_response, request_data)
+                    copied_func = functools.partial(CallbackProcessor.async_callback, rsp, entry, callback, callback_source, bot, entry.get("sender_id"), entry.get("channel"), request_data)
                     await copied_func()
 
                 CallbackProcessor.run_pyscript_async(script=callback.get("pyscript_code"),
@@ -159,11 +157,11 @@ class CallbackProcessor:
                 logger.info(f"Executing sync callback. Identifier: {entry.get('identifier')}")
                 result = CallbackProcessor.run_pyscript(script=callback.get("pyscript_code"),
                                                         predefined_objects=predefined_objects)
-                bot_response, state, invalidate = CallbackProcessor.parse_pyscript_data(result)
+                bot_response, state, invalidate, dispatch_bot_response = CallbackProcessor.parse_pyscript_data(result)
                 CallbackData.update_state(entry['bot'], entry['identifier'], state, invalidate)
                 data = bot_response
                 logger.info(f'Pyscript output: {bot_response, state, invalidate}')
-                if dispatch_response:
+                if dispatch_bot_response and bot_response:
                     await ChannelMessageDispatcher.dispatch_message(bot, entry.get("sender_id"), data, entry.get("channel"))
                 CallbackLog.create_success_entry(name=entry.get("action_name"),
                                                  bot=bot,

--- a/tests/unit_test/callback/callback_test.py
+++ b/tests/unit_test/callback/callback_test.py
@@ -516,17 +516,16 @@ async def test_run_pyscript_async_submit_exception(mock_script, mock_predefined_
 @patch('kairon.async_callback.processor.CallbackLog.create_failure_entry')
 @patch('kairon.shared.callback.data_objects.CallbackData.update_state')
 async def test_async_callback(mock_update_state, mock_failure_entry, mock_success_entry, mock_dispatch_message):
-    obj = {'result': {'bot_response': 'Test result'}}
+    obj = {'result': {'bot_response': 'Test result', 'dispatch_bot_response':True}}
     ent = {'action_name': 'Test action', 'bot': 'Test bot', 'identifier': 'Test identifier', 'pyscript_code': 'Test code', 'sender_id': 'Test sender', 'metadata': 'Test metadata', 'callback_url': 'Test url', 'callback_source': 'Test source'}
     cb = {'pyscript_code': 'Test code'}
     c_src = 'Test source'
     bot_id = 'Test bot'
     sid = 'Test sender'
     chnl = 'Test channel'
-    ds = True
     rd = {'key': 'value'}
 
-    await CallbackProcessor.async_callback(obj, ent, cb, c_src, bot_id, sid, chnl, ds, rd)
+    await CallbackProcessor.async_callback(obj, ent, cb, c_src, bot_id, sid, chnl, rd)
 
     mock_dispatch_message.assert_called_once_with(bot_id, sid, obj['result']['bot_response'], chnl)
     mock_success_entry.assert_called_once_with(name=ent['action_name'], bot=bot_id,
@@ -547,10 +546,9 @@ async def test_async_callback_fail(mock_failure_entry, mock_success_entry, mock_
     bot_id = 'Test bot'
     sid = 'Test sender'
     chnl = 'Test channel'
-    ds = False
     rd = {'key': 'value'}
 
-    await CallbackProcessor.async_callback(obj, ent, cb, c_src, bot_id, sid, chnl, ds, rd)
+    await CallbackProcessor.async_callback(obj, ent, cb, c_src, bot_id, sid, chnl, rd)
 
     mock_dispatch_message.assert_not_called()
     mock_success_entry.assert_not_called()
@@ -571,10 +569,9 @@ async def test_async_callback_no_response_none(mock_failure_entry):
     bot_id = 'Test bot'
     sid = 'Test sender'
     chnl = 'Test channel'
-    ds = False
     rd = {'key': 'value'}
 
-    await CallbackProcessor.async_callback(obj, ent, cb, c_src, bot_id, sid, chnl, ds, rd)
+    await CallbackProcessor.async_callback(obj, ent, cb, c_src, bot_id, sid, chnl, rd)
     mock_failure_entry.assert_called_once_with(
         name=ent['action_name'], bot=bot_id, identifier=ent['identifier'],
         channel=chnl, pyscript_code=cb['pyscript_code'], sender_id=sid,
@@ -592,10 +589,9 @@ async def test_async_callback_no_response_empty_dict(mock_failure_entry):
     bot_id = 'Test bot'
     sid = 'Test sender'
     chnl = 'Test channel'
-    ds = False
     rd = {'key': 'value'}
 
-    await CallbackProcessor.async_callback(obj, ent, cb, c_src, bot_id, sid, chnl, ds, rd)
+    await CallbackProcessor.async_callback(obj, ent, cb, c_src, bot_id, sid, chnl, rd)
     mock_failure_entry.assert_called_once_with(
         name=ent['action_name'], bot=bot_id, identifier=ent['identifier'],
         channel=chnl, pyscript_code=cb['pyscript_code'], sender_id=sid,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Bot responses can now be dispatched based on a flag returned by custom scripts, enabling script-controlled message delivery.
- Refactor
  - Dispatch behavior no longer depends on configuration; it’s driven by the script’s output, simplifying the callback flow.
  - Execution paths updated to handle the new response structure from scripts.
- Tests
  - Unit tests updated to reflect script-driven dispatch and the streamlined callback interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->