### PR TITLE
upgrading dependencies

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,7 +7,7 @@ mock==5.1.0
 moto[all]==5.0.26
 mongomock==4.1.2
 black==24.10.0
-packaging==21.3
+packaging>=20.0,<21.0
 locust==2.31.5.dev3
 deepdiff==8.6.1
 pytest-cov==5.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,14 +1,15 @@
 -r prod.txt
-pytest==8.3.2
+pytest==9.0.3
 pytest_httpx==0.30.0
 pytest-asyncio==0.24.0
 responses==0.25.6
 mock==5.1.0
 moto[all]==5.0.26
 mongomock==4.1.2
-black==22.12.0
+black==24.10.0
+packaging==21.3
 locust==2.31.5.dev3
-deepdiff==7.0.1
+deepdiff==8.6.1
 pytest-cov==5.0.0
 pytest-html==4.1.1
 pytest-aioresponses==0.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 -r prod.txt
-pytest==9.0.3
+pytest==8.3.5
 pytest_httpx==0.30.0
 pytest-asyncio==0.24.0
 responses==0.25.6
@@ -7,7 +7,7 @@ mock==5.1.0
 moto[all]==5.0.26
 mongomock==4.1.2
 black==24.10.0
-packaging>=20.0,<21.0
+packaging>=20.9,<21.0
 locust==2.31.5.dev3
 deepdiff==8.6.1
 pytest-cov==5.0.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -24,7 +24,7 @@ pymupdf==1.25.3
 python-docx==1.1.2
 pandas==2.2.2
 openpyxl==3.2.0b1
-sentencepiece==0.1.99
+sentencepiece==0.2.1
 dramatiq==1.17.0
 dramatiq-mongodb==0.8.3
 nlpaug==1.1.11
@@ -42,7 +42,7 @@ aiohttp-retry==2.8.3
 pqdict==1.4.0
 google-businessmessages==1.0.5
 google-apitools==0.5.32
-orjson==3.10.14
+orjson==3.11.6
 opentelemetry-distro[otlp]==0.48b0
 opentelemetry-sdk-extension-aws==2.0.2
 opentelemetry-propagator-aws-xray==1.0.2
@@ -70,7 +70,7 @@ imap-tools==1.7.4
 more-itertools
 python-multipart>=0.0.18
 nltk
-blacksheep==2.0.7
+blacksheep==2.4.6
 fastembed==0.5.1
 markdown-pdf==1.7
 genson==1.3.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies: pytest → 8.3.5, black → 24.10.0, deepdiff → 8.6.1; added packaging >=20.9,<21.0
  * Updated production dependencies: sentencepiece → 0.2.1, orjson → 3.11.6, blacksheep → 2.4.6
<!-- end of auto-generated comment: release notes by coderabbit.ai -->