### PR TITLE
Delete media file and fetch media url

### DIFF
--- a/kairon/api/app/routers/bot/data.py
+++ b/kairon/api/app/routers/bot/data.py
@@ -4,6 +4,8 @@ from typing import List, Optional
 from fastapi import UploadFile, File, Security, APIRouter, Query, HTTPException, Path
 from starlette.requests import Request
 from starlette.responses import FileResponse
+
+from kairon.shared.chat.processor import ChatDataProcessor
 from kairon.shared.chat.user_media import UserMedia
 from kairon.api.models import Response, CognitiveDataRequest, CognitionSchemaRequest, CollectionDataRequest
 from kairon.events.definitions.content_importer import DocContentImporterEvent
@@ -14,7 +16,7 @@ from kairon.shared.auth import Authentication
 from kairon.shared.cognition.data_objects import CognitionSchema
 from kairon.shared.cognition.processor import CognitionDataProcessor
 from kairon.shared.concurrency.actors.factory import ActorFactory
-from kairon.shared.constants import ActorType, CatalogSyncClass, UploadHandlerClass
+from kairon.shared.constants import ActorType, CatalogSyncClass, UploadHandlerClass, ChannelTypes
 from kairon.shared.constants import DESIGNER_ACCESS
 from kairon.shared.data.data_models import POSIntegrationRequest, BulkCollectionDataRequest
 from kairon.shared.data.collection_processor import DataProcessor
@@ -550,3 +552,23 @@ async def get_media_ids(
         return Response(message="List of media ids", data=media_ids)
     except Exception as e:
         raise AppException(f"Error while fetching media ids: {str(e)}")
+
+@router.delete("/{channel}/media/{media_id}", response_model=Response)
+async def delete_media_data(
+    channel : ChannelTypes,
+    media_id: str,
+    current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS)
+):
+    UserMedia.delete_media(current_user.get_bot(),media_id)
+    ChatDataProcessor.delete_media_from_bsp(current_user.get_bot(), channel, media_id)
+    return Response(message="Deleted Successfully")
+
+@router.get("/{channel}/fetch_api/{media_id}")
+async def fetch_meta_api(
+        channel : ChannelTypes,
+        media_id: str,
+        current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS)
+):
+    media_url = ChatDataProcessor.fetch_media_from_bsp(current_user.get_bot(), channel, media_id)
+    return Response(message="Successfully fetched media details", data={"media url": f"{media_url}",
+                        "media id": f"{media_id}"})

--- a/kairon/shared/channels/whatsapp/bsp/dialog360.py
+++ b/kairon/shared/channels/whatsapp/bsp/dialog360.py
@@ -359,3 +359,27 @@ class BSP360Dialog(WhatsappBusinessServiceProviderBase):
         )
 
         return external_media_id
+
+    @staticmethod
+    def delete_media_file(media_id: str, channel_config):
+        api_key = channel_config.get("config", {}).get("api_key")
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"]["waba_base_url"]
+        url = f"{base_url}/{media_id}"
+        header = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"]["auth_header"]
+        headers = {header: api_key}
+        Utility.execute_http_request(request_method="DELETE", http_url=url, headers=headers,
+                                     validate_status=True,
+                                     err_msg="Failed to delete file in meta.")
+        return "Media file deleted successfully"
+
+    @staticmethod
+    def fetch_media_file_url(media_id: str, channel_config):
+        api_key = channel_config.get("config", {}).get("api_key")
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"]["waba_base_url"]
+        url = f"{base_url}/{media_id}"
+        header = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"]["auth_header"]
+        headers = {header: api_key}
+        resp = Utility.execute_http_request(request_method="GET", http_url=url, headers=headers,
+                                            validate_status=True,
+                                            err_msg="media url does not exist for this media id.")
+        return resp.get("url")

--- a/kairon/shared/chat/processor.py
+++ b/kairon/shared/chat/processor.py
@@ -311,6 +311,43 @@ class ChatDataProcessor:
         return media_id
 
     @staticmethod
