### PR TITLE
- voice_disconnect + voice_call fixes

### DIFF
--- a/kairon/actions/definitions/factory.py
+++ b/kairon/actions/definitions/factory.py
@@ -24,6 +24,7 @@ from kairon.shared.actions.models import ActionType
 from kairon.shared.actions.utils import ActionUtility
 from kairon.actions.definitions.schedule import ActionSchedule
 from kairon.actions.definitions.voice_call import ActionVoiceCall
+from kairon.actions.definitions.voice_disconnect import ActionVoiceDisconnect
 
 
 class ActionFactory:
@@ -50,6 +51,7 @@ class ActionFactory:
         ActionType.schedule_action.value: ActionSchedule,
         ActionType.parallel_action.value: ActionParallel,
         ActionType.voice_call_action.value: ActionVoiceCall,
+        ActionType.kairon_voice_disconnect.value: ActionVoiceDisconnect,
     }
 
     @staticmethod

--- a/kairon/actions/definitions/voice_disconnect.py
+++ b/kairon/actions/definitions/voice_disconnect.py
@@ -1,0 +1,59 @@
+from typing import Text, Dict, Any
+
+from loguru import logger
+from rasa_sdk import Tracker
+from rasa_sdk.executor import CollectingDispatcher
+
+from kairon.actions.definitions.base import ActionsBase
+from kairon.shared.actions.data_objects import ActionServerLogs
+from kairon.shared.actions.models import ActionType
+from kairon.shared.data.constant import STATUSES
+from kairon.shared.request_context import get_request_id
+
+
+class ActionVoiceDisconnect(ActionsBase):
+    """
+    Sends a disconnect signal to the voice output channel so the handler
+    can terminate the call with a <Hangup> TwiML instruction.
+    Add this action to any flow node where the call should end gracefully.
+    """
+
+    def __init__(self, bot: Text, name: Text):
+        """
+        Initialize VoiceDisconnect action.
+
+        @param bot: bot id
+        @param name: action name
+        """
+        self.bot = bot
+        self.name = name
+
+    def retrieve_config(self):
+        return {}
+
+    async def execute(self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict[Text, Any], **kwargs):
+        status = STATUSES.SUCCESS.value
+        exception = None
+        try:
+            dispatcher.utter_custom_json({"disconnect": True})
+        except Exception as e:
+            logger.exception(e)
+            exception = str(e)
+            status = STATUSES.FAIL.value
+        finally:
+            trigger_info_data = kwargs.get('action_call', {}).get('trigger_info') or {}
+            from kairon.shared.actions.data_objects import TriggerInfo
+            ActionServerLogs(
+                type=ActionType.kairon_voice_disconnect.value,
+                intent=tracker.get_intent_of_latest_message(skip_fallback_intent=False),
+                action=self.name,
+                sender=tracker.sender_id,
+                bot=self.bot,
+                exception=exception,
+                bot_response=str({"disconnect": True}),
+                status=status,
+                user_msg=tracker.latest_message.get("text"),
+                trigger_info=TriggerInfo(**trigger_info_data),
+                request_id=get_request_id()
+            ).save()
+        return {}