+    def delete_media_from_bsp(bot: str, channel: str, media_id: str):
+        from ..channels.whatsapp.bsp.factory import BusinessServiceProviderFactory
+        try:
+            channel_config = ChatDataProcessor.get_channel_config(channel, bot)
+            bsp_type = channel_config.get("config").get("bsp_type", "meta")
+            BusinessServiceProviderFactory.get_instance(bsp_type).delete_media_file(media_id, channel_config)
+            return "File deleted from meta"
+        except DoesNotExist as e:
+            logger.error(
+                f"Media upload failed: No channel found for this bot. Please configure the channel first.: {str(e)}")
+            raise AppException(
+                "Media upload failed: No channel found for this bot. Please configure the channel first."
+            ) from e
+        except Exception as e:
+            logger.error(f"Error deleting file to BSP: {str(e)}")
+            raise AppException(f"Failed to delete media: {str(e)}")
+
+    @staticmethod
+    def fetch_media_from_bsp(bot: str, channel: str, media_id: str):
+        from ..channels.whatsapp.bsp.factory import BusinessServiceProviderFactory
+        try:
+            channel_config = ChatDataProcessor.get_channel_config(channel, bot)
+            bsp_type = channel_config.get("config").get("bsp_type", "meta")
+            media_url = BusinessServiceProviderFactory.get_instance(bsp_type).fetch_media_file_url(media_id,
+                                                                                                   channel_config)
+            return media_url
+        except DoesNotExist as e:
+            logger.error(
+                f"Media upload failed: No channel found for this bot. Please configure the channel first.: {str(e)}")
+            raise AppException(
+                "Media upload failed: No channel found for this bot. Please configure the channel first."
+            ) from e
+        except Exception as e:
+            logger.error(f"Error fetchin url to BSP: {str(e)}")
+            raise AppException(f"Failed to fetch media url: {str(e)}")
+
+    @staticmethod
     def validate_media_file_type(file_content: File):
         content_type = file_content.content_type
 

--- a/kairon/shared/chat/user_media.py
+++ b/kairon/shared/chat/user_media.py
@@ -534,6 +534,16 @@ class UserMedia:
         except Exception as e:
             raise AppException(f"Error while fetching media ids for bot '{bot}': {str(e)}")
 
+    @staticmethod
+    def delete_media(bot, media_id: str):
+        try:
+            UserMediaData.objects(
+                bot=bot,
+                media_id=media_id
+            ).first().delete()
+            return "Deleted successfully"
+        except Exception as e:
+            raise AppException(f"Failed to delete:{str(e)}")
 
     @staticmethod
     def create_media_doc(

--- a/tests/unit_test/channels/bsp_test.py
+++ b/tests/unit_test/channels/bsp_test.py
@@ -1297,3 +1297,76 @@ class TestBusinessServiceProvider:
 
         UserMediaData.objects().delete()
         Channels.objects().delete()
+
+
+@patch.object(Utility, "execute_http_request")
+def test_delete_media_file_success(mock_execute):
+    mock_execute.return_value = None
+    media_id = "12345"
+    channel_config = {"config": {"api_key": "fake_api_key"}}
+
+    result = BSP360Dialog.delete_media_file(media_id, channel_config)
+
+    mock_execute.assert_called_once()
+    assert result == "Media file deleted successfully"
+
+@patch.object(Utility, "execute_http_request")
+def test_delete_media_file_failure(mock_execute):
+    mock_execute.side_effect = Exception("Failed to delete file in meta.")
+    media_id = "12345"
+    channel_config = {"config": {"api_key": "fake_api_key"}}
+
+    with pytest.raises(Exception) as exc_info:
+        BSP360Dialog.delete_media_file(media_id, channel_config)
+
+    assert str(exc_info.value) == "Failed to delete file in meta."
+
+
+def test_delete_media_success():
+    from unittest.mock import patch, MagicMock
+    bot = "test_bot"
+    media_id = "12345"
+
+    mock_obj = MagicMock()
+    mock_obj.first.return_value = MagicMock(delete=MagicMock())
+
+    with patch.object(UserMediaData, "objects", return_value=mock_obj):
+        result = UserMedia.delete_media(bot, media_id)
+
+    mock_obj.first.return_value.delete.assert_called_once()
+    assert result == "Deleted successfully"
+
+def test_delete_media_failure():
+    from unittest.mock import patch, MagicMock
+    bot = "test_bot"
+    media_id = "12345"
+
+    mock_obj = MagicMock()
+    mock_obj.first.return_value = None
+
+    with patch.object(UserMediaData, "objects", return_value=mock_obj):
+        with pytest.raises(AppException) as exc_info:
+            UserMedia.delete_media(bot, media_id)
+
+    assert "Failed to delete" in str(exc_info.value)
+
+@patch.object(Utility, "execute_http_request")
+def test_fetch_media_file_url_success(mock_execute):
+    expected_url = "https://example.com/media/12345"
+    mock_execute.return_value = {"url": expected_url}
+    media_id = "12345"
+    channel_config = {"config": {"api_key": "fake_api_key"}}
+
+    result = BSP360Dialog.fetch_media_file_url(media_id, channel_config)
+    mock_execute.assert_called_once()
+    assert result == expected_url
+
+@patch.object(Utility, "execute_http_request")
+def test_fetch_media_file_url_failure(mock_execute):
+    mock_execute.side_effect = Exception("media url does not exist for this media id.")
+    media_id = "12345"
+    channel_config = {"config": {"api_key": "fake_api_key"}}
+    with pytest.raises(Exception) as exc_info:
+        BSP360Dialog.fetch_media_file_url(media_id, channel_config)
+
+    assert str(exc_info.value) == "media url does not exist for this media id."

--- a/tests/unit_test/chat/chat_test.py
+++ b/tests/unit_test/chat/chat_test.py
@@ -1997,3 +1997,129 @@ async def test_upload_media_other_exception(monkeypatch):
             "bot1", "user1", "whatsapp", "/tmp/file", file_info
         )
     assert str(e.value) == "Media upload failed: some random error"