--- a/kairon/api/app/routers/bot/action.py
+++ b/kairon/api/app/routers/bot/action.py
@@ -859,3 +859,26 @@ async def edit_voice_call_action(
     """
     mongo_processor.edit_voice_call_action(request_data.dict(), current_user.get_bot(), current_user.get_user())
     return Response(message='Action updated')
+
+
+@router.post("/voice_disconnect", response_model=Response)
+async def add_kairon_voice_disconnect(
+        current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS)
+):
+    """
+    Registers the kairon_voice_disconnect built-in action for this bot.
+    Once registered, it can be added to flows to gracefully end a voice call.
+    """
+    mongo_processor.add_kairon_voice_disconnect(current_user.get_bot(), current_user.get_user())
+    return Response(message='Action added')
+
+
+@router.get("/voice_disconnect", response_model=Response)
+async def list_kairon_voice_disconnect(
+        current_user: User = Security(Authentication.get_current_user_and_bot, scopes=TESTER_ACCESS)
+):
+    """
+    Returns whether kairon_voice_disconnect action is registered for this bot.
+    """
+    actions = mongo_processor.list_kairon_voice_disconnect(current_user.get_bot())
+    return Response(data=actions)

--- a/kairon/chat/handlers/channels/clients/voice/base.py
+++ b/kairon/chat/handlers/channels/clients/voice/base.py
@@ -31,3 +31,7 @@ class VoiceProviderBase(ABC):
     @abstractmethod
     def validate_config(self, config: dict) -> None:
         raise NotImplementedError
+
+    @abstractmethod
+    def build_hangup_response(self, messages: List[str]) -> str:
+        raise NotImplementedError

--- a/kairon/chat/handlers/channels/clients/voice/twilio.py
+++ b/kairon/chat/handlers/channels/clients/voice/twilio.py
@@ -28,7 +28,7 @@ class TwilioVoiceProvider(VoiceProviderBase):
         self.account_sid = config["account_sid"]
         self.auth_token = config["auth_token"]
         self.phone_number = config["phone_number"]
-        self.voice_type = config.get("voice_type", "Polly.Amy")
+        self.voice_type = config.get("voice_type", "Polly.Aditi")
         self.speech_model = "default"
         self.enhanced = "false"
         self._validator = RequestValidator(self.auth_token)
@@ -46,7 +46,7 @@ class TwilioVoiceProvider(VoiceProviderBase):
             speechTimeout=self.config.get("speech_timeout", "auto"),
             speechModel=self.speech_model,
             enhanced=self.enhanced,
-            language=self.config.get("language", "en-US"),
+            language=self.config.get("language", "en-IN"),
         )
         for i, msg in enumerate(messages):
             if i + 1 == len(messages):
@@ -72,6 +72,13 @@ class TwilioVoiceProvider(VoiceProviderBase):
             bot=bot,
             user=self.config.get("user", "system"),
         ).save()
+
+    def build_hangup_response(self, messages: List[str]) -> str:
+        voice_response = VoiceResponse()
+        for msg in messages:
+            voice_response.say(msg, voice=self.voice_type)
+        voice_response.hangup()
+        return str(voice_response)
 
     def validate_config(self, config: dict) -> None:
         for field in ["account_sid", "auth_token", "phone_number"]:

--- a/kairon/chat/handlers/channels/voice.py
+++ b/kairon/chat/handlers/channels/voice.py
@@ -8,6 +8,7 @@ from starlette.requests import Request
 from kairon.chat.agent_processor import AgentProcessor
 from kairon.chat.handlers.channels.base import ChannelHandlerBase
 from kairon.chat.handlers.channels.clients.voice.factory import VoiceProviderFactory
+from kairon.shared.chat.data_objects import ChannelLogs
 from kairon.shared.chat.processor import ChatDataProcessor
 from kairon.shared.constants import ChannelTypes
 from kairon.shared.models import User
@@ -24,6 +25,7 @@ class VoiceOutput(OutputChannel):
     def __init__(self):
         """Initialise empty message accumulator for the voice turn."""
         self._messages: list = []
+        self._should_hangup: bool = False
 
     async def send_text_message(self, recipient_id: Text, text: Text, **kwargs):
         self._messages.append(text)
@@ -40,15 +42,21 @@ class VoiceOutput(OutputChannel):
         pass
 
     async def send_custom_json(self, recipient_id: Text, json_message, **kwargs):
-        text = json_message.get("text") or json_message.get("data", {}).get("text")
-        if text:
-            self._messages.append(text)
+        if json_message.get("disconnect"):
+            self._should_hangup = True
+        else:
+            text = json_message.get("text") or json_message.get("data", {}).get("text")
+            if text:
+                self._messages.append(text)
 
     def get_accumulated_text(self) -> Text:
         return " ".join(self._messages)
 
     def get_messages(self) -> list:
         return list(self._messages)
+
+    def should_hangup(self) -> bool:
+        return self._should_hangup
 
 
 class VoiceHandler(InputChannel, ChannelHandlerBase):
@@ -90,39 +98,90 @@ class VoiceHandler(InputChannel, ChannelHandlerBase):
             logger.warning("Invalid %s signature on /call — bot=%s provider=%s", self.provider, self.bot, self.provider)
             raise HTTPException(status_code=403, detail=f"Invalid {self.provider} signature")
 
-        call_status = form.get("CallStatus", "")
         speech_result = form.get("SpeechResult", "")
         sender_id = form.get("CallSid", "anonymous")
 
-        if call_status == "ringing" and not speech_result:
-            text = config.get("welcomeMessage", "Hello! How can I help you?")
-        elif speech_result:
-            text = speech_result
-        else:
-            text = None
+        metadata = {
+            "is_integration_user": True,
+            "bot": self.bot,
+            "account": self.user.account,
+            "channel_type": ChannelTypes.VOICE.value,
+            "tabname": "default",
+            "caller_phone": form.get("Called", form.get("To", "")),
+            "call_sid": sender_id,
+        }
 
-        out_channel = VoiceOutput()
-        if text is not None:
-            metadata = {
-                "is_integration_user": True,
-                "bot": self.bot,
-                "account": self.user.account,
-                "channel_type": ChannelTypes.VOICE.value,
-                "tabname": "default",
-            }
-            user_msg = UserMessage(
-                text=text,
-                output_channel=out_channel,
+        if not speech_result:
+            has_history = await self._has_prior_conversation(sender_id)
+            if not has_history:
+                welcome = config.get("welcome_message", "Hello! How can I help you?")
+                await self._record_welcome_conversation(sender_id, welcome, metadata, form)
+                return provider_impl.build_voice_response([welcome], config["call_url"])
+
+            noinput_count = await self._count_noinput(sender_id)
+            max_attempts = int(config.get("max_noinput_attempts", 1))
+
+            if noinput_count >= max_attempts:
+                timeout_msg = config.get(
+                    "timeout_message",
+                    "We didn't hear from you. Thanks for your time. Goodbye."
+                )
+                return provider_impl.build_hangup_response([timeout_msg])
+
+            noinput_channel = VoiceOutput()
+            noinput_msg = UserMessage(
+                text="noinput",
+                output_channel=noinput_channel,
                 sender_id=sender_id,
                 input_channel=self.name(),
                 metadata=metadata,
             )
-            await AgentProcessor.handle_channel_message(self.bot, user_msg)
-            messages = out_channel.get_messages()
-        else:
+            await AgentProcessor.handle_channel_message(self.bot, noinput_msg)
             messages = await self._get_reprompt(sender_id, config)
+            return provider_impl.build_voice_response(messages, config["call_url"])
+
+        out_channel = VoiceOutput()
+        user_msg = UserMessage(
+            text=speech_result,
+            output_channel=out_channel,
+            sender_id=sender_id,
+            input_channel=self.name(),
+            metadata=metadata,
+        )
+        await AgentProcessor.handle_channel_message(self.bot, user_msg)
+        messages = out_channel.get_messages()
+
+        if out_channel.should_hangup():
+            return provider_impl.build_hangup_response(messages)
 
         return provider_impl.build_voice_response(messages, config["call_url"])
+
+    async def _has_prior_conversation(self, sender_id: Text) -> bool:
+        """Check ChannelLogs for a welcome_sent entry — true means this call was already greeted."""
+        try:
+            return ChannelLogs.objects(
+                bot=self.bot, message_id=sender_id,
+                type=ChannelTypes.VOICE.value, status="welcome_sent"
+            ).count() > 0
+        except Exception:
+            return False
+
+    async def _count_noinput(self, sender_id: Text) -> int:
+        from rasa.shared.core.events import UserUttered
+        try:
+            agent = AgentProcessor.get_agent(self.bot)
+            tracker = await agent.tracker_store.retrieve(sender_id)
+            if not tracker:
+                return 0
+            count = 0
+            for event in reversed(tracker.events):
+                if isinstance(event, UserUttered) and event.text == "noinput":
+                    count += 1
+                elif isinstance(event, UserUttered):
+                    break
+            return count
+        except Exception:
+            return 0
 
     async def _get_reprompt(self, sender_id: Text, config: dict) -> List[str]:
         from rasa.shared.core.events import BotUttered
@@ -139,6 +198,19 @@ class VoiceHandler(InputChannel, ChannelHandlerBase):
         except Exception:
             pass
         return [fallback]
+
+    async def _record_welcome_conversation(self, sender_id: Text, welcome_msg: Text, metadata: dict, form: dict) -> None:
+        try:
+            ChannelLogs(
+                type=ChannelTypes.VOICE.value,
+                status="welcome_sent",
+                message_id=sender_id,
+                bot=self.bot,
+                user=self.user.get_user(),
+                data={**form, "provider": self.provider},
+            ).save()
+        except Exception:
+            pass
 
     async def handle_call_status(self) -> None:
         provider_impl, config = self._load_provider()

--- a/kairon/chat/handlers/channels/voice.py
+++ b/kairon/chat/handlers/channels/voice.py
@@ -137,6 +137,12 @@ class VoiceHandler(InputChannel, ChannelHandlerBase):
                 metadata=metadata,
             )
             await AgentProcessor.handle_channel_message(self.bot, noinput_msg)
+            if noinput_channel.should_hangup():
+                messages = noinput_channel.get_messages() or [config.get(
+                    "timeout_message",
+                    "We didn't hear from you. Thanks for your time. Goodbye."
+                )]
+                return provider_impl.build_hangup_response(messages)
             messages = await self._get_reprompt(sender_id, config)
             return provider_impl.build_voice_response(messages, config["call_url"])
 

--- a/kairon/shared/actions/models.py
+++ b/kairon/shared/actions/models.py
@@ -51,6 +51,7 @@ class ActionType(str, Enum):
     schedule_action = "schedule_action"
     parallel_action = "parallel_action"
     voice_call_action = "voice_call_action"
+    kairon_voice_disconnect = "kairon_voice_disconnect"
 
 
 class HttpRequestContentType(str, Enum):

--- a/kairon/shared/actions/utils.py
+++ b/kairon/shared/actions/utils.py
@@ -508,7 +508,9 @@ class ActionUtility:
         @param bot: bot id
         @param name: action name
         """
-        if name.startswith(UTTER_PREFIX):
+        if name == ActionType.kairon_voice_disconnect.value:
+            action_type = ActionType.kairon_voice_disconnect
+        elif name.startswith(UTTER_PREFIX):
             action_type = ActionType.kairon_bot_response
         else:
             action = ActionUtility.get_action(bot=bot, name=name)

--- a/kairon/shared/chat/processor.py
+++ b/kairon/shared/chat/processor.py
@@ -39,11 +39,11 @@ class ChatDataProcessor:
                 raise AppException("Email configuration already exists for same email address and subject")
             input_interval = configuration["config"]["interval"]
             system_interval = int(Utility.environment['integrations']["email"]['interval'])
-            EventUtility.validate_cron(input_interval,system_interval)
+            EventUtility.validate_cron(input_interval, system_interval)
         try:
             filter_args = ChatDataProcessor.__attach_metadata_and_get_filter(configuration, bot)
             channel = Channels.objects(**filter_args).get()
-            channel.config = ChatDataProcessor.__validate_config_for_update(channel,configuration["config"])
+            channel.config = ChatDataProcessor.__validate_config_for_update(channel, configuration["config"])
             primary_slack_config_changed = True if channel.connector_type == 'slack' and channel.config.get(
                 'is_primary') else False
         except DoesNotExist:
@@ -62,8 +62,7 @@ class ChatDataProcessor:
             if not MongoProcessor.is_voice_enabled(bot):
                 raise AppException("Voice is not enabled for this bot")
             endpoints = DataUtility.get_voice_channel_endpoints(channel)
-            channel.config.update(endpoints)
-            channel.save()
+            Channels.objects(id=channel.id).update_one(set__config={**channel.config, **endpoints})
             return {k: v for k, v in endpoints.items() if k in ("call_url", "status_url")}
         channel_endpoint = DataUtility.get_channel_endpoint(channel)
         return channel_endpoint
@@ -91,6 +90,7 @@ class ChatDataProcessor:
             else:
                 merged[key] = val
         return merged
+
     @staticmethod
     def __attach_metadata_and_get_filter(configuration: Dict, bot: Text):
         filter_args = {"bot": bot, "connector_type": configuration['connector_type']}

--- a/kairon/shared/data/action_serializer.py
+++ b/kairon/shared/data/action_serializer.py
@@ -306,6 +306,11 @@ class ActionSerializer:
             if actions:
                 action_config[action_type] = actions
 
+        if Actions.objects(bot=bot, status=True, type=ActionType.kairon_voice_disconnect.value).count() > 0:
+            action_config[ActionType.kairon_voice_disconnect.value] = [
+                {"name": ActionType.kairon_voice_disconnect.value}
+            ]
+
         for other_type, other_info in other_collections.items():
             other_model = other_info.get("db_model")
             other_collections = ActionSerializer.get_action_config_data_list(bot, other_model)
@@ -372,6 +377,17 @@ class ActionSerializer:
             for action_type, data in filtered_actions.items():
                 if data:
                     ActionSerializer.save_collection_data_list(action_type, bot, user, data)
+
+            if ActionType.kairon_voice_disconnect.value in actions:
+                if not Actions.objects(bot=bot, status=True, type=ActionType.kairon_voice_disconnect.value).first():
+                    Actions(
+                        name=ActionType.kairon_voice_disconnect.value,
+                        type=ActionType.kairon_voice_disconnect.value,
+                        bot=bot,
+                        user=user,
+                        status=True,
+                    ).save()
+
         if other_collections_data:
             ActionSerializer.save_other_collections(other_collections_data, bot, user, overwrite)
 

--- a/kairon/shared/data/processor.py
+++ b/kairon/shared/data/processor.py
@@ -1989,6 +1989,11 @@ class MongoProcessor:
                     "name", "id"
                 )
             ),
+            StoryStepType.kairon_voice_disconnect.value: dict(
+                Actions.objects(bot=bot, status=True, type=ActionType.kairon_voice_disconnect.value).values_list(
+                    "name", "id"
+                )
+            ),
         }
         return component_dict
 
@@ -3802,6 +3807,8 @@ class MongoProcessor:
                         step["type"] = StoryStepType.schedule_action.value
                     elif event['name'] in voice_call_actions:
                         step["type"] = StoryStepType.voice_call_action.value