+
+
+@patch("kairon.shared.channels.whatsapp.bsp.factory.BusinessServiceProviderFactory.get_instance")
+def test_delete_media_to_bsp_success(mock_bsp_factory):
+    mock_bsp = MagicMock()
+    mock_bsp.delete_media_file.return_value = "Media file deleted successfully"
+    mock_bsp_factory.return_value = mock_bsp
+    BotSettings(
+        bot="test_bot",
+        user="test@example.com",
+        whatsapp="360dialog",
+        timestamp=datetime.utcnow(),
+    ).save()
+    Channels(
+        bot="test_bot",
+        connector_type="whatsapp",
+        config={
+            "client_name": "dummy",
+            "client_id": "dummy",
+            "channel_id": "dummy",
+            "api_key": "dummy_token",
+            "partner_id": "dummy",
+            "waba_account_id": "dummy",
+            "bsp_type": "360dialog"
+        },
+        user="user123",
+        timestamp=datetime.utcnow()
+    ).save()
+    result = ChatDataProcessor.delete_media_from_bsp(
+        bot="test_bot",
+        channel="whatsapp",
+        media_id="715690454858053"
+    )
+
+    assert result == "File deleted from meta"
+
+
+
+@patch("kairon.shared.channels.whatsapp.bsp.factory.BusinessServiceProviderFactory.get_instance")
+def test_delete_media_to_bsp_failure(mock_bsp_factory):
+    mock_bsp_factory.side_effect = AppException("bsp_type not yet implemented!")
+
+    with pytest.raises(AppException) as exc_info:
+        ChatDataProcessor.delete_media_from_bsp(
+            bot="test_bot",
+            channel="whatsapp",
+            media_id="7156904548580531",
+        )
+
+    assert "Failed to delete media: bsp_type not yet implemented!" == str(exc_info.value)
+
+    Channels.objects().delete()
+    BotSettings.objects().delete()
+
+def test_delete_media_from_bsp_channel_does_not_exist():
+    with patch("kairon.shared.chat.processor.ChatDataProcessor.get_channel_config", side_effect=DoesNotExist("no channel")):
+        with pytest.raises(AppException) as exc_info:
+            ChatDataProcessor.delete_media_from_bsp(
+                bot="test_bot",
+                channel="whatsapp",
+                media_id="12345",
+            )
+
+    assert str(exc_info.value) == "Media upload failed: No channel found for this bot. Please configure the channel first."
+
+@patch("kairon.shared.channels.whatsapp.bsp.factory.BusinessServiceProviderFactory.get_instance")
+def test_fetch_media_to_bsp_success(mock_bsp_factory):
+    mock_bsp = MagicMock()
+    mock_bsp.fetch_media_file_url.return_value = "https://lookaside.fbsbx.com/whatsapp_business/attachments/?mid=794331822986650&source=getMedia&ext=1758864163&hash=ARlClCLYiLgc7FYITJpJb8gI-RAQ69AbNNwDuQIsvEk3EA"
+    mock_bsp_factory.return_value = mock_bsp
+    BotSettings(
+        bot="test_bot",
+        user="test@example.com",
+        whatsapp="360dialog",
+        timestamp=datetime.utcnow(),
+    ).save()
+    Channels(
+        bot="test_bot",
+        connector_type="whatsapp",
+        config={
+            "client_name": "dummy",
+            "client_id": "dummy",
+            "channel_id": "dummy",
+            "api_key": "dummy_token",
+            "partner_id": "dummy",
+            "waba_account_id": "dummy",
+            "bsp_type": "360dialog"
+        },
+        user="user123",
+        timestamp=datetime.utcnow()
+    ).save()
+    result = ChatDataProcessor.fetch_media_from_bsp(
+        bot="test_bot",
+        channel="whatsapp",
+        media_id="715690454858053"
+    )
+
+    assert "https://lookaside.fbsbx.com/whatsapp_business/attachments/?mid=794331822986650&source=getMedia&ext=1758864163&hash=ARlClCLYiLgc7FYITJpJb8gI-RAQ69AbNNwDuQIsvEk3EA" in result
+
+
+def test_fetch_media_from_bsp_channel_does_not_exist():
+    with patch("kairon.shared.chat.processor.ChatDataProcessor.get_channel_config", side_effect=DoesNotExist("no channel")):
+        with pytest.raises(AppException) as exc_info:
+            ChatDataProcessor.fetch_media_from_bsp(
+                bot="test_bot",
+                channel="whatsapp",
+                media_id="12345",
+            )
+
+    assert str(exc_info.value) == "Media upload failed: No channel found for this bot. Please configure the channel first."
+
+@patch("kairon.shared.channels.whatsapp.bsp.factory.BusinessServiceProviderFactory.get_instance")
+def test_fetch_media_to_bsp_failure(mock_bsp_factory):
+    mock_bsp_factory.side_effect = AppException("bsp_type not yet implemented!")
+
+    with pytest.raises(AppException) as exc_info:
+        ChatDataProcessor.fetch_media_from_bsp(
+            bot="test_bot",
+            channel="whatsapp",
+            media_id="7156904548580531",
+        )
+
+    assert "Failed to fetch media url: bsp_type not yet implemented!" == str(exc_info.value)
+
+    Channels.objects().delete()
+    BotSettings.objects().delete()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added API endpoints to delete media by ID and fetch media URLs for supported channels.
  - Integrated media delete/fetch with WhatsApp Business providers (including 360dialog/Meta).
  - Enhanced media management with the ability to remove stored media records.

- Tests
  - Added integration tests covering media deletion and URL retrieval, including success and error scenarios.
  - Added unit tests for provider interactions and data-layer delete logic, ensuring robust handling of external requests and missing media cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->