+                    elif event['name'] == ActionType.kairon_voice_disconnect.value:
+                        step["type"] = StoryStepType.kairon_voice_disconnect.value
                     elif event['name'] == 'action_listen':
                         step["type"] = StoryStepType.stop_flow_action.value
                         step["name"] = 'stop_flow_action'
@@ -7055,6 +7062,13 @@ class MongoProcessor:
             )
 
     def delete_action(self, name: Text, bot: Text, user: Text):
+        """
+        soft delete an action
+        :param name: action name
+        :param bot: bot id
+        :param user: user id
+        :return:
+        """
         try:
             action = Actions.objects(name=name, bot=bot, status=True).get()
 
@@ -7236,6 +7250,24 @@ class MongoProcessor:
             raise AppException(f'Action with name "{action_name}" not found')
         VoiceCallAction.objects(name=action_name, bot=bot, status=True).get().delete()
         self.delete_action(action_name, user, bot)
+
+    def add_kairon_voice_disconnect(self, bot: Text, user: Text):
+        """Register the kairon_voice_disconnect built-in action for this bot."""
+        if not Actions.objects(bot=bot, status=True, type=ActionType.kairon_voice_disconnect.value).first():
+            Actions(
+                name=ActionType.kairon_voice_disconnect.value,
+                type=ActionType.kairon_voice_disconnect.value,
+                bot=bot,
+                user=user,
+                status=True,
+            ).save()
+
+    def list_kairon_voice_disconnect(self, bot: Text):
+        return list(
+            Actions.objects(
+                bot=bot, status=True, type=ActionType.kairon_voice_disconnect.value
+            ).values_list("name")
+        )
 
     def add_jira_action(self, action: Dict, bot: str, user: str):
         """

--- a/kairon/shared/models.py
+++ b/kairon/shared/models.py
@@ -33,6 +33,7 @@ class StoryStepType(str, Enum):
     schedule_action = "SCHEDULE_ACTION"
     parallel_action = "PARALLEL_ACTION"
     voice_call_action = "VOICE_CALL_ACTION"
+    kairon_voice_disconnect = "KAIRON_VOICE_DISCONNECT"
 
 
 class StoryType(str, Enum):

--- a/metadata/integrations.yml
+++ b/metadata/integrations.yml
@@ -102,11 +102,11 @@ voice_channels:
       - phone_number
     optional_fields:
       - voice_type
-      - voice_types
       - language
       - welcome_message
       - speech_timeout
       - reprompt_fallback_phrase
+      - timeout_message
     disabled_fields:
       - call_url
       - status_url

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -20681,11 +20681,12 @@ def test_add_story_invalid_event_type():
                     "CALLBACK_ACTION",
                     "SCHEDULE_ACTION",
                     "PARALLEL_ACTION",
-                    "VOICE_CALL_ACTION"
+                    "VOICE_CALL_ACTION",
+                    "KAIRON_VOICE_DISCONNECT"
                 ]
             },
             "loc": ["body", "steps", 0, "type"],
-            "msg": "value is not a valid enumeration member; permitted: 'INTENT', 'SLOT', 'FORM_START', 'FORM_END', 'BOT', 'HTTP_ACTION', 'ACTION', 'SLOT_SET_ACTION', 'FORM_ACTION', 'GOOGLE_SEARCH_ACTION', 'EMAIL_ACTION', 'JIRA_ACTION', 'ZENDESK_ACTION', 'PIPEDRIVE_LEADS_ACTION', 'HUBSPOT_FORMS_ACTION', 'RAZORPAY_ACTION', 'TWO_STAGE_FALLBACK_ACTION', 'PYSCRIPT_ACTION', 'PROMPT_ACTION', 'DATABASE_ACTION', 'WEB_SEARCH_ACTION', 'LIVE_AGENT_ACTION', 'STOP_FLOW_ACTION', 'CALLBACK_ACTION', 'SCHEDULE_ACTION', 'PARALLEL_ACTION', 'VOICE_CALL_ACTION'",
+            "msg": "value is not a valid enumeration member; permitted: 'INTENT', 'SLOT', 'FORM_START', 'FORM_END', 'BOT', 'HTTP_ACTION', 'ACTION', 'SLOT_SET_ACTION', 'FORM_ACTION', 'GOOGLE_SEARCH_ACTION', 'EMAIL_ACTION', 'JIRA_ACTION', 'ZENDESK_ACTION', 'PIPEDRIVE_LEADS_ACTION', 'HUBSPOT_FORMS_ACTION', 'RAZORPAY_ACTION', 'TWO_STAGE_FALLBACK_ACTION', 'PYSCRIPT_ACTION', 'PROMPT_ACTION', 'DATABASE_ACTION', 'WEB_SEARCH_ACTION', 'LIVE_AGENT_ACTION', 'STOP_FLOW_ACTION', 'CALLBACK_ACTION', 'SCHEDULE_ACTION', 'PARALLEL_ACTION', 'VOICE_CALL_ACTION', 'KAIRON_VOICE_DISCONNECT'",
             "type": "type_error.enum",
         }
     ]
@@ -21328,7 +21329,7 @@ def test_add_multiflow_story_invalid_event_type():
                    "'EMAIL_ACTION', 'JIRA_ACTION', 'ZENDESK_ACTION', 'PIPEDRIVE_LEADS_ACTION', "
                    "'HUBSPOT_FORMS_ACTION', 'RAZORPAY_ACTION', 'TWO_STAGE_FALLBACK_ACTION', 'PYSCRIPT_ACTION', "
                    "'PROMPT_ACTION', 'DATABASE_ACTION', 'WEB_SEARCH_ACTION', 'LIVE_AGENT_ACTION', 'STOP_FLOW_ACTION', "
-                   "'CALLBACK_ACTION', 'SCHEDULE_ACTION', 'PARALLEL_ACTION', 'VOICE_CALL_ACTION'",
+                   "'CALLBACK_ACTION', 'SCHEDULE_ACTION', 'PARALLEL_ACTION', 'VOICE_CALL_ACTION', 'KAIRON_VOICE_DISCONNECT'",
             "type": "type_error.enum",
             "ctx": {
                 "enum_values": [
@@ -21358,7 +21359,8 @@ def test_add_multiflow_story_invalid_event_type():
                     "CALLBACK_ACTION",
                     "SCHEDULE_ACTION",
                     "PARALLEL_ACTION",
-                    "VOICE_CALL_ACTION"
+                    "VOICE_CALL_ACTION",
+                    "KAIRON_VOICE_DISCONNECT"
                 ]
             },
         }
@@ -21454,11 +21456,12 @@ def test_update_story_invalid_event_type():
                     "CALLBACK_ACTION",
                     "SCHEDULE_ACTION",
                     "PARALLEL_ACTION",
-                    "VOICE_CALL_ACTION"
+                    "VOICE_CALL_ACTION",
+                    "KAIRON_VOICE_DISCONNECT"
                 ]
             },
             "loc": ["body", "steps", 0, "type"],
-            "msg": "value is not a valid enumeration member; permitted: 'INTENT', 'SLOT', 'FORM_START', 'FORM_END', 'BOT', 'HTTP_ACTION', 'ACTION', 'SLOT_SET_ACTION', 'FORM_ACTION', 'GOOGLE_SEARCH_ACTION', 'EMAIL_ACTION', 'JIRA_ACTION', 'ZENDESK_ACTION', 'PIPEDRIVE_LEADS_ACTION', 'HUBSPOT_FORMS_ACTION', 'RAZORPAY_ACTION', 'TWO_STAGE_FALLBACK_ACTION', 'PYSCRIPT_ACTION', 'PROMPT_ACTION', 'DATABASE_ACTION', 'WEB_SEARCH_ACTION', 'LIVE_AGENT_ACTION', 'STOP_FLOW_ACTION', 'CALLBACK_ACTION', 'SCHEDULE_ACTION', 'PARALLEL_ACTION', 'VOICE_CALL_ACTION'",
+            "msg": "value is not a valid enumeration member; permitted: 'INTENT', 'SLOT', 'FORM_START', 'FORM_END', 'BOT', 'HTTP_ACTION', 'ACTION', 'SLOT_SET_ACTION', 'FORM_ACTION', 'GOOGLE_SEARCH_ACTION', 'EMAIL_ACTION', 'JIRA_ACTION', 'ZENDESK_ACTION', 'PIPEDRIVE_LEADS_ACTION', 'HUBSPOT_FORMS_ACTION', 'RAZORPAY_ACTION', 'TWO_STAGE_FALLBACK_ACTION', 'PYSCRIPT_ACTION', 'PROMPT_ACTION', 'DATABASE_ACTION', 'WEB_SEARCH_ACTION', 'LIVE_AGENT_ACTION', 'STOP_FLOW_ACTION', 'CALLBACK_ACTION', 'SCHEDULE_ACTION', 'PARALLEL_ACTION', 'VOICE_CALL_ACTION', 'KAIRON_VOICE_DISCONNECT'",
             "type": "type_error.enum",
         }
     ]
@@ -21923,7 +21926,7 @@ def test_update_multiflow_story_invalid_event_type():
                    "'GOOGLE_SEARCH_ACTION', 'EMAIL_ACTION', 'JIRA_ACTION', 'ZENDESK_ACTION', "
                    "'PIPEDRIVE_LEADS_ACTION', 'HUBSPOT_FORMS_ACTION', 'RAZORPAY_ACTION', "
                    "'TWO_STAGE_FALLBACK_ACTION', 'PYSCRIPT_ACTION', 'PROMPT_ACTION', 'DATABASE_ACTION', "
-                   "'WEB_SEARCH_ACTION', 'LIVE_AGENT_ACTION', 'STOP_FLOW_ACTION', 'CALLBACK_ACTION', 'SCHEDULE_ACTION', 'PARALLEL_ACTION', 'VOICE_CALL_ACTION'",
+                   "'WEB_SEARCH_ACTION', 'LIVE_AGENT_ACTION', 'STOP_FLOW_ACTION', 'CALLBACK_ACTION', 'SCHEDULE_ACTION', 'PARALLEL_ACTION', 'VOICE_CALL_ACTION', 'KAIRON_VOICE_DISCONNECT'",
             "type": "type_error.enum",
             "ctx": {
                 "enum_values": [
@@ -21953,7 +21956,8 @@ def test_update_multiflow_story_invalid_event_type():
                     "CALLBACK_ACTION",
                     "SCHEDULE_ACTION",
                     "PARALLEL_ACTION",
-                    "VOICE_CALL_ACTION"
+                    "VOICE_CALL_ACTION",
+                    "KAIRON_VOICE_DISCONNECT"
                 ]
             },
         }
@@ -27339,7 +27343,7 @@ def test_list_actions():
                               'two_stage_fallback': [], 'kairon_bot_response': [], 'razorpay_action': [],
                               'prompt_action': [], 'callback_action': [], 'schedule_action': [],
                               'pyscript_action': [], 'web_search_action': [], 'live_agent_action': [],
-                                         'parallel_action':[], 'voice_call_action':[]}, ignore_order=True)
+                                         'parallel_action':[], 'voice_call_action':[], 'kairon_voice_disconnect': []}, ignore_order=True)
 
     assert actual["success"]
 
@@ -27932,11 +27936,12 @@ def test_add_rule_invalid_event_type():
                     "CALLBACK_ACTION",
                     "SCHEDULE_ACTION",
                     "PARALLEL_ACTION",
-                    "VOICE_CALL_ACTION"
+                    "VOICE_CALL_ACTION",
+                    "KAIRON_VOICE_DISCONNECT"
                 ]
             },
             "loc": ["body", "steps", 0, "type"],
-            "msg": "value is not a valid enumeration member; permitted: 'INTENT', 'SLOT', 'FORM_START', 'FORM_END', 'BOT', 'HTTP_ACTION', 'ACTION', 'SLOT_SET_ACTION', 'FORM_ACTION', 'GOOGLE_SEARCH_ACTION', 'EMAIL_ACTION', 'JIRA_ACTION', 'ZENDESK_ACTION', 'PIPEDRIVE_LEADS_ACTION', 'HUBSPOT_FORMS_ACTION', 'RAZORPAY_ACTION', 'TWO_STAGE_FALLBACK_ACTION', 'PYSCRIPT_ACTION', 'PROMPT_ACTION', 'DATABASE_ACTION', 'WEB_SEARCH_ACTION', 'LIVE_AGENT_ACTION', 'STOP_FLOW_ACTION', 'CALLBACK_ACTION', 'SCHEDULE_ACTION', 'PARALLEL_ACTION', 'VOICE_CALL_ACTION'",
+            "msg": "value is not a valid enumeration member; permitted: 'INTENT', 'SLOT', 'FORM_START', 'FORM_END', 'BOT', 'HTTP_ACTION', 'ACTION', 'SLOT_SET_ACTION', 'FORM_ACTION', 'GOOGLE_SEARCH_ACTION', 'EMAIL_ACTION', 'JIRA_ACTION', 'ZENDESK_ACTION', 'PIPEDRIVE_LEADS_ACTION', 'HUBSPOT_FORMS_ACTION', 'RAZORPAY_ACTION', 'TWO_STAGE_FALLBACK_ACTION', 'PYSCRIPT_ACTION', 'PROMPT_ACTION', 'DATABASE_ACTION', 'WEB_SEARCH_ACTION', 'LIVE_AGENT_ACTION', 'STOP_FLOW_ACTION', 'CALLBACK_ACTION', 'SCHEDULE_ACTION', 'PARALLEL_ACTION', 'VOICE_CALL_ACTION', 'KAIRON_VOICE_DISCONNECT'",
             "type": "type_error.enum",
         }
     ]
@@ -28049,11 +28054,12 @@ def test_update_rule_invalid_event_type():
                     "CALLBACK_ACTION",
                     "SCHEDULE_ACTION",
                     "PARALLEL_ACTION",
-                    "VOICE_CALL_ACTION"
+                    "VOICE_CALL_ACTION",
+                    "KAIRON_VOICE_DISCONNECT"
                 ]
             },
             "loc": ["body", "steps", 0, "type"],
-            "msg": "value is not a valid enumeration member; permitted: 'INTENT', 'SLOT', 'FORM_START', 'FORM_END', 'BOT', 'HTTP_ACTION', 'ACTION', 'SLOT_SET_ACTION', 'FORM_ACTION', 'GOOGLE_SEARCH_ACTION', 'EMAIL_ACTION', 'JIRA_ACTION', 'ZENDESK_ACTION', 'PIPEDRIVE_LEADS_ACTION', 'HUBSPOT_FORMS_ACTION', 'RAZORPAY_ACTION', 'TWO_STAGE_FALLBACK_ACTION', 'PYSCRIPT_ACTION', 'PROMPT_ACTION', 'DATABASE_ACTION', 'WEB_SEARCH_ACTION', 'LIVE_AGENT_ACTION', 'STOP_FLOW_ACTION', 'CALLBACK_ACTION', 'SCHEDULE_ACTION', 'PARALLEL_ACTION', 'VOICE_CALL_ACTION'",
+            "msg": "value is not a valid enumeration member; permitted: 'INTENT', 'SLOT', 'FORM_START', 'FORM_END', 'BOT', 'HTTP_ACTION', 'ACTION', 'SLOT_SET_ACTION', 'FORM_ACTION', 'GOOGLE_SEARCH_ACTION', 'EMAIL_ACTION', 'JIRA_ACTION', 'ZENDESK_ACTION', 'PIPEDRIVE_LEADS_ACTION', 'HUBSPOT_FORMS_ACTION', 'RAZORPAY_ACTION', 'TWO_STAGE_FALLBACK_ACTION', 'PYSCRIPT_ACTION', 'PROMPT_ACTION', 'DATABASE_ACTION', 'WEB_SEARCH_ACTION', 'LIVE_AGENT_ACTION', 'STOP_FLOW_ACTION', 'CALLBACK_ACTION', 'SCHEDULE_ACTION', 'PARALLEL_ACTION', 'VOICE_CALL_ACTION', 'KAIRON_VOICE_DISCONNECT'",
             "type": "type_error.enum",
         }
     ]
@@ -34204,7 +34210,8 @@ def test_add_bot_with_template_name(monkeypatch):
             "callback_action": [],
             "schedule_action": [],
             "parallel_action": [],
-            "voice_call_action": []
+            "voice_call_action": [],
+            "kairon_voice_disconnect": []
         },
         ignore_order=True,
     )
@@ -37856,6 +37863,40 @@ def test_edit_voice_call_action(monkeypatch):
     assert actual["success"]
     assert actual["error_code"] == 0
     assert actual["message"] == "Action updated"
+
+
+def test_add_kairon_voice_disconnect():
+    response = client.post(
+        f"/api/bot/{pytest.bot}/action/voice_disconnect",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["message"] == "Action added"
+
+
+def test_add_kairon_voice_disconnect_idempotent():
+    response = client.post(
+        f"/api/bot/{pytest.bot}/action/voice_disconnect",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert actual["message"] == "Action added"
+
+
+def test_list_kairon_voice_disconnect():
+    response = client.get(
+        f"/api/bot/{pytest.bot}/action/voice_disconnect",
+        headers={"Authorization": pytest.token_type + " " + pytest.access_token},
+    )
+    actual = response.json()
+    assert actual["success"]
+    assert actual["error_code"] == 0
+    assert isinstance(actual["data"], list)
+    assert len(actual["data"]) >= 1
 
 
 def test_add_asset(monkeypatch):

--- a/tests/unit_test/action/action_test.py
+++ b/tests/unit_test/action/action_test.py
@@ -3383,6 +3383,10 @@ class TestActions:
         action_type = ActionUtility.get_action_type(bot, 'utter_greet')
         assert action_type == "kairon_bot_response"
 
+    def test_get_action_type_kairon_voice_disconnect(self):
+        result = ActionUtility.get_action_type("any_bot", "kairon_voice_disconnect")
+        assert result == ActionType.kairon_voice_disconnect
+
     def test_get_action_config_slot_set_action(self):
         bot = 'test_actions'
         user = 'test'

--- a/tests/unit_test/action/test_voice_call_action.py
+++ b/tests/unit_test/action/test_voice_call_action.py
@@ -253,3 +253,83 @@ class TestActionVoiceCall:
                 bot="bot",
                 user="user",
             ).validate()
+
+
+class TestActionVoiceDisconnect:
+
+    @pytest.fixture(autouse=True, scope="class")
+    def setup(self):
+        os.environ["system_file"] = "./tests/testing_data/system.yaml"
+        Utility.load_environment()
+        connect(**Utility.mongoengine_connection(Utility.environment["database"]["url"]))
+
+    @pytest.fixture
+    def tracker(self):
+        t = MagicMock()
+        t.sender_id = "CA_test_sid"
+        t.get_intent_of_latest_message.return_value = "end_call"
+        t.latest_message = {"text": "goodbye"}
+        return t
+
+    @pytest.fixture
+    def dispatcher(self):
+        from rasa_sdk.executor import CollectingDispatcher
+        return CollectingDispatcher()
+
+    def test_retrieve_config_returns_empty_dict(self):
+        from kairon.actions.definitions.voice_disconnect import ActionVoiceDisconnect
+        action = ActionVoiceDisconnect("bot1", "kairon_voice_disconnect")
+        assert action.retrieve_config() == {}
+
+    @pytest.mark.asyncio
+    async def test_execute_sends_disconnect_signal(self, tracker, dispatcher):
+        from kairon.actions.definitions.voice_disconnect import ActionVoiceDisconnect
+        with patch("kairon.actions.definitions.voice_disconnect.ActionServerLogs.save"):
+            result = await ActionVoiceDisconnect("bot1", "kairon_voice_disconnect").execute(
+                dispatcher, tracker, {}, action_call={}
+            )
+        assert result == {}
+        assert any(m.get("custom", {}).get("disconnect") for m in dispatcher.messages)
+
+    @pytest.mark.asyncio
+    async def test_execute_logs_success_status(self, tracker, dispatcher):
+        from kairon.actions.definitions.voice_disconnect import ActionVoiceDisconnect
+        from kairon.shared.data.constant import STATUSES
+        with patch("kairon.actions.definitions.voice_disconnect.ActionServerLogs") as mock_log:
+            mock_log.return_value.save = MagicMock()
+            await ActionVoiceDisconnect("bot1", "kairon_voice_disconnect").execute(
+                dispatcher, tracker, {}, action_call={}
+            )
+        call_kwargs = mock_log.call_args[1]
+        assert call_kwargs["status"] == STATUSES.SUCCESS.value
+        assert call_kwargs["exception"] is None
+
+    @pytest.mark.asyncio
+    async def test_execute_logs_failure_on_dispatcher_error(self, tracker):
+        from kairon.actions.definitions.voice_disconnect import ActionVoiceDisconnect
+        from kairon.shared.data.constant import STATUSES
+        bad_dispatcher = MagicMock()
+        bad_dispatcher.utter_custom_json.side_effect = Exception("dispatcher broke")
+        with patch("kairon.actions.definitions.voice_disconnect.ActionServerLogs") as mock_log:
+            mock_log.return_value.save = MagicMock()
+            await ActionVoiceDisconnect("bot1", "kairon_voice_disconnect").execute(
+                bad_dispatcher, tracker, {}, action_call={}
+            )
+        call_kwargs = mock_log.call_args[1]
+        assert call_kwargs["status"] == STATUSES.FAIL.value
+        assert "dispatcher broke" in call_kwargs["exception"]
+
+    @pytest.mark.asyncio
+    async def test_execute_logs_bot_response_as_disconnect_json(self, tracker, dispatcher):
+        from kairon.actions.definitions.voice_disconnect import ActionVoiceDisconnect
+        with patch("kairon.actions.definitions.voice_disconnect.ActionServerLogs") as mock_log:
+            mock_log.return_value.save = MagicMock()
+            await ActionVoiceDisconnect("bot1", "kairon_voice_disconnect").execute(
+                dispatcher, tracker, {}, action_call={}
+            )
+        call_kwargs = mock_log.call_args[1]
+        assert call_kwargs["bot_response"] == str({"disconnect": True})
+
+    def test_action_type_enum_has_kairon_voice_disconnect(self):
+        assert hasattr(ActionType, "kairon_voice_disconnect")
+        assert ActionType.kairon_voice_disconnect.value == "kairon_voice_disconnect"

--- a/tests/unit_test/channels/voice_test.py
+++ b/tests/unit_test/channels/voice_test.py
@@ -165,10 +165,10 @@ class TestTwilioVoiceProvider:
         twiml = provider.build_voice_response(["Hello"], "https://example.com/call")
         assert "en-IN" in twiml
 
-    def test_build_voice_response_default_language_is_en_us(self):
+    def test_build_voice_response_default_language_is_en_in(self):
         provider = self._make_provider()
         twiml = provider.build_voice_response(["Hello"], "https://example.com/call")
-        assert "en-US" in twiml
+        assert "en-IN" in twiml
 
     @pytest.mark.asyncio
     async def test_handle_call_status_saves_channel_log(self):
@@ -225,6 +225,19 @@ class TestTwilioVoiceProvider:
         provider = self._make_provider()
         with pytest.raises(AppException, match="phone_number"):
             provider.validate_config({"account_sid": "x", "auth_token": "y"})
+
+    def test_build_hangup_response_has_say_and_hangup_no_gather(self):
+        provider = self._make_provider()
+        result = provider.build_hangup_response(["Goodbye! Have a nice day."])
+        assert "<Hangup" in result
+        assert "Goodbye! Have a nice day." in result
+        assert "<Gather" not in result
+
+    def test_build_hangup_response_empty_messages(self):
+        provider = self._make_provider()
+        result = provider.build_hangup_response([])
+        assert "<Hangup" in result
+        assert "<Gather" not in result
 
 
 class TestVoiceOutput:
@@ -329,6 +342,23 @@ class TestVoiceOutput:
         from kairon.shared.constants import ChannelTypes
         assert VoiceOutput.name() == ChannelTypes.VOICE.value
 
+    @pytest.mark.asyncio
+    async def test_send_custom_json_disconnect_sets_hangup_flag(self):
+        from kairon.chat.handlers.channels.voice import VoiceOutput
+        out = VoiceOutput()
+        assert not out.should_hangup()
+        await out.send_custom_json("user1", {"disconnect": True})
+        assert out.should_hangup()
+        assert out.get_messages() == []
+
+    @pytest.mark.asyncio
+    async def test_send_custom_json_text_does_not_set_hangup(self):
+        from kairon.chat.handlers.channels.voice import VoiceOutput
+        out = VoiceOutput()
+        await out.send_custom_json("user1", {"text": "Hello"})
+        assert not out.should_hangup()
+        assert out.get_messages() == ["Hello"]
+
 
 class TestVoiceHandler:
 
@@ -406,32 +436,27 @@ class TestVoiceHandler:
         from kairon.chat.handlers.channels.voice import VoiceHandler
         from kairon.shared.chat.processor import ChatDataProcessor
 
-        request = self._make_request({"CallSid": "CA123", "CallStatus": "ringing"})
+        request = self._make_request({"CallSid": "CA123"})
         handler = VoiceHandler("testbot", self._make_user(), request, "twilio")
-
-        async def _inject(bot, user_msg):
-            await user_msg.output_channel.send_text_message(user_msg.sender_id, "Hello!")
 
         with patch.object(ChatDataProcessor, "get_channel_config", return_value=self._make_channel_config()):
             with patch(
                 "kairon.chat.handlers.channels.clients.voice.twilio.TwilioVoiceProvider.validate_signature",
                 return_value=True,
             ):
-                with patch(
-                    "kairon.chat.handlers.channels.voice.AgentProcessor.handle_channel_message",
-                    side_effect=_inject,
-                ):
-                    result = await handler.handle_incoming_call()
+                with patch.object(handler, "_has_prior_conversation", new=AsyncMock(return_value=False)):
+                    with patch.object(handler, "_record_welcome_conversation", new=AsyncMock()):
+                        result = await handler.handle_incoming_call()
 
         assert "<Gather" in result
         assert "<Say" in result
 
     @pytest.mark.asyncio
-    async def test_handle_incoming_call_ringing_sends_welcome_to_rasa(self):
+    async def test_handle_incoming_call_first_contact_returns_welcome_directly(self):
         from kairon.chat.handlers.channels.voice import VoiceHandler
         from kairon.shared.chat.processor import ChatDataProcessor
 
-        request = self._make_request({"CallSid": "CA123", "CallStatus": "ringing"})
+        request = self._make_request({"CallSid": "CA123"})
         handler = VoiceHandler("testbot", self._make_user(), request, "twilio")
 
         with patch.object(ChatDataProcessor, "get_channel_config", return_value=self._make_channel_config()):
@@ -439,24 +464,27 @@ class TestVoiceHandler:
                 "kairon.chat.handlers.channels.clients.voice.twilio.TwilioVoiceProvider.validate_signature",
                 return_value=True,
             ):
-                with patch(
-                    "kairon.chat.handlers.channels.voice.AgentProcessor.handle_channel_message",
-                    new_callable=AsyncMock,
-                ) as mock_agent:
-                    await handler.handle_incoming_call()
+                with patch.object(handler, "_has_prior_conversation", new=AsyncMock(return_value=False)):
+                    with patch.object(handler, "_record_welcome_conversation", new=AsyncMock()) as mock_record:
+                        with patch(
+                            "kairon.chat.handlers.channels.voice.AgentProcessor.handle_channel_message",
+                            new_callable=AsyncMock,
+                        ) as mock_agent:
+                            result = await handler.handle_incoming_call()
 
-        mock_agent.assert_called_once()
-        user_msg = mock_agent.call_args[0][1]
-        assert user_msg.text == "Hello! How can I help you?"
-        assert user_msg.sender_id == "CA123"
+        mock_agent.assert_not_called()
+        mock_record.assert_called_once()
+        assert "Hello! How can I help you?" in result
+        assert "<Gather" in result
 
     @pytest.mark.asyncio
-    async def test_handle_incoming_call_ringing_uses_custom_welcome_message(self):
+    async def test_handle_incoming_call_first_contact_uses_custom_welcome_message(self):
         from kairon.chat.handlers.channels.voice import VoiceHandler
         from kairon.shared.chat.processor import ChatDataProcessor
 
         config = self._make_channel_config()
-        request = self._make_request({"CallSid": "CA123", "CallStatus": "ringing"})
+        config["config"]["welcome_message"] = "Welcome to our service!"
+        request = self._make_request({"CallSid": "CA123"})
         handler = VoiceHandler("testbot", self._make_user(), request, "twilio")
 
         with patch.object(ChatDataProcessor, "get_channel_config", return_value=config):
@@ -464,21 +492,24 @@ class TestVoiceHandler:
                 "kairon.chat.handlers.channels.clients.voice.twilio.TwilioVoiceProvider.validate_signature",
                 return_value=True,
             ):
-                with patch(
-                    "kairon.chat.handlers.channels.voice.AgentProcessor.handle_channel_message",
-                    new_callable=AsyncMock,
-                ) as mock_agent:
-                    await handler.handle_incoming_call()
+                with patch.object(handler, "_has_prior_conversation", new=AsyncMock(return_value=False)):
+                    with patch.object(handler, "_record_welcome_conversation", new=AsyncMock()):
+                        with patch(
+                            "kairon.chat.handlers.channels.voice.AgentProcessor.handle_channel_message",
+                            new_callable=AsyncMock,
+                        ) as mock_agent:
+                            result = await handler.handle_incoming_call()
 
-        user_msg = mock_agent.call_args[0][1]
-        assert user_msg.text == "Hello! How can I help you?"
+        mock_agent.assert_not_called()
+        assert "Welcome to our service!" in result
+        assert "<Gather" in result
 
     @pytest.mark.asyncio
     async def test_handle_incoming_call_speech_result_goes_to_rasa(self):
         from kairon.chat.handlers.channels.voice import VoiceHandler
         from kairon.shared.chat.processor import ChatDataProcessor
 
-        request = self._make_request({"CallSid": "CA123", "SpeechResult": "book a meeting"})
+        request = self._make_request({"CallSid": "+15550001234", "SpeechResult": "book a meeting"})
         handler = VoiceHandler("testbot", self._make_user(), request, "twilio")
 
         with patch.object(ChatDataProcessor, "get_channel_config", return_value=self._make_channel_config()):
@@ -495,15 +526,15 @@ class TestVoiceHandler:
         mock_agent.assert_called_once()
         user_msg = mock_agent.call_args[0][1]
         assert user_msg.text == "book a meeting"
-        assert user_msg.sender_id == "CA123"
+        assert user_msg.sender_id == "+15550001234"
         assert "<Gather" in result
 
     @pytest.mark.asyncio
-    async def test_handle_incoming_call_speech_uses_call_sid_as_sender_id(self):
+    async def test_handle_incoming_call_speech_uses_callsid_as_sender_id(self):
         from kairon.chat.handlers.channels.voice import VoiceHandler
         from kairon.shared.chat.processor import ChatDataProcessor
 
-        call_sid = "CAunique9988"
+        call_sid = "+15559876543"
         request = self._make_request({"CallSid": call_sid, "SpeechResult": "hello"})
         handler = VoiceHandler("testbot", self._make_user(), request, "twilio")
 
@@ -534,11 +565,17 @@ class TestVoiceHandler:
                 "kairon.chat.handlers.channels.clients.voice.twilio.TwilioVoiceProvider.validate_signature",
                 return_value=True,
             ):
-                with patch(
-                    "kairon.chat.handlers.channels.voice.AgentProcessor.get_agent",
-                    side_effect=Exception("no agent"),
-                ):
-                    result = await handler.handle_incoming_call()
+                with patch.object(handler, "_has_prior_conversation", new=AsyncMock(return_value=True)):
+                    with patch.object(handler, "_count_noinput", new=AsyncMock(return_value=0)):
+                        with patch(
+                            "kairon.chat.handlers.channels.voice.AgentProcessor.handle_channel_message",
+                            new_callable=AsyncMock,
+                        ):
+                            with patch(
+                                "kairon.chat.handlers.channels.voice.AgentProcessor.get_agent",
+                                side_effect=Exception("no agent"),
+                            ):
+                                result = await handler.handle_incoming_call()
 
         assert "<Gather" in result
         assert "sorry" in result.lower() or "repeat" in result.lower()
@@ -656,6 +693,118 @@ class TestVoiceHandler:
         with patch.object(ChatDataProcessor, "get_channel_config", return_value=self._make_channel_config()):
             with pytest.raises(AppException, match="not implemented"):
                 handler._load_provider()
+
+    @pytest.mark.asyncio
+    async def test_handle_incoming_call_disconnect_action_triggers_hangup(self):
+        from kairon.chat.handlers.channels.voice import VoiceHandler
+        from kairon.shared.chat.processor import ChatDataProcessor
+
+        request = self._make_request({"CallSid": "CA123", "SpeechResult": "goodbye"})
+        handler = VoiceHandler("testbot", self._make_user(), request, "twilio")
+
+        async def _inject_disconnect(bot, user_msg):
+            await user_msg.output_channel.send_text_message(user_msg.sender_id, "Goodbye!")
+            await user_msg.output_channel.send_custom_json(user_msg.sender_id, {"disconnect": True})
+
+        with patch.object(ChatDataProcessor, "get_channel_config", return_value=self._make_channel_config()):
+            with patch(
+                "kairon.chat.handlers.channels.clients.voice.twilio.TwilioVoiceProvider.validate_signature",
+                return_value=True,
+            ):
+                with patch(
+                    "kairon.chat.handlers.channels.voice.AgentProcessor.handle_channel_message",
+                    side_effect=_inject_disconnect,
+                ):
+                    result = await handler.handle_incoming_call()
+
+        assert "<Hangup" in result
+        assert "Goodbye!" in result
+        assert "<Gather" not in result
+
+    @pytest.mark.asyncio
+    async def test_handle_incoming_call_timeout_triggers_hangup_with_default_message(self):
+        from kairon.chat.handlers.channels.voice import VoiceHandler
+        from kairon.shared.chat.processor import ChatDataProcessor
+
+        request = self._make_request({"CallSid": "CA123"})
+        handler = VoiceHandler("testbot", self._make_user(), request, "twilio")
+
+        with patch.object(ChatDataProcessor, "get_channel_config", return_value=self._make_channel_config()):
+            with patch(
+                "kairon.chat.handlers.channels.clients.voice.twilio.TwilioVoiceProvider.validate_signature",
+                return_value=True,
+            ):
+                with patch.object(handler, "_has_prior_conversation", new=AsyncMock(return_value=True)):
+                    with patch.object(handler, "_count_noinput", new=AsyncMock(return_value=1)):
+                        result = await handler.handle_incoming_call()
+
+        assert "<Hangup" in result
+        assert "didn't hear" in result.lower() or "goodbye" in result.lower()
+        assert "<Gather" not in result
+
+    @pytest.mark.asyncio
+    async def test_handle_incoming_call_custom_timeout_message(self):
+        from kairon.chat.handlers.channels.voice import VoiceHandler
+        from kairon.shared.chat.processor import ChatDataProcessor
+
+        config = self._make_channel_config()
+        config["config"]["timeout_message"] = "Sorry, no response detected. Goodbye!"
+        request = self._make_request({"CallSid": "CA123"})
+        handler = VoiceHandler("testbot", self._make_user(), request, "twilio")
+
+        with patch.object(ChatDataProcessor, "get_channel_config", return_value=config):
+            with patch(
+                "kairon.chat.handlers.channels.clients.voice.twilio.TwilioVoiceProvider.validate_signature",
+                return_value=True,
+            ):
+                with patch.object(handler, "_has_prior_conversation", new=AsyncMock(return_value=True)):
+                    with patch.object(handler, "_count_noinput", new=AsyncMock(return_value=1)):
+                        result = await handler.handle_incoming_call()
+
+        assert "Sorry, no response detected. Goodbye!" in result
+        assert "<Hangup" in result
+        assert "<Gather" not in result
+
+    @pytest.mark.asyncio
+    async def test_has_prior_conversation_false_when_no_channel_log(self):
+        from kairon.chat.handlers.channels.voice import VoiceHandler
+        from kairon.shared.chat.data_objects import ChannelLogs
+
+        handler = VoiceHandler("testbot", self._make_user(), MagicMock(), "twilio")
+        with patch.object(ChannelLogs, "objects") as mock_objects:
+            mock_objects.return_value.count.return_value = 0
+            result = await handler._has_prior_conversation("CATEST")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_has_prior_conversation_true_when_channel_log_exists(self):
+        from kairon.chat.handlers.channels.voice import VoiceHandler
+        from kairon.shared.chat.data_objects import ChannelLogs
+
+        handler = VoiceHandler("testbot", self._make_user(), MagicMock(), "twilio")
+        with patch.object(ChannelLogs, "objects") as mock_objects:
+            mock_objects.return_value.count.return_value = 1
+            result = await handler._has_prior_conversation("CATEST")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_record_welcome_conversation_writes_channel_log(self):
+        from kairon.chat.handlers.channels.voice import VoiceHandler
+        from kairon.shared.chat.data_objects import ChannelLogs
+
+        user = self._make_user()
+        user.get_user = MagicMock(return_value="test@example.com")
+        handler = VoiceHandler("testbot", user, MagicMock(), "twilio")
+        form = {"CallSid": "CATEST", "Called": "+15550001234", "CallStatus": "in-progress"}
+        metadata = {"caller_phone": "+15550001234", "call_sid": "CATEST"}
+
+        with patch.object(ChannelLogs, "save") as mock_save:
+            await handler._record_welcome_conversation("CATEST", "Hello!", metadata, form)
+
+        mock_save.assert_called_once()
+        # verify the ChannelLogs instance was built with correct fields
+        # (save is called on the instance, so check via call inspection)
+        assert mock_save.called
 
 
 class TestVoiceChannelConfigSave:
@@ -825,8 +974,10 @@ class TestSaveChannelConfigVoiceBranch:
     def test_save_voice_config_stores_urls_back_into_channel_config(self):
         from kairon.shared.chat.processor import ChatDataProcessor
 
+        base_config = self._voice_config()["config"].copy()
         mock_channel = MagicMock()
         mock_channel.connector_type = "voice"
+        mock_channel.config = base_config
 
         endpoints = self._fake_endpoints()
 
@@ -845,8 +996,9 @@ class TestSaveChannelConfigVoiceBranch:
                             self._voice_config(), "bot1", "user@test.com"
                         )
 
-        mock_channel.config.update.assert_called_once_with(endpoints)
-        assert mock_channel.save.call_count == 2
+        assert mock_channel.save.call_count == 1
+        expected_config = {**base_config, **endpoints}
+        mock_channels_cls.objects.return_value.update_one.assert_called_once_with(set__config=expected_config)
 
     def test_save_voice_config_calls_get_voice_endpoints_not_get_channel_endpoint(self):
         from kairon.shared.chat.processor import ChatDataProcessor
@@ -1289,3 +1441,73 @@ class TestVoiceServiceEndpoints:
             self._clear_overrides()
         assert response.status_code == 200
         assert response.json().get("success") is False
+
+
+class TestCountNoinput:
+
+    @pytest.fixture(autouse=True, scope="class")
+    def setup(self):
+        os.environ["system_file"] = "./tests/testing_data/system.yaml"
+        Utility.load_environment()
+        connect(**Utility.mongoengine_connection(Utility.environment["database"]["url"]))
+
+    def _make_handler(self):
+        from kairon.chat.handlers.channels.voice import VoiceHandler
+        user = MagicMock()
+        user.account = "test_account"
+        return VoiceHandler("testbot", user, MagicMock(), "twilio")
+
+    def _make_tracker(self, texts):
+        from rasa.shared.core.events import UserUttered
+        tracker = MagicMock()
+        tracker.events = [UserUttered(text=t) for t in texts]
+        return tracker
+
+    @pytest.mark.asyncio
+    async def test_count_noinput_all_trailing(self):
+        handler = self._make_handler()
+        tracker = self._make_tracker(["hello", "noinput", "noinput", "noinput"])
+        mock_agent = MagicMock()
+        mock_agent.tracker_store.retrieve = AsyncMock(return_value=tracker)
+        with patch("kairon.chat.handlers.channels.voice.AgentProcessor.get_agent", return_value=mock_agent):
+            result = await handler._count_noinput("CA_test")
+        assert result == 3
+
+    @pytest.mark.asyncio
+    async def test_count_noinput_stops_at_real_speech(self):
+        handler = self._make_handler()
+        tracker = self._make_tracker(["noinput", "hello", "noinput"])
+        mock_agent = MagicMock()
+        mock_agent.tracker_store.retrieve = AsyncMock(return_value=tracker)
+        with patch("kairon.chat.handlers.channels.voice.AgentProcessor.get_agent", return_value=mock_agent):
+            result = await handler._count_noinput("CA_test")
+        assert result == 1
+
+    @pytest.mark.asyncio
+    async def test_count_noinput_no_noinput(self):
+        handler = self._make_handler()
+        tracker = self._make_tracker(["hello", "how are you"])
+        mock_agent = MagicMock()
+        mock_agent.tracker_store.retrieve = AsyncMock(return_value=tracker)
+        with patch("kairon.chat.handlers.channels.voice.AgentProcessor.get_agent", return_value=mock_agent):
+            result = await handler._count_noinput("CA_test")
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_count_noinput_exception_returns_zero(self):
+        handler = self._make_handler()
+        with patch("kairon.chat.handlers.channels.voice.AgentProcessor.get_agent",
+                   side_effect=Exception("agent unavailable")):
+            result = await handler._count_noinput("CA_test")
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_count_noinput_empty_events(self):
+        handler = self._make_handler()
+        tracker = MagicMock()
+        tracker.events = []
+        mock_agent = MagicMock()
+        mock_agent.tracker_store.retrieve = AsyncMock(return_value=tracker)
+        with patch("kairon.chat.handlers.channels.voice.AgentProcessor.get_agent", return_value=mock_agent):
+            result = await handler._count_noinput("CA_test")
+        assert result == 0

--- a/tests/unit_test/channels/voice_test.py
+++ b/tests/unit_test/channels/voice_test.py
@@ -766,6 +766,63 @@ class TestVoiceHandler:
         assert "<Gather" not in result
 
     @pytest.mark.asyncio
+    async def test_handle_incoming_call_noinput_disconnect_triggers_hangup(self):
+        from kairon.chat.handlers.channels.voice import VoiceHandler
+        from kairon.shared.chat.processor import ChatDataProcessor
+
+        request = self._make_request({"CallSid": "CA123"})
+        handler = VoiceHandler("testbot", self._make_user(), request, "twilio")
+
+        async def _inject_disconnect(bot, user_msg):
+            await user_msg.output_channel.send_text_message(user_msg.sender_id, "Goodbye!")
+            await user_msg.output_channel.send_custom_json(user_msg.sender_id, {"disconnect": True})
+
+        with patch.object(ChatDataProcessor, "get_channel_config", return_value=self._make_channel_config()):
+            with patch(
+                "kairon.chat.handlers.channels.clients.voice.twilio.TwilioVoiceProvider.validate_signature",
+                return_value=True,
+            ):
+                with patch.object(handler, "_has_prior_conversation", new=AsyncMock(return_value=True)):
+                    with patch.object(handler, "_count_noinput", new=AsyncMock(return_value=0)):
+                        with patch(
+                            "kairon.chat.handlers.channels.voice.AgentProcessor.handle_channel_message",
+                            side_effect=_inject_disconnect,
+                        ):
+                            result = await handler.handle_incoming_call()
+
+        assert "<Hangup" in result
+        assert "Goodbye!" in result
+        assert "<Gather" not in result
+
+    @pytest.mark.asyncio
+    async def test_handle_incoming_call_noinput_disconnect_without_message_uses_timeout_fallback(self):
+        from kairon.chat.handlers.channels.voice import VoiceHandler
+        from kairon.shared.chat.processor import ChatDataProcessor
+
+        request = self._make_request({"CallSid": "CA123"})
+        handler = VoiceHandler("testbot", self._make_user(), request, "twilio")
+
+        async def _inject_silent_disconnect(bot, user_msg):
+            await user_msg.output_channel.send_custom_json(user_msg.sender_id, {"disconnect": True})
+
+        with patch.object(ChatDataProcessor, "get_channel_config", return_value=self._make_channel_config()):
+            with patch(
+                "kairon.chat.handlers.channels.clients.voice.twilio.TwilioVoiceProvider.validate_signature",
+                return_value=True,
+            ):
+                with patch.object(handler, "_has_prior_conversation", new=AsyncMock(return_value=True)):
+                    with patch.object(handler, "_count_noinput", new=AsyncMock(return_value=0)):
+                        with patch(
+                            "kairon.chat.handlers.channels.voice.AgentProcessor.handle_channel_message",
+                            side_effect=_inject_silent_disconnect,
+                        ):
+                            result = await handler.handle_incoming_call()
+
+        assert "<Hangup" in result
+        assert "didn't hear" in result.lower() or "goodbye" in result.lower()
+        assert "<Gather" not in result
+
+    @pytest.mark.asyncio
     async def test_has_prior_conversation_false_when_no_channel_log(self):
         from kairon.chat.handlers.channels.voice import VoiceHandler
         from kairon.shared.chat.data_objects import ChannelLogs

--- a/tests/unit_test/data_processor/data_processor_test.py
+++ b/tests/unit_test/data_processor/data_processor_test.py
@@ -16098,7 +16098,8 @@ class TestMongoProcessor:
             'pipedrive_leads_action': [], 'hubspot_forms_action': [], 'two_stage_fallback': [],
             'kairon_bot_response': [], 'razorpay_action': [], 'prompt_action': [], 'actions': [],
             'database_action': [], 'pyscript_action': [], 'web_search_action': [], 'live_agent_action': [],
-            'callback_action': [], 'schedule_action': [], 'voice_call_action': [], 'parallel_action': []
+            'callback_action': [], 'schedule_action': [], 'voice_call_action': [], 'parallel_action': [],
+            'kairon_voice_disconnect': []
         }
 
     def test_add_complex_story_with_action(self):
@@ -16122,7 +16123,7 @@ class TestMongoProcessor:
             'zendesk_action': [], 'pipedrive_leads_action': [], 'hubspot_forms_action': [], 'two_stage_fallback': [],
             'kairon_bot_response': [], 'razorpay_action': [], 'prompt_action': [], 'database_action': [],
             'pyscript_action': [], 'voice_call_action': [], 'web_search_action': [], 'live_agent_action': [], 'callback_action': [], 'schedule_action': [],
-            'parallel_action': []
+            'parallel_action': [], 'kairon_voice_disconnect': []
         }
 
     def test_add_complex_story(self):
@@ -16149,6 +16150,7 @@ class TestMongoProcessor:
                                       'razorpay_action': [], 'prompt_action': ['gpt_llm_faq'],
                                       'database_action': [], 'pyscript_action': [], 'web_search_action': [], 'live_agent_action': [],
                                       'callback_action': [], 'schedule_action': [], 'voice_call_action': [], 'parallel_action': [],
+                                      'kairon_voice_disconnect': [],
                                       'utterances': ['utter_greet',
                                                      'utter_cheer_up',
                                                      'utter_did_that_help',
@@ -18036,7 +18038,7 @@ class TestMongoProcessor:
             'hubspot_forms_action': [], 'two_stage_fallback': [], 'kairon_bot_response': [], 'razorpay_action': [],
             'email_action': [], 'form_validation_action': [], 'prompt_action': [], 'database_action': [],
             'pyscript_action': [], 'web_search_action': [], 'live_agent_action': [], 'callback_action': [], 'schedule_action': [],
-            'voice_call_action': [],
+            'voice_call_action': [], 'kairon_voice_disconnect': [],
             'utterances': ['utter_offer_help', 'utter_query', 'utter_goodbye', 'utter_feedback', 'utter_default',
                            'utter_please_rephrase'], 'parallel_action': []}, ignore_order=True)
 
@@ -18147,6 +18149,7 @@ class TestMongoProcessor:
             'slot_set_action': [], 'email_action': [], 'form_validation_action': [], 'jira_action': [],
             'database_action': [], 'pyscript_action': [], 'web_search_action': [], 'live_agent_action': [],
             'callback_action': [], 'schedule_action': [], 'voice_call_action': [], 'parallel_action': [],
+            'kairon_voice_disconnect': [],
             'utterances': ['utter_greet',
                            'utter_cheer_up',
                            'utter_did_that_help',

--- a/tests/unit_test/data_processor/voice_call_test.py
+++ b/tests/unit_test/data_processor/voice_call_test.py
@@ -422,3 +422,100 @@ class TestVoiceCallStoryIntegration:
 
         from kairon.shared.actions.models import ActionType
         assert ActionType.voice_call_action.value in action_config or True
+
+
+class TestKaironVoiceDisconnect:
+
+    @pytest.fixture(autouse=True, scope="class")
+    def init_connection(self):
+        connect(**Utility.mongoengine_connection())
+
+    def test_story_step_type_enum_has_kairon_voice_disconnect(self):
+        assert hasattr(StoryStepType, "kairon_voice_disconnect")
+        assert StoryStepType.kairon_voice_disconnect.value == "KAIRON_VOICE_DISCONNECT"
+
+    def test_add_kairon_voice_disconnect_inserts_when_not_exists(self):
+        processor = MongoProcessor()
+        with patch("kairon.shared.data.processor.Actions") as mock_actions_cls:
+            mock_actions_cls.objects.return_value.first.return_value = None
+            mock_instance = MagicMock()
+            mock_actions_cls.return_value = mock_instance
+            processor.add_kairon_voice_disconnect("testbot", "testuser")
+        mock_instance.save.assert_called_once()
+
+    def test_add_kairon_voice_disconnect_skips_if_exists(self):
+        processor = MongoProcessor()
+        with patch("kairon.shared.data.processor.Actions") as mock_actions_cls:
+            mock_actions_cls.objects.return_value.first.return_value = MagicMock()
+            mock_instance = MagicMock()
+            mock_actions_cls.return_value = mock_instance
+            processor.add_kairon_voice_disconnect("testbot", "testuser")
+        mock_instance.save.assert_not_called()
+
+    def test_list_kairon_voice_disconnect_returns_names(self):
+        from kairon.shared.actions.data_objects import Actions
+        from kairon.shared.actions.models import ActionType
+        processor = MongoProcessor()
+        with patch("kairon.shared.data.processor.Actions") as mock_actions:
+            mock_actions.objects.return_value.values_list.return_value = ["kairon_voice_disconnect"]
+            result = processor.list_kairon_voice_disconnect("somebot")
+        assert result == ["kairon_voice_disconnect"]
+        mock_actions.objects.assert_called_once_with(
+            bot="somebot", status=True, type=ActionType.kairon_voice_disconnect.value
+        )
+
+    def test_list_kairon_voice_disconnect_empty(self):
+        processor = MongoProcessor()
+        with patch("kairon.shared.data.processor.Actions") as mock_actions:
+            mock_actions.objects.return_value.values_list.return_value = []
+            result = processor.list_kairon_voice_disconnect("emptybot")
+        assert result == []
+
+    def test_action_serializer_serialize_includes_voice_disconnect_when_present(self):
+        from kairon.shared.actions.data_objects import Actions
+        from kairon.shared.actions.models import ActionType
+        bot = "serialize_vd_bot"
+        with patch.object(Actions, "objects") as mock_objects:
+            mock_count = MagicMock()
+            mock_count.count.return_value = 1
+            mock_objects.return_value = mock_count
+            action_config, _ = ActionSerializer.serialize(bot)
+        from kairon.shared.actions.models import ActionType
+        assert ActionType.kairon_voice_disconnect.value in action_config
+        assert action_config[ActionType.kairon_voice_disconnect.value] == [
+            {"name": ActionType.kairon_voice_disconnect.value}
+        ]
+
+    def test_action_serializer_serialize_excludes_voice_disconnect_when_absent(self):
+        from kairon.shared.actions.data_objects import Actions
+        from kairon.shared.actions.models import ActionType
+        bot = "serialize_vd_absent_bot"
+        with patch.object(Actions, "objects") as mock_objects:
+            mock_count = MagicMock()
+            mock_count.count.return_value = 0
+            mock_objects.return_value = mock_count
+            action_config, _ = ActionSerializer.serialize(bot)
+        assert ActionType.kairon_voice_disconnect.value not in action_config
+
+    def test_action_serializer_deserialize_creates_actions_entry_when_key_present(self):
+        from kairon.shared.actions.data_objects import Actions
+        from kairon.shared.actions.models import ActionType
+        bot = "deserialize_vd_bot"
+        actions = {ActionType.kairon_voice_disconnect.value: [{"name": ActionType.kairon_voice_disconnect.value}]}
+        with patch.object(Actions, "objects") as mock_objects, \
+             patch.object(Actions, "save") as mock_save:
+            mock_objects.return_value.first.return_value = None
+            ActionSerializer.deserialize(bot, "user1", actions=actions)
+        mock_save.assert_called_once()
+
+    def test_action_serializer_deserialize_skips_if_already_exists(self):
+        from kairon.shared.actions.data_objects import Actions
+        from kairon.shared.actions.models import ActionType
+        bot = "deserialize_vd_existing_bot"
+        actions = {ActionType.kairon_voice_disconnect.value: [{"name": ActionType.kairon_voice_disconnect.value}]}
+        existing = MagicMock()
+        with patch.object(Actions, "objects") as mock_objects, \
+             patch.object(Actions, "save") as mock_save:
+            mock_objects.return_value.first.return_value = existing
+            ActionSerializer.deserialize(bot, "user1", actions=actions)
+        mock_save.assert_not_called()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a built-in voice disconnect action for bots, including automatic registration/listing via new `/voice_disconnect` API endpoints.
  * Voice calls can now terminate gracefully when a disconnect signal is received or when no-input/max-attempts/timeouts occur.
  * Provider hangup/farewell responses are now supported (including Twilio).
* **Bug Fixes**
  * Improved first-call handling so the initial welcome message is delivered correctly based on prior conversation history.
* **Tests**
  * Added and updated unit/integration tests covering disconnect, hangup, timeout/no-input flows, and Twilio behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->