### PR TITLE
- invalidate token on logout

### DIFF
--- a/email.yaml
+++ b/email.yaml
@@ -13,6 +13,7 @@ email:
         confirmation_subject: ${EMAIL_TEMPLATES_CONFIRMATION_SUBJECT:"Welcome to kAIron! Please verify your account."}
         confirmed_subject: ${EMAIL_TEMPLATES_CONFIRMED_SUBJECT:"Verification complete! Build your first chatbot."}
         password_reset_subject: ${EMAIL_TEMPLATES_PASSWORD_RESET_SUBJECT:"Password Reset"}
+        password_reset_unverified_subject: ${EMAIL_TEMPLATES_PASSWORD_RESET_UNVERIFIED_SUBJECT:"Verify your email to reset password"}
         password_changed_subject: ${EMAIL_TEMPLATES_PASSWORD_CHANGED_SUBJECT:"Password Changed!"}
         add_member_subject: ${EMAIL_TEMPLATES_ADD_MEMBER_SUBJECT:"Invitation to collaborate on BOT_NAME bot"}
         add_member_confirmation_subject: ${EMAIL_TEMPLATES_ADD_MEMBER_CONFIRMATION_SUBJECT:"Invitation accepted by INVITED_PERSON_NAME"}

--- a/kairon/api/app/routers/account.py
+++ b/kairon/api/app/routers/account.py
@@ -105,10 +105,8 @@ async def password_link_generate(mail: RecaptchaVerifiedTextData, background_tas
     Used to send a password reset link when the user clicks on the "Forgot Password" link and enters his/her mail id
     """
     Utility.validate_enable_sso_only()
-    email = mail.data
-    mail, first_name, url = await AccountProcessor.send_reset_link(email.strip())
-    background_tasks.add_task(MailUtility.format_and_send_mail, mail_type='password_reset', email=mail, first_name=first_name, url=url)
-    return {"message": "Success! A password reset link has been sent to your mail id"}
+    background_tasks.add_task(AccountProcessor.handle_password_reset_request, mail.data.strip())
+    return {"message": "If the email address is registered with us, you'll receive a password reset email shortly."}
 
 
 @router.post("/password/change", response_model=Response)

--- a/kairon/api/app/routers/auth.py
+++ b/kairon/api/app/routers/auth.py
@@ -176,11 +176,13 @@ async def sso_callback(
 
 @router.post("/logout", response_model=Response)
 async def logout(
-        current_user: User = Depends(Authentication.get_current_user)
+        current_user: User = Depends(Authentication.get_current_user),
+        token: str = Depends(DataUtility.oauth2_scheme)
 ):
     """
     Invalidate user session and revoke authentication token upon successful logout.
     """
+    Authentication.logout(token, current_user.email)
     UserActivityLogger.add_log(a_type=UserActivityType.logout.value, account=current_user.account,
                                email=current_user.email, data={"username": current_user.email})
     return Response(message="User Logged out!")

--- a/kairon/api/app/routers/bot/data.py
+++ b/kairon/api/app/routers/bot/data.py
@@ -3,6 +3,8 @@ from typing import List, Optional
 from fastapi import UploadFile, File, Security, APIRouter, Query, HTTPException, Path
 from starlette.requests import Request
 from starlette.responses import FileResponse
+
+from kairon.shared.chat.broadcast.processor import MessageBroadcastProcessor
 from kairon.shared.chat.processor import ChatDataProcessor
 from kairon.shared.chat.user_media import UserMedia
 from kairon.api.models import Response, CognitiveDataRequest, CognitionSchemaRequest, CollectionDataRequest
@@ -608,7 +610,18 @@ async def get_media_ids(
     current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
 ):
     try:
-        media_ids = UserMedia.get_media_ids(current_user.get_bot())
+        media_ids = MessageBroadcastProcessor.fetch_media_ids(current_user.get_bot(), current_user.get_user())
+        return Response(message="List of media ids", data=media_ids)
+    except Exception as e:
+        raise AppException(f"Error while fetching media ids: {str(e)}")
+
+
+@router.get("/broadcast/media/ids", response_model=Response)
+async def get_whatsapp_media_ids(
+    current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
+):
+    try:
+        media_ids = MessageBroadcastProcessor.fetch_broadcast_media_ids(current_user.get_bot(), current_user.get_user())
         return Response(message="List of media ids", data=media_ids)
     except Exception as e:
         raise AppException(f"Error while fetching media ids: {str(e)}")
@@ -638,3 +651,12 @@ async def fetch_media_url(
     media_url = CloudUtility.get_s3_media_url(filename, current_user.get_bot())
     return Response(message="Successfully fetched media details", data={"media_url": f"{media_url}",
                                                                         "filename": f"{filename}"})
+
+
+@router.get("/fetch_handle_id/{media_id}")
+async def fetch_media_handle_id(
+        media_id: str,
+        current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS)
+):
+    media_handle_id = UserMedia.get_media_handle_id(current_user.get_bot(), media_id)
+    return Response(message="Successfully fetched media details", data={"handle_id": media_handle_id})

--- a/kairon/chat/handlers/channels/clients/whatsapp/cloud.py
+++ b/kairon/chat/handlers/channels/clients/whatsapp/cloud.py
@@ -46,8 +46,6 @@ class WhatsappCloud(object):
 
         self.access_token = access_token
         self.from_phone_number_id = kwargs.get('from_phone_number_id')
-        if self.client_type == "meta" and Utility.check_empty_string(self.from_phone_number_id):
-            raise AppException("missing parameter 'from_phone_number_id'")
         self.session = kwargs.get('session', requests.Session())
         self.api_version = kwargs.get('api_version', DEFAULT_API_VERSION)
         self.app = 'https://graph.facebook.com/v{api_version}'.format(api_version=self.api_version)
@@ -57,6 +55,10 @@ class WhatsappCloud(object):
     @property
     def client_type(self):
         return "meta"
+
+    @staticmethod
+    def _recipient_field(to_phone_number: str) -> str:
+        return "recipient" if "." in to_phone_number else "to"
 
     @property
     def auth_args(self):
@@ -88,10 +90,10 @@ class WhatsappCloud(object):
         body = {
             'messaging_product': "whatsapp",
             'recipient_type': recipient_type,
-            "to": to_phone_number,
             "type": messaging_type,
             messaging_type: payload
         }
+        body[self._recipient_field(to_phone_number)] = to_phone_number
 
         if tag:
             body['tag'] = tag
@@ -118,10 +120,10 @@ class WhatsappCloud(object):
         body = {
             'messaging_product': "whatsapp",
             'recipient_type': recipient_type,
-            "to": to_phone_number,
             "type": messaging_type,
             messaging_type: payload
         }
+        body[self._recipient_field(to_phone_number)] = to_phone_number
 
         if tag:
             body['tag'] = tag
@@ -141,7 +143,7 @@ class WhatsappCloud(object):
         payload.update({
             'messaging_product': "whatsapp",
             'recipient_type': recipient_type,
-            "to": to_phone_number
+            self._recipient_field(to_phone_number): to_phone_number
         })
 
         return self.send_action(payload)
@@ -154,6 +156,8 @@ class WhatsappCloud(object):
                 timeout: request timeout
             @outputs: response json
         """
+        if self.client_type == "meta" and Utility.check_empty_string(self.from_phone_number_id):
+            raise AppException("missing parameter 'from_phone_number_id'")
         r = self.session.post(
             '{app}/{from_phone_number_id}/messages'.format(app=self.app, from_phone_number_id=self.from_phone_number_id),
             params=self.auth_args,
@@ -223,6 +227,10 @@ class WhatsappCloud(object):
             payload.update({"components": components})
         return await self.send_async(payload, to_phone_number, messaging_type="template")
 
+    async def send_broadcast_template_async(self, template_id: str, recipient: str,
+                                            language_code: str, components, namespace: str = None):
+        return await self.send_template_message_async(template_id, recipient, language_code, components, namespace)
+
     async def send_action_async(self, payload: dict, timeout: float = WHATSAPP_REQUEST_TIMEOUT, attempts: int = 3,
                                 **kwargs) -> (bool, int, dict):
         """
@@ -236,6 +244,8 @@ class WhatsappCloud(object):
                 status_code: response status code
                 response: response json
         """
+        if self.client_type == "meta" and Utility.check_empty_string(self.from_phone_number_id):
+            raise AppException("missing parameter 'from_phone_number_id'")
         last_status_code = 500
         last_response = None
         try:
@@ -264,7 +274,7 @@ class WhatsappCloud(object):
         except Exception as e:
             return False, last_status_code, {"error": str(e), "response": last_response}
 
-    def get_media_info(self, whatsapp_media_id, config):
+    def get_media_info(self, whatsapp_media_id, config, media_data=None):
         import mimetypes
 
         endpoint = f"{self.app}/{whatsapp_media_id}"

--- a/kairon/chat/handlers/channels/clients/whatsapp/dialog360.py
+++ b/kairon/chat/handlers/channels/clients/whatsapp/dialog360.py
@@ -88,7 +88,7 @@ class BSP360Dialog(WhatsappCloud):
         return self.send_action(payload)
 
 
-    def get_media_info(self, whatsapp_media_id, config):
+    def get_media_info(self, whatsapp_media_id, config, media_data=None):
         import mimetypes
         import requests
 

--- a/kairon/chat/handlers/channels/clients/whatsapp/factory.py
+++ b/kairon/chat/handlers/channels/clients/whatsapp/factory.py
@@ -2,6 +2,7 @@ from typing import Text
 
 from kairon.chat.handlers.channels.clients.whatsapp.dialog360 import BSP360Dialog
 from kairon.chat.handlers.channels.clients.whatsapp.cloud import WhatsappCloud
+from kairon.chat.handlers.channels.clients.whatsapp.gupshup import BSPGupshup
 from kairon.exceptions import AppException
 from kairon.shared.constants import WhatsappBSPTypes
 
@@ -10,7 +11,8 @@ class WhatsappFactory:
 
     __clients = {
         "meta": WhatsappCloud,
-        WhatsappBSPTypes.bsp_360dialog.value: BSP360Dialog
+        WhatsappBSPTypes.bsp_360dialog.value: BSP360Dialog,
+        WhatsappBSPTypes.bsp_gupshup.value: BSPGupshup
     }
 
     @staticmethod

--- a/kairon/chat/handlers/channels/clients/whatsapp/gupshup.py
+++ b/kairon/chat/handlers/channels/clients/whatsapp/gupshup.py
@@ -1,0 +1,255 @@
+import json
+import requests
+from aiohttp import ClientResponseError, ClientConnectionError, ClientError
+from aiohttp_retry import ExponentialRetry, RetryClient
+
+from kairon import Utility
+from kairon.chat.handlers.channels.clients.whatsapp.cloud import WhatsappCloud
+from kairon.exceptions import AppException
+from kairon.shared.constants import WhatsappBSPTypes
+from loguru import logger
+
+INVALID_STATUS_CODES = set(range(400, 600))
+
+class BSPGupshup(WhatsappCloud):
+    WHATSAPP_REQUEST_TIMEOUT = 120.0
+
+    def __init__(self, access_token, **kwargs):
+        """Initialize BSPGupshup chat client with access token and channel config."""
+        super().__init__(access_token, **kwargs)
+        self.access_token = access_token
+        # config kwarg may be a full channel doc {"config": {...}, "connector_type": ...}
+        # or an inner config dict {"app_id": ...} — handle both
+        config_kwarg = kwargs.get('config', {})
+        inner_config = config_kwarg.get('config', config_kwarg)
+        self.app_id = inner_config.get('app_id')
+        self.app_name = inner_config.get('app_name')
+        self.phone_number = inner_config.get('phone_number')
+        self.partner_base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"][
+            "partner_base_url"]
+        self.auth_header = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"][
+            "auth_header"]
+        self.app = f'{self.partner_base_url}'
+
+    @property
+    def client_type(self):
+        return WhatsappBSPTypes.bsp_gupshup.value
+
+    @property
+    def auth_args(self):
+        if not hasattr(self, '_auth_args'):
+            self._auth_args = {self.auth_header: self.access_token}
+        return self._auth_args
+
+    def send_action(self, payload, timeout=None, **kwargs):
+        """Send a synchronous Gupshup message."""
+        messaging_type = payload.get("type")
+        destination = payload.get("to") or payload.get("recipient")
+        form_data = {
+            "source": self.phone_number,
+            "destination": destination,
+            "message": json.dumps(self._build_gupshup_message(messaging_type, payload.get(messaging_type, {})))
+        }
+        r = requests.post(
+            self.get_url(api_type="message"),
+            headers=self.auth_args,
+            data=form_data,
+            timeout=timeout
+        )
+        resp = r.json()
+        logger.debug(resp)
+        return resp
+
+    async def send_action_async(self, payload, timeout=None, attempts: int = 3, **kwargs):
+        """Send an asynchronous Gupshup message with exponential retry."""
+        last_status_code = 500
+        last_response = None
+        try:
+            retry_options = ExponentialRetry(attempts=attempts, statuses=INVALID_STATUS_CODES, max_timeout=timeout)
+            url = kwargs.get('url')
+            use_form = kwargs.get('use_form', False)
+            headers = kwargs.get('headers') or self.auth_args
+
+            async with RetryClient(raise_for_status=False, retry_options=retry_options) as client:
+                if use_form:
+                    request = client.post(url, data=payload, headers=headers)
+                else:
+                    request = client.post(url, json=payload, headers=headers)
+                async with request as response:
+                    last_status_code = response.status
+
+                    if response.status in (200, 202):
+                        resp = await response.json()
+                        logger.debug(f"Gupshup send success: {resp}")
+                        return True, response.status, resp
+                    else:
+                        try:
+                            last_response = await response.json()
+                        except Exception:
+                            last_response = await response.text()
+                        logger.error(f"Gupshup send failed: status={last_status_code} url={url} response={last_response}")
+
+            return False, last_status_code, last_response
+        except ClientResponseError as cre:
+            return False, last_status_code, {"error": str(cre), "response": last_response}
+        except ClientConnectionError as cce:
+            return False, last_status_code, {"error": str(cce), "response": last_response}
+        except ClientError as ce:
+            return False, last_status_code, {"error": str(ce), "response": last_response}
+        except Exception as e:
+            return False, last_status_code, {"error": str(e), "response": last_response}
+
+    async def send_template_message_async(self, name: str, to_phone_number: str, language_code: str = "en",
+                                          components: dict = None, namespace: str = None) -> (bool, int, any):
+        payload = {
+            "language": {
+                "code": language_code
+            },
+            "name": name
+        }
+        if components:
+            payload.update({"components": components})
+        return await self.send_async(payload, to_phone_number, messaging_type="template")
+
+    def get_url(self, api_type: str) -> str:
+        if api_type == "message":
+            # SMSGW apps use /msg (form-encoded); CAPI apps use /v3/message (JSON)
+            return f"{self.partner_base_url}/partner/app/{self.app_id}/msg"
+        elif api_type == "template":
+            return f"{self.partner_base_url}/partner/app/{self.app_id}/template/msg"
+        else:
+            raise ValueError(f"Unknown api_type: {api_type}")
+
+    def _build_gupshup_message(self, messaging_type: str, payload: dict) -> dict:
+        """Map Meta Cloud API message payload to Gupshup SMSGW message format."""
+        if messaging_type == "text":
+            return {"type": "text", "text": payload.get("body", "")}
+        elif messaging_type == "image":
+            url = payload.get("link", "")
+            return {"type": "image", "originalUrl": url, "previewUrl": url,
+                    "caption": payload.get("caption", "")}
+        elif messaging_type == "document":
+            return {"type": "file", "url": payload.get("link", ""),
+                    "filename": payload.get("filename", ""),
+                    "caption": payload.get("caption", "")}
+        elif messaging_type == "audio":
+            return {"type": "audio", "url": payload.get("link", "")}
+        elif messaging_type == "video":
+            return {"type": "video", "url": payload.get("link", ""),
+                    "caption": payload.get("caption", "")}
+        elif messaging_type == "location":
+            return {"type": "location", "longitude": payload.get("longitude"),
+                    "latitude": payload.get("latitude"),
+                    "name": payload.get("name", ""), "address": payload.get("address", "")}
+        logger.warning(f"Gupshup SMSGW: unsupported messaging_type '{messaging_type}'")
+        return {"type": messaging_type}
+
+    async def send_gupshup_template_message(self, recipient, components):
+        template, message = components
+
+        url = self.get_url(api_type="template")
+
+        headers = {
+            self.auth_header: self.access_token,
+            "Content-Type": "application/x-www-form-urlencoded",
+            "accept": "application/json"
+        }
+
+        data = {
+            "destination": recipient,
+            "source": self.phone_number or self.app_name,
+            "src.name": self.app_name,
+            "template": json.dumps(template),
+        }
+        if message.get("type") != "text":
+            data["message"] = json.dumps(message)
+
+
+        return await self.send_action_async(
+            payload=data,
+            url=url,
+            headers=headers,
+            use_form=True
+        )
+
+    async def send_broadcast_template_async(self, template_id: str, recipient: str,
+                                            language_code: str, components, namespace: str = None):
+        if isinstance(components, tuple):
+            return await self.send_gupshup_template_message(recipient, components)
+        return await self.send_template_message_async(template_id, recipient, language_code, components, namespace)
+
+    async def send_async(self, payload: dict, to_phone_number: str, messaging_type: str,
+                         recipient_type: str = 'individual',
+                         timeout: float = WHATSAPP_REQUEST_TIMEOUT, tag=None) -> (bool, int, any):
+        """Send an async Gupshup message via SMSGW form-encoded endpoint."""
+        if messaging_type not in self.MESSAGING_TYPES:
+            raise ValueError('`{}` is not a valid `messaging_type`'.format(messaging_type))
+
+        url = self.get_url(api_type="message")
+
+        form_data = {
+            "source": self.phone_number,
+            "destination": to_phone_number,
+            "message": json.dumps(self._build_gupshup_message(messaging_type, payload))
+        }
+
+        return await self.send_action_async(
+            payload=form_data,
+            url=url,
+            timeout=timeout,
+            headers=self.auth_args,
+            use_form=True
+        )
+
+
+    def _v3_url(self):
+        return f"{self.partner_base_url}/partner/app/{self.app_id}/v3/message"
+
+    def _v3_headers(self):
+        # v3 endpoint uses Authorization header (not token)
+        return {"Authorization": self.access_token, "Content-Type": "application/json"}
+
+    def send_statuses(self, payload, timeout):
+        r = requests.post(self._v3_url(), headers=self._v3_headers(), json=payload, timeout=timeout)
+        resp = r.json()
+        return resp
+
+    def mark_as_read(self, msg_id, timeout=None):
+        payload = {"messaging_product": "whatsapp", "status": "read", "message_id": msg_id}
+        return self.send_statuses(payload, timeout)
+
+    def typing_indicator(self, msg_id, timeout=None):
+        payload = {"messaging_product": "whatsapp", "status": "read", "message_id": msg_id,
+                   "typing_indicator": {"type": "text"}}
+        return self.send_statuses(payload, timeout)
+
+    def get_media_info(self, whatsapp_media_id, config, media_data=None):
+        import mimetypes
+
+        headers = {"Authorization": self.access_token}
+        logger.debug(media_data)
+
+        if media_data and media_data.get("url"):
+            download_url = media_data["url"]
+            mime_type = media_data.get("mime_type", "")
+            extension = mimetypes.guess_extension(mime_type) or ""
+            file_path = f"whatsapp_gupshup_{whatsapp_media_id}{extension}"
+            return download_url, headers, file_path
+
+        endpoint = f"{self.partner_base_url}/partner/app/{self.app_id}/media/{whatsapp_media_id}"
+
+        resp = requests.get(endpoint, headers=headers, timeout=10)
+
+        if resp.status_code != 200:
+            raise AppException(
+                f"Failed to get media info from Gupshup: {resp.status_code}"
+            )
+
+        data = resp.json()
+        download_url = data.get("url")
+        mime_type = data.get("mime_type")
+        extension = mimetypes.guess_extension(mime_type) or ""
+        file_path = f"whatsapp_gupshup_{whatsapp_media_id}{extension}"
+
+        return download_url, headers, file_path
+

--- a/kairon/chat/handlers/channels/whatsapp.py
+++ b/kairon/chat/handlers/channels/whatsapp.py
@@ -14,7 +14,7 @@ from kairon.shared.chat.processor import ChatDataProcessor
 from kairon import Utility
 from kairon.shared.chat.user_media import UserMedia
 from kairon.shared.concurrency.actors.factory import ActorFactory
-from kairon.shared.constants import ChannelTypes, ActorType
+from kairon.shared.constants import ChannelTypes, ActorType, WhatsappBSPTypes
 from kairon.shared.models import User
 
 logger = logging.getLogger(__name__)
@@ -56,9 +56,10 @@ class Whatsapp:
                         media_id = doc["id"]
                         ids = UserMedia.save_whatsapp_media_content(
                             bot=bot,
-                            sender_id=message["from"],
+                            sender_id=message.get("from") or message.get("from_user_id"),
                             whatsapp_media_id=media_id,
-                            config=self.config
+                            config=self.config,
+                            user_id=message.get("from_user_id")
                         )
                         media_id_list.append(media_id)
                         temp_media_ids.extend(ids)
@@ -73,10 +74,11 @@ class Whatsapp:
 
                         ids = UserMedia.save_whatsapp_media_and_get_url(
                             bot=bot,
-                            sender_id=message["from"],
+                            sender_id=message.get("from") or message.get("from_user_id"),
                             whatsapp_media_id=whatsapp_media_id,
                             config=self.config,
-                            description=description
+                            description=description,
+                            user_id=message.get("from_user_id")
                         )
 
                         media_id_list.append(whatsapp_media_id)
@@ -101,9 +103,11 @@ class Whatsapp:
             text = f"/k_multimedia_msg{{\"{message['type']}\": \"{message[message['type']]['id']}\"}}"
             media_ids = UserMedia.save_whatsapp_media_content(
                 bot=bot,
-                sender_id=message["from"],
+                sender_id=message.get("from") or message.get("from_user_id"),
                 whatsapp_media_id=message[message['type']]['id'],
-                config=self.config
+                config=self.config,
+                user_id=message.get("from_user_id"),
+                media_data=message[message['type']]
             )
         elif message.get("type") == "location":
             logger.debug(message['location'])
@@ -120,7 +124,7 @@ class Whatsapp:
             logger.warning(f"Received a message from whatsapp that we can not handle. Message: {message}")
             return
         message.update(metadata)
-        await self._handle_user_message(text, message["from"], message, bot, media_ids)
+        await self._handle_user_message(text, message.get("from") or message.get("from_user_id"), message, bot, media_ids)
 
     async def handle_meta_payload(self, payload: Dict, metadata: Optional[Dict[Text, Any]], bot: str) -> None:
         provider = self.config.get("bsp_type", "meta")
@@ -129,15 +133,15 @@ class Whatsapp:
             for changes in entry["changes"]:
                 self.last_message = changes
                 client = WhatsappFactory.get_client(provider)
-                self.client = client(access_token, from_phone_number_id=self.get_business_phone_number_id())
+                self.client = client(access_token, from_phone_number_id=self.get_business_phone_number_id(), config=self.config)
                 msg_metadata = changes.get("value", {}).get("metadata", {})
                 metadata.update(msg_metadata)
                 messages = changes.get("value", {}).get("messages")
                 if not messages:
                     statuses = changes.get("value", {}).get("statuses")
                     user = metadata.get('display_phone_number')
-                    for status_data in statuses:
-                        recipient = status_data.get('recipient_id')
+                    for status_data in (statuses or []):
+                        recipient = status_data.get('recipient_id') or status_data.get('recipient_user_id')
                         ChatDataProcessor.save_whatsapp_audit_log(status_data, bot, user, recipient,
                                                                   ChannelTypes.WHATSAPP.value)
                         if status_data.get('type') == "payment":
@@ -150,13 +154,14 @@ class Whatsapp:
         """Send a message to the user."""
         from kairon.chat.converters.channels.response_factory import ConverterFactory
 
-        is_bps = self.config.get("bsp_type", "meta") == "360dialog"
-        client = WhatsappFactory.get_client(self.config.get("bsp_type", "meta"))
+        bsp_type = self.config.get("bsp_type", "meta")
+        is_bps = bsp_type in {t.value for t in WhatsappBSPTypes if t != WhatsappBSPTypes.meta}
+        client = WhatsappFactory.get_client(bsp_type)
         phone_number_id = self.config.get('phone_number_id')
         if not phone_number_id and not is_bps:
             raise ValueError("Phone number not found in channel config")
         access_token = self.__get_access_token()
-        c = client(access_token, from_phone_number_id=phone_number_id)
+        c = client(access_token, from_phone_number_id=phone_number_id, config=self.config)
         message_type = "text"
         if isinstance(message, str):
             message = {
@@ -194,6 +199,7 @@ class Whatsapp:
 
         actor = ActorFactory.get_instance(ActorType.callable_runner.value)
         actor.execute(self.handle_meta_payload, payload, metadata, bot)
+
         return msg
 
     def get_business_phone_number_id(self) -> Text:
@@ -224,6 +230,8 @@ class Whatsapp:
         provider = self.config.get("bsp_type", "meta")
         if provider == "meta":
             return self.config.get('access_token')
+        elif provider == WhatsappBSPTypes.bsp_gupshup.value:
+            return self.config.get('partner_app_token')
         else:
             return self.config.get('api_key')
 

--- a/kairon/shared/account/data_objects.py
+++ b/kairon/shared/account/data_objects.py
@@ -162,6 +162,7 @@ class MailTemplates(EmbeddedDocument):
     button_template = StringField()
     leave_bot_owner_notification = StringField()
     catalog_sync_status = StringField()
+    password_reset_unverified = StringField()
 
 
 class SystemProperties(Document):

--- a/kairon/shared/account/processor.py
+++ b/kairon/shared/account/processor.py
@@ -42,7 +42,7 @@ from kairon.shared.data.constant import ACCESS_ROLES, ACTIVITY_STATUS, INTEGRATI
     RE_ALPHA_NUM, RE_VALID_NAME
 from kairon.shared.data.data_objects import BotSettings, ChatClientConfig, SlotMapping
 from kairon.shared.plugins.factory import PluginFactory
-from kairon.shared.utils import Utility
+from kairon.shared.utils import Utility, MailUtility
 from kairon.shared.models import User as UserModel
 
 Utility.load_email_configuration()
@@ -1004,6 +1004,7 @@ class AccountProcessor:
                 button_template=open("template/emails/button.html", "r").read(),
                 leave_bot_owner_notification=open("template/emails/leaveBotOwnerNotification.html", "r").read(),
                 catalog_sync_status=open("template/emails/catalog_sync_status.html", "r").read(),
+                password_reset_unverified=open("template/emails/passwordResetUnverified.html", "r").read(),
             )
             system_properties = (
                 SystemProperties(mail_templates=mail_templates)
@@ -1060,6 +1061,15 @@ class AccountProcessor:
             "leave_bot_owner_notification"]
         Utility.email_conf["email"]["templates"]["catalog_sync_status"] = system_properties["mail_templates"][
             "catalog_sync_status"]
+        Utility.email_conf["email"]["templates"]["password_reset_unverified"] = system_properties[
+            "mail_templates"
+        ].get("password_reset_unverified")
+        if not Utility.email_conf["email"]["templates"].get("password_reset_unverified"):
+            template_html = open("template/emails/passwordResetUnverified.html", "r").read()
+            SystemProperties.objects().update_one(
+                set__mail_templates__password_reset_unverified=template_html
+            )
+            Utility.email_conf["email"]["templates"]["password_reset_unverified"] = template_html
 
     @staticmethod
     async def confirm_email(token: str):
@@ -1139,7 +1149,7 @@ class AccountProcessor:
                 raise_error=False,
                 check_base_fields=False,
             ):
-                raise AppException("Error! There is no user with the following mail id")
+                raise AppException("If the email address is registered with us, you'll receive a password reset email shortly.")
             if not Utility.is_exist(
                 UserEmailConfirmation, email__iexact=mail, raise_error=False
             ):
@@ -1171,6 +1181,42 @@ class AccountProcessor:
             return mail, user["first_name"], link
         else:
             raise AppException("Error! Email verification is not enabled")
+
+    @staticmethod
+    async def handle_password_reset_request(email: str):
+        if not Utility.email_conf["email"]["enable"]:
+            return
+        email = email.strip()
+        if isinstance(mail_check(email), ValidationFailure):
+            return
+        if not Utility.is_exist(User, email__iexact=email, status=True, raise_error=False, check_base_fields=False):
+            return
+        try:
+            UserActivityLogger.is_password_reset_within_cooldown_period(email)
+            UserActivityLogger.is_password_reset_request_limit_exceeded(email)
+        except AppException:
+            return
+        user = AccountProcessor.get_user(email)
+        if not Utility.is_exist(UserEmailConfirmation, email__iexact=email, raise_error=False):
+            token = Utility.generate_token(email)
+            link = Utility.email_conf["app"]["url"] + "/verify/" + token
+            await MailUtility.format_and_send_mail(
+                mail_type='password_reset_unverified', email=email,
+                first_name=user['first_name'], url=link
+            )
+            return
+        token_expiry = Utility.environment["user"]["reset_password_cooldown_period"] or 120
+        uuid_value = str(uuid.uuid1())
+        token = Utility.generate_token_payload({"mail_id": email, "uuid": uuid_value}, token_expiry * 60)
+        link = Utility.email_conf["app"]["url"] + '/reset_password/' + token
+        UserActivityLogger.add_log(a_type=UserActivityType.reset_password_request.value,
+                                   account=user['account'], email=email,
+                                   data={"status": "pending", "uuid": uuid_value})
+        UserActivityLogger.add_log(a_type=UserActivityType.link_usage.value, account=user['account'],
+                                   email=email, message=["Send Reset Link"],
+                                   data={"status": "pending", "uuid": uuid_value})
+        await MailUtility.format_and_send_mail(mail_type='password_reset', email=email,
+                                               first_name=user['first_name'], url=link)
 
     @staticmethod
     async def overwrite_password(token: str, password: str):

--- a/kairon/shared/auth.py
+++ b/kairon/shared/auth.py
@@ -4,6 +4,8 @@ from calendar import timegm
 from datetime import datetime, timedelta, timezone
 from typing import Text
 
+from uuid6 import uuid7
+
 from fastapi import Depends, HTTPException, status, Request
 from fastapi.security import SecurityScopes
 from jwt import PyJWTError, encode
@@ -50,6 +52,11 @@ class Authentication:
         )
         try:
             payload = Utility.decode_limited_access_token(token)
+            jti = payload.get("jti")
+            if jti and payload.get("type") == TOKEN_TYPE.LOGIN.value:
+                from kairon.shared.authorization.data_objects import UserSessions
+                if UserSessions.objects(jti=jti).first():
+                    raise credentials_exception
             username: str = payload.get("sub")
             Authentication.validate_limited_access_token(request, payload.get("access-limit"))
             if username is None:
@@ -167,6 +174,7 @@ class Authentication:
             to_encode.update({"exp": expire})
             if to_encode.get("iat") is None:
                 to_encode.update({"iat": datetime.utcnow()})
+            to_encode.update({"jti": str(uuid7())})
         to_encode.update({"type": token_type})
         to_encode = Authentication.encrypt_token_claims(to_encode)
         encoded_jwt = encode(to_encode, secret_key, algorithm=algorithm)
@@ -239,6 +247,20 @@ class Authentication:
             metric_type = UserActivityType.login_refresh_token.value
         UserActivityLogger.add_log(a_type=metric_type, account=user["account"], email=username, data={"username": username})
         return access_token, access_token_expiry.timestamp(), refresh_token, refresh_token_expiry.timestamp()
+
+    @staticmethod
+    def logout(token: str, user: str):
+        from kairon.shared.authorization.data_objects import UserSessions
+        payload = Utility.decode_limited_access_token(token)
+        jti = payload.get("jti")
+        if jti:
+            exp = payload.get("exp")
+            expires_at = (
+                datetime.utcfromtimestamp(exp)
+                if exp
+                else datetime.utcnow() + timedelta(minutes=Utility.environment["security"]["token_expire"])
+            )
+            UserSessions(jti=jti, user=user, expires_at=expires_at).save()
 
     @staticmethod
     def validate_limited_access_token(request: Request, access_limit: list):

--- a/kairon/shared/authorization/data_objects.py
+++ b/kairon/shared/authorization/data_objects.py
@@ -1,4 +1,7 @@
+from datetime import datetime
+
 from mongoengine import (
+    Document,
     StringField,
     DateTimeField,
     ListField
@@ -32,3 +35,17 @@ class Integration(Auditlog):
     def validate(self, clean=True):
         if clean:
             self.clean()
+
+
+class UserSessions(Document):
+    user = StringField(required=True)
+    jti = StringField(required=True, unique=True)
+    invalidated_at = DateTimeField(default=datetime.utcnow)
+    expires_at = DateTimeField(required=True)
+
+    meta = {
+        "indexes": [
+            "jti",
+            {"fields": ["expires_at"], "expireAfterSeconds": 0},
+        ]
+    }

--- a/kairon/shared/channels/broadcast/whatsapp.py
+++ b/kairon/shared/channels/broadcast/whatsapp.py
@@ -11,12 +11,12 @@ from kairon import Utility
 from kairon.chat.handlers.channels.clients.whatsapp.factory import WhatsappFactory
 from kairon.exceptions import AppException
 from kairon.shared.channels.broadcast.from_config import MessageBroadcastFromConfig
-from kairon.shared.channels.whatsapp.bsp.dialog360 import BSP360Dialog
+from kairon.shared.channels.whatsapp.bsp.factory import BusinessServiceProviderFactory
 from kairon.shared.chat.agent.agent_flow import AgenticFlow
 from kairon.shared.chat.broadcast.constants import MessageBroadcastLogType, MessageBroadcastType
 from kairon.shared.chat.broadcast.processor import MessageBroadcastProcessor
 from kairon.shared.chat.processor import ChatDataProcessor
-from kairon.shared.constants import ChannelTypes, ActorType
+from kairon.shared.constants import ChannelTypes, ActorType, WhatsappBSPTypes
 from kairon.shared.data.collection_processor import DataProcessor
 from kairon.shared.data.constant import EVENT_STATUS, MEDIA_TYPES, STATUSES
 from kairon.shared.data.processor import MongoProcessor
@@ -74,12 +74,11 @@ class WhatsappBroadcast(MessageBroadcastFromConfig):
                 elif custom := resp.get('custom'):
                     components = custom
 
+        status_flag = status_code = response = None
 
-        status_flag, status_code, response = await self.channel_client.send_template_message_async(template_id,
-                                                                                              recipient,
-                                                                                              language_code,
-                                                                                              components,
-                                                                                              namespace)
+        status_flag, status_code, response = await self.channel_client.send_broadcast_template_async(
+            template_id, recipient, language_code, components, namespace
+        )
         status = EVENT_STATUS.FAIL.value if response.get("error") else STATUSES.SUCCESS.value
 
         if status == EVENT_STATUS.FAIL.value:
@@ -99,11 +98,12 @@ class WhatsappBroadcast(MessageBroadcastFromConfig):
                                     namespace: Text = None):
         if not self.channel_client:
             self.channel_client = self.__get_client()
-        status_flag, status_code, response = await self.channel_client.send_template_message_async(template_id,
-                                                                                                   recipient,
-                                                                                                   language_code,
-                                                                                                   components,
-                                                                                                   namespace)
+
+        status_flag = status_code = response = None
+
+        status_flag, status_code, response = await self.channel_client.send_broadcast_template_async(
+            template_id, recipient, language_code, components, namespace
+        )
         status = EVENT_STATUS.FAIL.value if response.get("error") else STATUSES.SUCCESS.value
 
         MessageBroadcastProcessor.add_event_log(
@@ -239,8 +239,9 @@ class WhatsappBroadcast(MessageBroadcastFromConfig):
 
         template_name = self.config['template_name']
         language_code = self.config['language_code']
+        bsp_type = self.config.get('bsp_type', WhatsappBSPTypes.bsp_360dialog.value)
 
-        raw_template, template_exception = self.__get_template(template_name, language_code)
+        raw_template, template_exception = self.__get_template(template_name, language_code, bsp_type)
         raw_template = raw_template if raw_template else []
         MessageBroadcastProcessor.update_broadcast_logs_with_template(
             self.reference_id, self.event_id, raw_template=raw_template, template_name=template_name,
@@ -344,14 +345,17 @@ class WhatsappBroadcast(MessageBroadcastFromConfig):
             template_id = template_config["template_id"]
             namespace = template_config.get("namespace")
             lang = template_config["language"]
-            raw_template, template_exception = self.__get_template(template_id, lang)
+            bsp_type = self.config.get('bsp_type', WhatsappBSPTypes.bsp_360dialog.value)
+            bsp = BusinessServiceProviderFactory.get_instance(bsp_type)(self.bot, self.user)
+
+            raw_template, template_exception = self.__get_template(template_id, lang, bsp_type)
+            raw_template = bsp.normalize_raw_template(raw_template)
 
             if self.config.get('collection_config'):
                 template_params, recipients = self.__prepare_template_params(raw_template, template_id)
             else:
-                template_params = self._get_template_parameters(template_config)
-
-                template_params = template_params if template_params else [template_params] * len(recipients)
+                default_params = self._get_template_parameters(template_config)
+                template_params = bsp.get_template_params_for_broadcast(raw_template, template_config, recipients, default_params)
 
             total = len(recipients)
             num_msg = len(list(zip(recipients, template_params)))
@@ -367,8 +371,8 @@ class WhatsappBroadcast(MessageBroadcastFromConfig):
             for recipient, t_params in zip(recipients, template_params):
                 recipient = str(recipient) if recipient else ""
                 if not Utility.check_empty_string(recipient):
-
-                    message_list.append((template_id, recipient, lang, t_params, namespace, None))
+                    entry_namespace, entry_lang = bsp.get_broadcast_namespace_and_language(raw_template, namespace, lang)
+                    message_list.append((template_id, recipient, entry_lang, t_params, entry_namespace, None))
 
             _, non_sent_recipients = self.initiate_broadcast(message_list)
             failure_cnt = len(non_sent_recipients)
@@ -379,8 +383,9 @@ class WhatsappBroadcast(MessageBroadcastFromConfig):
                 recipients=recipients, **evaluation_log
             )
 
+            log_template = bsp.to_log_template(raw_template)
             MessageBroadcastProcessor.update_broadcast_logs_with_template(
-                self.reference_id, self.event_id, raw_template=raw_template, template_name=template_id,
+                self.reference_id, self.event_id, raw_template=log_template, template_name=template_id,
                 log_type=MessageBroadcastLogType.send.value, retry_count=0,
                 template_exception=template_exception
             )
@@ -388,13 +393,19 @@ class WhatsappBroadcast(MessageBroadcastFromConfig):
     def __send_using_flow(self, recipients: List, **kwargs):
         total = len(recipients)
         flowname = self.config.get("flowname")
+        bsp_type = self.config.get('bsp_type', WhatsappBSPTypes.bsp_360dialog.value)
         for i, template_config in enumerate(self.config['template_config']):
             template_id = template_config["template_id"]
             namespace = template_config.get("namespace")
             lang = template_config["language"]
-            template_params = self._get_template_parameters(template_config)
-            raw_template, template_exception = self.__get_template(template_id, lang)
-            template_params = template_params if template_params else [template_params] * len(recipients)
+            bsp = BusinessServiceProviderFactory.get_instance(bsp_type)(self.bot, self.user)
+
+            raw_template, template_exception = self.__get_template(template_id, lang, bsp_type)
+            raw_template = bsp.normalize_raw_template(raw_template)
+
+            default_params = self._get_template_parameters(template_config)
+            template_params = bsp.get_template_params_for_broadcast(raw_template, template_config, recipients, default_params)
+
             num_msg = len(list(zip(recipients, template_params)))
             no_of_recipients = "one recipient" if total == 1 else f"{total} recipients"
             evaluation_log = {
@@ -409,9 +420,8 @@ class WhatsappBroadcast(MessageBroadcastFromConfig):
             for recipient, t_params in zip(recipients, template_params):
                 recipient = str(recipient) if recipient else ""
                 if not Utility.check_empty_string(recipient):
-
-
-                    message_list.append((template_id, recipient, lang, t_params, namespace, flowname))
+                    entry_namespace, entry_lang = bsp.get_broadcast_namespace_and_language(raw_template, namespace, lang)
+                    message_list.append((template_id, recipient, entry_lang, t_params, entry_namespace, flowname))
 
             _, non_sent_recipients = self.initiate_broadcast(message_list)
             failure_cnt = len(non_sent_recipients)
@@ -421,8 +431,9 @@ class WhatsappBroadcast(MessageBroadcastFromConfig):
                 event_id=self.event_id, nonsent_recipients=non_sent_recipients, **evaluation_log
             )
 
+            log_template = bsp.to_log_template(raw_template)
             MessageBroadcastProcessor.update_broadcast_logs_with_template(
-                self.reference_id, self.event_id, raw_template=raw_template, template_name=template_id,
+                self.reference_id, self.event_id, raw_template=log_template, template_name=template_id,
                 log_type=MessageBroadcastLogType.send.value, retry_count=0,
                 template_exception=template_exception
             )
@@ -447,7 +458,8 @@ class WhatsappBroadcast(MessageBroadcastFromConfig):
         skipped_count = len(broadcast_logs) - total
         template_name = required_logs[0]["template_name"]
         language_code = required_logs[0]["language_code"]
-        template, template_exception = self.__get_template(template_name, language_code)
+        bsp_type = config.get('bsp_type', WhatsappBSPTypes.bsp_360dialog.value)
+        template, template_exception = self.__get_template(template_name, language_code, bsp_type)
 
         message_list = []
 
@@ -495,24 +507,18 @@ class WhatsappBroadcast(MessageBroadcastFromConfig):
         try:
             bot_settings = MongoProcessor.get_bot_settings(self.bot, self.user)
             channel_config = ChatDataProcessor.get_channel_config(ChannelTypes.WHATSAPP.value, self.bot, mask_characters=False)
-            access_token = channel_config["config"].get('api_key') or channel_config["config"].get('access_token')
+            bsp_type = channel_config["config"].get("bsp_type")
+            if bsp_type == WhatsappBSPTypes.bsp_gupshup.value:
+                access_token = channel_config["config"].get("partner_app_token")
+            else:
+                access_token = channel_config["config"].get('api_key') or channel_config["config"].get('access_token') or channel_config["config"].get("partner_app_token")
             channel_client = WhatsappFactory.get_client(bot_settings["whatsapp"])
             channel_client = channel_client(access_token, config=channel_config)
             return channel_client
         except DoesNotExist as e:
             logger.exception(e)
-            raise AppException(f"Whatsapp channel config not found!")
+            raise AppException("Whatsapp channel config not found!") from e
 
-    def __get_template(self, name: Text, language: Text):
-        template_exception = None
-        template = []
-        try:
-            for template in BSP360Dialog(self.bot, self.user).list_templates(**{"business_templates.name": name}):
-                if template.get("language") == language:
-                    template = template.get("components")
-                    break
-            return template, template_exception
-        except Exception as e:
-            logger.exception(e)
-            template_exception = str(e)
-            return template, template_exception
+    def __get_template(self, name: Text, language: Text, bsp_type: Text = WhatsappBSPTypes.bsp_360dialog.value):
+        bsp = BusinessServiceProviderFactory.get_instance(bsp_type)(self.bot, self.user)
+        return bsp.get_template_for_broadcast(name, language)

--- a/kairon/shared/channels/whatsapp/bsp/base.py
+++ b/kairon/shared/channels/whatsapp/bsp/base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Dict
 
 
 class WhatsappBusinessServiceProviderBase(ABC):
@@ -37,4 +38,25 @@ class WhatsappBusinessServiceProviderBase(ABC):
 
     @abstractmethod
     def validate(self, **kwargs):
+        raise NotImplementedError("Provider not implemented")
+
+    @abstractmethod
+    def validate_template_request(self, data: Dict):
+        raise NotImplementedError("Provider not implemented")
+
+    @staticmethod
+    def fetch_media_ids(bot: str):
+        raise NotImplementedError("Provider not implemented")
+
+    @staticmethod
+    def fetch_broadcast_media_ids(bot: str):
+        raise NotImplementedError("Provider not implemented")
+
+    def normalize_raw_template(self, raw_template):
+        raise NotImplementedError("Provider not implemented")
+
+    def get_template_params_for_broadcast(self, raw_template, template_config, recipients, default_params):
+        raise NotImplementedError("Provider not implemented")
+
+    def get_broadcast_namespace_and_language(self, raw_template, namespace, lang):
         raise NotImplementedError("Provider not implemented")

--- a/kairon/shared/channels/whatsapp/bsp/dialog360.py
+++ b/kairon/shared/channels/whatsapp/bsp/dialog360.py
@@ -96,7 +96,7 @@ class BSP360Dialog(WhatsappBusinessServiceProviderBase):
 
     def add_template(self, data: Dict, bot: Text, user: Text):
         try:
-            Utility.validate_create_template_request(data)
+            self.validate_template_request(data)
             config = ChatDataProcessor.get_channel_config(ChannelTypes.WHATSAPP.value, self.bot, mask_characters=False)
             api_key = config.get("config", {}).get("api_key")
             base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["360dialog"]["waba_base_url"]
@@ -174,6 +174,40 @@ class BSP360Dialog(WhatsappBusinessServiceProviderBase):
         except Exception as e:
             logger.exception(e)
             raise AppException(str(e))
+
+    def get_template_for_broadcast(self, name: Text, language: Text):
+        """Fetch template components matching name+language for broadcast use."""
+        template_exception = None
+        template = []
+        try:
+            for t in self.list_templates(**{"business_templates.name": name}):
+                if t.get("language") == language:
+                    template = t.get("components")
+                    break
+        except Exception as e:
+            logger.exception(e)
+            template_exception = str(e)
+        return template, template_exception
+
+    def to_log_template(self, raw_template):
+        """360Dialog raw template is already in components format — return as-is."""
+        return raw_template
+
+    def normalize_raw_template(self, raw_template):
+        return raw_template
+
+    def get_template_params_for_broadcast(self, raw_template, template_config, recipients, default_params):
+        params = default_params if default_params else [default_params] * len(recipients)
+        return params
+
+    def get_broadcast_namespace_and_language(self, raw_template, namespace, lang):
+        return namespace, lang
+
+    def validate_template_request(self, data: Dict):
+        required_keys = ["name", "category", "components", "language"]
+        missing_keys = [key for key in required_keys if key not in data]
+        if missing_keys:
+            raise AppException(f'Missing {", ".join(missing_keys)} in request body!')
 
     @staticmethod
     def get_partner_auth_token():
@@ -365,6 +399,54 @@ class BSP360Dialog(WhatsappBusinessServiceProviderBase):
             UserMedia.save_media_content(bot, sender_id, external_media_id, binary_data, filename, file_path,
                                          output_filename, bucket, False)
         return external_media_id
+
+    @staticmethod
+    def fetch_media_ids(bot: str):
+        try:
+            thirty_days_ago = datetime.utcnow() - timedelta(days=30)
+            media_data = UserMediaData.objects(
+                bot=bot,
+                upload_status=UserMediaUploadStatus.completed.value,
+                media_id__ne="",
+                upload_type=UserMediaUploadType.broadcast.value,
+                timestamp__gte=thirty_days_ago,
+            ).only("filename", "media_id", "upload_status", "sender_id", "timestamp")
+            return [
+                {
+                    "filename": doc.filename,
+                    "media_id": doc.media_id,
+                    "upload_status": doc.upload_status,
+                    "sender_id": doc.sender_id,
+                    "timestamp": doc.timestamp,
+                }
+                for doc in media_data
+            ]
+        except Exception as e:
+            raise AppException(f"Error while fetching media ids for bot '{bot}': {str(e)}")
+
+    @staticmethod
+    def fetch_broadcast_media_ids(bot: str):
+        try:
+            thirty_days_ago = datetime.utcnow() - timedelta(days=30)
+            media_data = UserMediaData.objects(
+                bot=bot,
+                upload_status=UserMediaUploadStatus.completed.value,
+                media_id__ne="",
+                upload_type=UserMediaUploadType.broadcast.value,
+                timestamp__gte=thirty_days_ago,
+            ).only("filename", "media_id", "upload_status", "sender_id", "timestamp")
+            return [
+                {
+                    "filename": doc.filename,
+                    "media_id": doc.media_id,
+                    "upload_status": doc.upload_status,
+                    "sender_id": doc.sender_id,
+                    "timestamp": doc.timestamp,
+                }
+                for doc in media_data
+            ]
+        except Exception as e:
+            raise AppException(f"Error while fetching media ids for bot '{bot}': {str(e)}")
 
     @staticmethod
     def delete_media_file(media_id: str, channel_config):

--- a/kairon/shared/channels/whatsapp/bsp/factory.py
+++ b/kairon/shared/channels/whatsapp/bsp/factory.py
@@ -1,12 +1,14 @@
 from kairon.exceptions import AppException
 from kairon.shared.channels.whatsapp.bsp.dialog360 import BSP360Dialog
+from kairon.shared.channels.whatsapp.bsp.gupshup import BSPGupshup
 from kairon.shared.constants import WhatsappBSPTypes
 
 
 class BusinessServiceProviderFactory:
 
     __implementations = {
-        WhatsappBSPTypes.bsp_360dialog.value: BSP360Dialog
+        WhatsappBSPTypes.bsp_360dialog.value: BSP360Dialog,
+        WhatsappBSPTypes.bsp_gupshup.value: BSPGupshup,
     }
 
     @staticmethod

--- a/kairon/shared/channels/whatsapp/bsp/gupshup.py
+++ b/kairon/shared/channels/whatsapp/bsp/gupshup.py
@@ -1,0 +1,621 @@
+import asyncio
+import json
+import os
+from datetime import datetime, timedelta
+from typing import Text, Dict
+
+import requests
+
+from kairon import Utility
+from kairon.exceptions import AppException
+from kairon.shared.account.activity_log import UserActivityLogger
+
+from loguru import logger
+from mongoengine import DoesNotExist
+
+from kairon.shared.channels.whatsapp.bsp.base import WhatsappBusinessServiceProviderBase
+from kairon.shared.chat.processor import ChatDataProcessor
+from kairon.shared.chat.user_media import UserMedia
+from kairon.shared.constants import WhatsappBSPTypes, ChannelTypes, UserActivityType
+from kairon.shared.data.data_objects import UserMediaData
+from kairon.shared.models import UserMediaUploadStatus, UserMediaUploadType
+
+
+class BSPGupshup(WhatsappBusinessServiceProviderBase):
+
+    def __init__(self, bot: Text, user: Text):
+        """Initialize BSPGupshup with bot and user identifiers."""
+        self.bot = bot
+        self.user = user
+
+    def validate(self, **kwargs):
+        from kairon.shared.data.processor import MongoProcessor
+
+        bot_settings = MongoProcessor.get_bot_settings(self.bot, self.user)
+        bot_settings = bot_settings.to_mongo().to_dict()
+        if bot_settings["whatsapp"] != WhatsappBSPTypes.bsp_gupshup.value:
+            raise AppException("Feature disabled for this account. Please contact support!")
+
+    def get_account(self, app_id: Text):
+        # Gupshup identifies apps by app_id — no WABA account lookup needed
+        return app_id
+
+    def post_process(self):
+        try:
+            config = ChatDataProcessor.get_channel_config(
+                ChannelTypes.WHATSAPP.value, self.bot, mask_characters=False,
+                config__bsp_type=WhatsappBSPTypes.bsp_gupshup.value
+            )
+            app_id = config.get("config", {}).get("app_id")
+            partner_base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+
+            webhook_url = self.__update_channel_config(config, {}, self.bot, self.user)
+
+            token = self.__get_partner_token(partner_base_url)
+            url = f"{partner_base_url}/partner/app/{app_id}"
+            Utility.execute_http_request(
+                request_method="PUT", http_url=url,
+                request_body={"webhookUrl": webhook_url},
+                headers={"Authorization": token},
+                validate_status=True,
+                err_msg="Failed to set Gupshup webhook: "
+            )
+            return webhook_url
+        except DoesNotExist as e:
+            logger.exception(e)
+            raise AppException("Channel not found!")
+        except Exception as e:
+            logger.exception(e)
+            raise AppException(str(e))
+
+    @staticmethod
+    def __get_partner_token(partner_base_url: Text) -> Text:
+        gupshup_cfg = Utility.system_metadata["channels"]["gupshup"]
+        email = gupshup_cfg.get("partner_email")
+        password = gupshup_cfg.get("partner_password")
+        if not email or not password:
+            raise AppException("Gupshup partner_email / partner_password not configured in system metadata!")
+        resp = requests.post(
+            f"{partner_base_url}/partner/account/login",
+            json={"email": email, "password": password},
+            timeout=30
+        )
+        if resp.status_code != 200:
+            raise AppException(f"Gupshup partner login failed: [{resp.status_code}] {resp.text}")
+        token = resp.json().get("token")
+        if not token:
+            raise AppException(f"Gupshup partner login returned no token: {resp.text}")
+        return token
+
+    @staticmethod
+    def __update_channel_config(config, payload, bot, user):
+        conf = config["config"]
+        conf.update(payload)
+        config["config"] = conf
+        return ChatDataProcessor.save_channel_config(config, bot, user)
+
+    def save_channel_config(self, **kwargs):
+        app_id = kwargs.get("app_id")
+        app_name = kwargs.get("app_name") or app_id
+        partner_app_token = kwargs.get("partner_app_token")
+        phone_number = kwargs.get("phone_number")
+
+        if not app_id:
+            raise AppException("app_id is required for Gupshup channel setup!")
+        if not partner_app_token:
+            raise AppException("partner_app_token is required for Gupshup channel setup!")
+
+        conf = {
+            "config": {
+                "app_id": Utility.sanitise_data(app_id),
+                "app_name": Utility.sanitise_data(app_name),
+                "partner_app_token": Utility.sanitise_data(partner_app_token),
+                "phone_number": Utility.sanitise_data(phone_number) if phone_number else None,
+                "bsp_type": WhatsappBSPTypes.bsp_gupshup.value
+            },
+            "connector_type": ChannelTypes.WHATSAPP.value
+        }
+        return ChatDataProcessor.save_channel_config(conf, self.bot, self.user)
+
+    def validate_template_request(self, data: Dict):
+        required_keys = ["elementName", "content", "category", "vertical", "templateType", "example"]
+        missing_keys = [key for key in required_keys if key not in data]
+        if missing_keys:
+            raise AppException(f'Missing {", ".join(missing_keys)} in request body!')
+        template_type = data.get("templateType")
+        if template_type in ["IMAGE", "VIDEO", "DOCUMENT"]:
+            if not data.get("exampleMedia"):
+                raise AppException(f"exampleMedia (handleId) is required for {template_type} templates")
+        elif template_type == "TEXT":
+            header = data.get("header")
+            if header and "{{" in header and not data.get("exampleHeader"):
+                raise AppException("exampleHeader is required when header contains variables")
+        else:
+            raise AppException(f"Invalid templateType: {template_type}")
+
+    def add_template(self, data: Dict, bot: Text, user: Text):
+        try:
+            template_type = data.get("templateType")
+            if template_type in ["IMAGE", "VIDEO", "DOCUMENT"]:
+                media_id = data.get("media_id")
+                if media_id:
+                    handle_id = UserMedia.get_media_handle_id(self.bot, media_id)
+                    if handle_id:
+                        data["exampleMedia"] = handle_id
+            self.validate_template_request(data)
+
+            config = ChatDataProcessor.get_channel_config(
+                ChannelTypes.WHATSAPP.value,
+                self.bot,
+                mask_characters=False
+            )
+
+            app_id = config.get("config", {}).get("app_id")
+            partner_app_token = config.get("config", {}).get("partner_app_token")
+            partner_base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"][
+                "partner_base_url"]
+            header = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["auth_header"]
+
+
+            payload = data.copy()
+            if payload.get('buttons'):
+                payload['buttons'] = json.dumps(payload.get('buttons'))
+            headers = {
+                header: partner_app_token,
+                "Content-Type": "application/x-www-form-urlencoded",
+                "accept": "application/json"
+            }
+
+
+            url = f"{partner_base_url}/partner/app/{app_id}/templates"
+            resp = requests.post(url, headers=headers, data=payload)
+
+            if resp.status_code not in [200, 201]:
+                raise AppException(
+                    f"Failed to add gupshup template: {resp.text}"
+                )
+
+            UserActivityLogger.add_log(
+                a_type=UserActivityType.template_creation.value,
+                email=user,
+                bot=bot,
+                message=["Template created!"]
+            )
+
+            return resp.json()
+
+        except DoesNotExist as e:
+            logger.exception(e)
+            raise AppException("Channel not found!")
+
+        except Exception as e:
+            logger.exception(e)
+            raise AppException(str(e))
+
+    def edit_template(self, data: Dict, template_id: str):
+        try:
+            config = ChatDataProcessor.get_channel_config(
+                ChannelTypes.WHATSAPP.value,
+                self.bot,
+                mask_characters=False
+            )
+
+            app_id = config.get("config", {}).get("app_id")
+            partner_app_token = config.get("config", {}).get("partner_app_token")
+            partner_base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"][
+                "partner_base_url"]
+            header = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["auth_header"]
+
+            payload = data.copy()
+            if payload.get('buttons'):
+                payload['buttons'] = json.dumps(payload.get('buttons'))
+            headers = {
+                header: partner_app_token,
+                "Content-Type": "application/x-www-form-urlencoded",
+                "accept": "application/json"
+            }
+
+            url = f"{partner_base_url}/partner/app/{app_id}/templates/{template_id}"
+            resp = requests.put(url, headers=headers, data=payload)
+
+            if resp.status_code not in [200, 201]:
+                raise AppException(
+                    f"Failed to edit gupshup template: {resp.text}"
+                )
+
+            return resp.json()
+
+        except DoesNotExist as e:
+            logger.exception(e)
+            raise AppException("Channel not found!")
+        except Exception as e:
+            logger.exception(e)
+            raise AppException(str(e))
+
+    def delete_template(self, template_name: str):
+        try:
+            config = ChatDataProcessor.get_channel_config(
+                ChannelTypes.WHATSAPP.value,
+                self.bot,
+                mask_characters=False
+            )
+
+            app_id = config.get("config", {}).get("app_id")
+            partner_app_token = config.get("config", {}).get("partner_app_token")
+            partner_base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"][
+                "partner_base_url"]
+            header = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["auth_header"]
+
+            headers = {
+                header: partner_app_token
+            }
+
+            url = f"{partner_base_url}/partner/app/{app_id}/template/{template_name}"
+            resp = requests.delete(url, headers=headers)
+
+            if resp.status_code not in [200, 201]:
+                raise AppException(
+                    f"Failed to delete gupshup template: {resp.text}"
+                )
+
+            return resp.json()
+
+        except DoesNotExist as e:
+            logger.exception(e)
+            raise AppException("Channel not found!")
+
+    def get_template(self, template_id: Text):
+        return self.list_templates(id=template_id)
+
+    def list_templates(self, **kwargs):
+        from urllib.parse import urlencode
+        query_string = urlencode(kwargs)
+        try:
+            config = ChatDataProcessor.get_channel_config(ChannelTypes.WHATSAPP.value, self.bot, mask_characters=False)
+            app_id = config.get("config", {}).get("app_id")
+            partner_app_token = config.get("config", {}).get("partner_app_token")
+            partner_base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+            header = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["auth_header"]
+
+            headers = {header: partner_app_token}
+
+            url = f"{partner_base_url}/partner/app/{app_id}/templates?{query_string}"
+            resp = Utility.execute_http_request(request_method="GET", http_url=url, headers=headers,
+                                                validate_status=True, err_msg="Failed to get gupshup template: ")
+            return resp.get("waba_templates") or resp.get("templates") or []
+        except DoesNotExist as e:
+            logger.exception(e)
+            raise AppException("Channel not found!")
+        except Exception as e:
+            logger.exception(e)
+            raise AppException(str(e))
+
+
+    @staticmethod
+    async def upload_media_file(bot: str, channel_config: dict, sender_id: str, filename: str, extension: str,
+                           filesize: int = 0) -> str:
+        from uuid6 import uuid7
+
+        app_id = channel_config.get("config", {}).get("app_id")
+        partner_app_token = channel_config.get("config", {}).get("partner_app_token")
+
+        if not partner_app_token:
+            raise AppException("partner app token not found in channel config")
+
+        partner_base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"][
+            "partner_base_url"]
+
+        headers = {
+            "Authorization": partner_app_token,
+        }
+        payload = {"file_type": extension}
+        content_dir = os.path.join("media_upload_records", bot)
+        os.makedirs(content_dir, exist_ok=True)
+        file_path = os.path.join(content_dir, filename)
+
+        media_doc = UserMedia.create_media_doc(
+            bot=bot,
+            sender_id = sender_id,
+            filename = filename,
+            extension = extension,
+            filesize = filesize,
+            bsp_type = WhatsappBSPTypes.bsp_gupshup.value
+        )
+
+
+        async def _post():
+            def _do():
+                with open(file_path, "rb") as f:
+                    files = {"file": (filename, f, f"{extension}")}
+
+                    return requests.post(
+                            f"{partner_base_url}/partner/app/{app_id}/upload/media",
+                            headers=headers,
+                            data = payload,
+                            files = files,
+                            timeout = (5, 60),
+                            )
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(None, _do)
+
+        try:
+            response = await _post()
+        except requests.RequestException as e:
+                    media_doc.update(
+                        set__upload_status = UserMediaUploadStatus.failed.value,
+                        set__additional_info ={"message": "Upload failed: network error"},
+                        set__external_upload_info__error = str(e),
+                    )
+                    raise AppException(f"Upload request failed: {e}") from e
+
+        if response.status_code not in (200, 201):
+            media_doc.update(
+                set__upload_status = UserMediaUploadStatus.failed.value,
+                set__additional_info ={"message": "Upload failed"},
+                set__external_upload_info__error = response.text,
+            )
+            raise AppException(response.text)
+
+        media_id = uuid7().hex
+        resp_data = response.json()
+        handle_id_raw = resp_data.get("handleId")
+        handle_id = handle_id_raw if isinstance(handle_id_raw, str) else (handle_id_raw or {}).get("message")
+        expiration_date = datetime.utcnow() + timedelta(days = 30)
+
+        output_filename = f"template_media/{bot}/{filename}"
+        bucket = Utility.environment["storage"]["whatsapp_media"].get("bucket")
+        with open(file_path, "rb") as f:
+            binary_data = f.read()
+            media_url = UserMedia.save_media_content(bot, sender_id, media_id, binary_data, filename,
+                                                     file_path, output_filename, bucket, False)
+
+        async def _get_external_media_id():
+            def _do():
+                headers['accept'] = 'application/json'
+                return requests.post(
+                    f"{partner_base_url}/partner/app/{app_id}/media",
+                    headers=headers,
+                    files={
+                        "file": (None, media_url),
+                        "file_type": (None, extension)
+                    },
+                    timeout=(5, 60)
+                )
+
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(None, _do)
+
+        media_doc.update(
+            set__media_url=media_url,
+            set__upload_type=UserMediaUploadType.broadcast.value,
+            set__additional_info={"message": "Upload successful"},
+            set__external_upload_info__handle_id=handle_id,
+            set__external_upload_info__expiry_date=expiration_date,
+        )
+
+        external_media_id = None
+
+        try:
+            media_resp = await _get_external_media_id()
+
+        except requests.RequestException as e:
+            logger.exception(f"Failed to fetch external media id: {e}")
+
+            media_doc.update(
+                set__upload_status = UserMediaUploadStatus.failed.value,
+                set__additional_info ={"message": "Upload failed: network error"},
+                set__external_upload_info__error = str(e),
+            )
+            raise AppException(f"Upload request failed: {e}") from e
+
+        if media_resp.status_code not in (200, 201):
+            logger.error(f"Media API failed: {media_resp.text}")
+            media_doc.update(
+                set__upload_status = UserMediaUploadStatus.failed.value,
+                set__additional_info ={"message": "Upload failed"},
+                set__external_upload_info__error = media_resp.text,
+            )
+            raise AppException(media_resp.text)
+
+        external_media_id = media_resp.json().get("mediaId")
+
+        media_doc.update(
+            set__media_id = external_media_id,
+            set__upload_status = UserMediaUploadStatus.completed.value,
+            set__upload_type = UserMediaUploadType.broadcast.value,
+            set__additional_info ={"message": "Upload successful and media_id generated."},
+            set__external_upload_info__external_media_id = external_media_id,
+        )
+
+        return external_media_id
+
+    @staticmethod
+    def delete_media_file(media_id: str, channel_config):
+        app_id = channel_config.get("config", {}).get("app_id")
+        partner_app_token = channel_config.get("config", {}).get("partner_app_token")
+
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+        url = f"{base_url}/partner/app/{app_id}/media/{media_id}"
+        header = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["auth_header"]
+        headers = {header: partner_app_token}
+        Utility.execute_http_request(request_method="DELETE", http_url=url, headers=headers,
+                                     validate_status=True,
+                                     err_msg="media file does not exist for this media id.")
+        return "Media file deleted successfully"
+
+    def get_template_for_broadcast(self, name: Text, language: Text):
+        """Fetch template matching name+language for broadcast use."""
+        template_exception = None
+        template = {}
+        try:
+            for t in self.list_templates():
+                if t.get("id") == name:
+                    template = t
+                    break
+        except Exception as e:
+            logger.exception(e)
+            template_exception = str(e)
+        return template, template_exception
+
+    def to_log_template(self, raw_template):
+        """Convert Gupshup raw template dict to components list for broadcast logs."""
+        if not isinstance(raw_template, dict):
+            return []
+        components = []
+        template_type = raw_template.get("templateType", "TEXT")
+        try:
+            container_meta = json.loads(raw_template.get("containerMeta", "{}"))
+        except Exception:
+            container_meta = {}
+        if template_type in ("IMAGE", "VIDEO", "DOCUMENT"):
+            components.append({"type": "HEADER", "format": template_type})
+        elif container_meta.get("header"):
+            components.append({"type": "HEADER", "format": "TEXT", "text": container_meta["header"]})
+        body_text = container_meta.get("data") or raw_template.get("data", "")
+        if body_text:
+            components.append({"type": "BODY", "text": body_text})
+        footer = container_meta.get("footer")
+        if footer:
+            components.append({"type": "FOOTER", "text": footer})
+        buttons = container_meta.get("buttons") or []
+        if buttons:
+            components.append({"type": "BUTTONS", "buttons": buttons})
+        return components
+
+    def normalize_raw_template(self, raw_template):
+        return raw_template if isinstance(raw_template, dict) else {}
+
+    def get_template_params_for_broadcast(self, raw_template, template_config, recipients, default_params):
+        template, message = self.get_broadcast_template_params(raw_template, template_config)
+        return [(template, message) for _ in recipients]
+
+    def get_broadcast_namespace_and_language(self, raw_template, namespace, lang):
+        return raw_template.get("namespace", namespace), raw_template.get("languageCode", lang)
+
+    def get_broadcast_template_params(self, raw_template, template_config):
+        """Return (template, message) tuple for Gupshup broadcast send."""
+        if not isinstance(raw_template, dict):
+            raw_template = {}
+        template_id = template_config.get("template_id") or raw_template.get("id")
+        template_type = raw_template.get("templateType")
+        logger.debug(f"Gupshup template raw: {raw_template}")
+        try:
+            container_meta = json.loads(raw_template.get("containerMeta", "{}"))
+        except Exception:
+            container_meta = {}
+        body_params, media_id = BSPGupshup._resolve_runtime_params(template_config, container_meta)
+        return BSPGupshup._build_template_payload(template_id, body_params, media_id, template_type, container_meta)
+
+    @staticmethod
+    def _resolve_runtime_params(template_config, container_meta):
+        import json
+        try:
+            parsed_data = json.loads(template_config.get("data", "[]") or "[]")
+        except Exception:
+            parsed_data = []
+        if isinstance(parsed_data, dict):
+            body_params = [v for _, v in sorted(parsed_data.items(), key=lambda x: int(x[0]))]
+            media_id = None
+        else:
+            components = parsed_data[0] if parsed_data and isinstance(parsed_data[0], list) else []
+            body_params, media_id = BSPGupshup._extract_components_params(components)
+        if not body_params:
+            body_params = BSPGupshup._extract_sample_text_params(container_meta)
+        if not media_id:
+            media_id = container_meta.get("sampleMedia")
+        return body_params, media_id
+
+    @staticmethod
+    def _extract_components_params(components):
+        body_params = []
+        media_id = None
+        for comp in components:
+            comp_type = comp.get("type")
+            if comp_type == "body":
+                for param in comp.get("parameters", []):
+                    if param.get("type") == "text":
+                        body_params.append(param.get("text"))
+            elif comp_type == "header":
+                for param in comp.get("parameters", []):
+                    p_type = param.get("type")
+                    if p_type in ("image", "video", "document"):
+                        media_id = param.get(p_type, {}).get("id")
+        return body_params, media_id
+
+    @staticmethod
+    def _extract_sample_text_params(container_meta):
+        import re
+        template_text = container_meta.get("data", "")
+        sample_text = container_meta.get("sampleText", "")
+        placeholders = re.findall(r"\{\{(\d+)\}\}", template_text)
+        if not (placeholders and sample_text):
+            return []
+        static_parts = re.split(r"\{\{\d+\}\}", template_text)
+        temp_text = sample_text
+        for part in static_parts:
+            if part:
+                temp_text = temp_text.replace(part, "|")
+        extracted = [p.strip() for p in temp_text.split("|") if p.strip()]
+        return extracted[:len(placeholders)]
+
+    @staticmethod
+    def fetch_media_ids(bot: str):
+        try:
+            thirty_days_ago = datetime.utcnow() - timedelta(days=30)
+            media_data = UserMediaData.objects(
+                bot=bot,
+                upload_status=UserMediaUploadStatus.completed.value,
+                upload_type=UserMediaUploadType.broadcast.value,
+                timestamp__gte=thirty_days_ago,
+            ).only("filename", "media_id", "upload_status", "sender_id", "timestamp", "external_upload_info")
+            return [
+                {
+                    "filename": doc.filename,
+                    "handle_id": (doc.external_upload_info or {}).get("handle_id"),
+                    "upload_status": doc.upload_status,
+                    "sender_id": doc.sender_id,
+                    "timestamp": doc.timestamp,
+                }
+                for doc in media_data
+            ]
+        except Exception as e:
+            raise AppException(f"Error while fetching media ids for bot '{bot}': {str(e)}")
+
+    @staticmethod
+    def fetch_broadcast_media_ids(bot: str):
+        try:
+            thirty_days_ago = datetime.utcnow() - timedelta(days=30)
+            media_data = UserMediaData.objects(
+                bot=bot,
+                upload_status=UserMediaUploadStatus.completed.value,
+                media_id__ne="",
+                upload_type=UserMediaUploadType.broadcast.value,
+                timestamp__gte=thirty_days_ago,
+            ).only("filename", "media_id", "upload_status", "sender_id", "timestamp")
+            return [
+                {
+                    "filename": doc.filename,
+                    "media_id": doc.media_id,
+                    "upload_status": doc.upload_status,
+                    "sender_id": doc.sender_id,
+                    "timestamp": doc.timestamp,
+                }
+                for doc in media_data
+            ]
+        except Exception as e:
+            raise AppException(f"Error while fetching media ids for bot '{bot}': {str(e)}")
+
+    @staticmethod
+    def _build_template_payload(template_id, body_params, media_id, template_type, container_meta):
+        template = {"id": template_id, "params": body_params}
+        media_type_map = {"IMAGE": "image", "VIDEO": "video", "DOCUMENT": "document"}
+        if media_id:
+            m_type = media_type_map.get(template_type, "image")
+            message = {"type": m_type, m_type: {"id": media_id}}
+        else:
+            text_template = container_meta.get("data", "")
+            for i, val in enumerate(body_params, start=1):
+                text_template = text_template.replace(f"{{{{{i}}}}}", str(val))
+            message = {"type": "text", "text": text_template or " "}
+        return template, message
+

--- a/kairon/shared/chat/broadcast/data_objects.py
+++ b/kairon/shared/chat/broadcast/data_objects.py
@@ -3,6 +3,7 @@ from mongoengine import Document, StringField, DateTimeField, DynamicDocument, E
     EmbeddedDocumentField, ValidationError, ListField, BooleanField, IntField, DictField
 
 from kairon import Utility
+from kairon.shared.constants import WhatsappBSPTypes
 from kairon.shared.data.audit.data_objects import Auditlog
 from kairon.shared.data.signals import push_notification
 from datetime import datetime
@@ -111,6 +112,7 @@ class MessageBroadcastSettings(Auditlog):
     collection_config = DictField(default=dict)
     pyscript = StringField()
     flowname = StringField()
+    bsp_type = StringField(default=WhatsappBSPTypes.bsp_360dialog.value)
     template_name = StringField(default=None)
     language_code = StringField(default=None)
     retry_count = IntField(default=0)

--- a/kairon/shared/chat/broadcast/processor.py
+++ b/kairon/shared/chat/broadcast/processor.py
@@ -53,6 +53,10 @@ class MessageBroadcastProcessor:
                          name=config['name'], status=True)
         if not Utility.is_exist(Channels, raise_error=False, bot=bot, connector_type=channel):
             raise AppException(f"Channel '{channel}' not configured!")
+        if channel == ChannelTypes.WHATSAPP.value and "bsp_type" not in config:
+            channel_doc = Channels.objects(bot=bot, connector_type=channel).first()
+            if channel_doc and channel_doc.config.get("bsp_type"):
+                config["bsp_type"] = channel_doc.config["bsp_type"]
         max_template_limit = MessageBroadcastProcessor._get_max_template_limit(bot)
         template_config = config.get("template_config") or []
         if len(template_config) > max_template_limit:
@@ -211,13 +215,17 @@ class MessageBroadcastProcessor:
                                                               log_type=log_type,
                                                               retry_count=retry_count)
 
-        broadcast_logs = {
-            message['id']: log
-            for log in message_broadcast_logs
-            if log.api_response and log.api_response.get('messages', [])
-            for message in log.api_response['messages']
-            if message['id']
-        }
+        broadcast_logs = {}
+        for log in message_broadcast_logs:
+            if not log.api_response:
+                continue
+            messages = log.api_response.get('messages', [])
+            if messages:
+                for message in messages:
+                    if message.get('id'):
+                        broadcast_logs[message['id']] = log
+            elif log.api_response.get('messageId'):
+                broadcast_logs[log.api_response['messageId']] = log
         return broadcast_logs
 
     @staticmethod
@@ -345,9 +353,33 @@ class MessageBroadcastProcessor:
         campaign_id = None
         try:
             log = MessageBroadcastLogs.objects(api_response__messages__id=message_id, log_type=MessageBroadcastLogType.send.value)
+            if not log:
+                log = MessageBroadcastLogs.objects(api_response__messageId=message_id, log_type=MessageBroadcastLogType.send.value)
             if log:
                 campaign_id = log[0].reference_id
         except Exception as e:
             logger.debug(e)
 
         return campaign_id
+
+    @staticmethod
+    def fetch_media_ids(bot: Text, user: Text):
+        from kairon.shared.constants import WhatsappBSPTypes
+        from kairon.shared.chat.processor import ChatDataProcessor
+        from kairon.shared.channels.whatsapp.bsp.factory import BusinessServiceProviderFactory
+        channel_config = ChatDataProcessor.get_channel_config(ChannelTypes.WHATSAPP.value, bot, mask_characters=False)
+        bsp_type = channel_config.get("config", {}).get("bsp_type", WhatsappBSPTypes.bsp_360dialog.value)
+        bsp_class = BusinessServiceProviderFactory.get_instance(bsp_type)(bot, user)
+        return bsp_class.fetch_media_ids(bot)
+
+    @staticmethod
+    def fetch_broadcast_media_ids(bot: Text, user: Text):
+        from kairon.shared.constants import WhatsappBSPTypes
+        from kairon.shared.chat.processor import ChatDataProcessor
+        from kairon.shared.channels.whatsapp.bsp.factory import BusinessServiceProviderFactory
+        channel_config = ChatDataProcessor.get_channel_config(ChannelTypes.WHATSAPP.value, bot, mask_characters=False)
+        bsp_type = channel_config.get("config", {}).get("bsp_type", WhatsappBSPTypes.bsp_360dialog.value)
+        bsp_class = BusinessServiceProviderFactory.get_instance(bsp_type)(bot, user)
+        return bsp_class.fetch_broadcast_media_ids(bot)
+
+

--- a/kairon/shared/chat/processor.py
+++ b/kairon/shared/chat/processor.py
@@ -236,7 +236,7 @@ class ChatDataProcessor:
         """
         campaign_id = None
         status = status_data.get('status')
-        msg_id = status_data.get('id')
+        msg_id = status_data.get('gs_id') or status_data.get('id')
 
         if msg_id and status in {"delivered", "read"}:
             campaign_id = MessageBroadcastProcessor.get_campaign_id(msg_id)
@@ -253,6 +253,7 @@ class ChatDataProcessor:
             bot=bot,
             user=user,
             recipient=recipient,
+            user_id=status_data.get('recipient_user_id'),
             campaign_id=campaign_id
         ).save()
 

--- a/kairon/shared/chat/user_media.py
+++ b/kairon/shared/chat/user_media.py
@@ -19,6 +19,7 @@ from kairon.shared.actions.data_objects import Actions, PromptAction
 from kairon.shared.actions.models import ActionType
 from kairon.shared.chat.agent.agent_flow import AgenticFlow
 from kairon.shared.cloud.utils import CloudUtility
+from kairon.shared.constants import WhatsappBSPTypes
 from kairon.shared.data.data_objects import UserMediaData, Rules, Intents
 from kairon.shared.data.processor import MongoProcessor
 from kairon.shared.models import UserMediaUploadType, UserMediaUploadStatus, FlowTagType
@@ -126,6 +127,7 @@ class UserMedia:
                                                        output_filename=output_filename,
                                                        filesize=filesize)
             logger.info(f"saved {media_id} successfully")
+            return url
         except ClientError as e:
             logger.exception(e)
             UserMedia.mark_user_media_data_upload_failed(media_id=media_id, reason=str(e))
@@ -136,49 +138,30 @@ class UserMedia:
             raise AppException(f"File upload for {media_id} failed")
 
     @staticmethod
-    def save_whatsapp_media_content(bot: str, sender_id: str, whatsapp_media_id:str, config: dict):
+    def save_whatsapp_media_content(bot: str, sender_id: str, whatsapp_media_id:str, config: dict, user_id: str = None, media_data: dict = None):
         """
-        Download media from 360 dialog or meta and save it to cloud storage via background task.
+        Download media from 360dialog, meta, or gupshup and save it to cloud storage via background task.
         :param bot: bot name
         :param sender_id: sender id
         :param whatsapp_media_id: whatsapp media id
-        :param config: configuration for 360 dialog or meta
+        :param config: channel config (bsp_type determines which provider path is used)
         :return: list of media ids
         """
-        download_url = None
-        file_path = None
-        headers = {}
+        from kairon.chat.handlers.channels.clients.whatsapp.factory import WhatsappFactory
+
         provider = config.get("bsp_type", "meta")
-        if provider == '360dialog':
-            endpoint = f'https://waba-v2.360dialog.io/{whatsapp_media_id}'
-            headers = {
-                'D360-API-KEY': config.get('api_key'),
-            }
-            resp = requests.get(endpoint, headers=headers, stream=True)
-            if resp.status_code != 200:
-                raise AppException(f"Failed to download media from 360 dialog: {resp.status_code} - {resp.text}")
-            json_resp = resp.json()
-            download_url = json_resp.get("url")
-            download_url = download_url.replace('https://lookaside.fbsbx.com', 'https://waba-v2.360dialog.io')
-            mime_type = json_resp.get("mime_type")
-            extension = mimetypes.guess_extension(mime_type) or ''
-            file_path = f"whataspp_360_{whatsapp_media_id}{extension}"
-        elif provider == 'meta':
-            endpoint = f'https://graph.facebook.com/v22.0/{whatsapp_media_id}'
-            access_token = config.get('access_token')
-            headers = {'Authorization': f'Bearer {access_token}'}
-            media_info_resp = requests.get(
-                endpoint,
-                params={"fields": "url", "access_token": access_token},
-                timeout=10
-            )
-            if media_info_resp.status_code != 200:
-                raise AppException(f"Failed to get url from meta for media: {whatsapp_media_id}")
-            json_resp = media_info_resp.json()
-            download_url = json_resp.get("url")
-            mime_type = json_resp.get("mime_type")
-            extension = mimetypes.guess_extension(mime_type) or ''
-            file_path = f"whatsapp_meta_{whatsapp_media_id}{extension}"
+        access_token_key_map = {
+            "meta": "access_token",
+            WhatsappBSPTypes.bsp_360dialog.value: "api_key",
+            WhatsappBSPTypes.bsp_gupshup.value: "partner_app_token",
+        }
+        access_token = config.get(access_token_key_map.get(provider, "access_token"))
+        client = WhatsappFactory.get_client(provider)
+        download_url, headers, file_path = client(
+            access_token=access_token,
+            from_phone_number_id=config.get("from_phone_number_id"),
+            config=config
+        ).get_media_info(whatsapp_media_id, config, media_data=media_data)
 
         media_resp = requests.get(
             download_url,
@@ -200,7 +183,8 @@ class UserMedia:
             media_id=media_id,
             filename=file_path,
             sender_id=sender_id,
-            upload_type=UserMediaUploadType.user_uploaded.value)
+            upload_type=UserMediaUploadType.user_uploaded.value,
+            user_id=user_id)
 
         def background_task():
             try:
@@ -551,6 +535,20 @@ class UserMedia:
             raise AppException(f"Error while fetching media ids for bot '{bot}': {str(e)}")
 
     @staticmethod
+    def get_media_handle_id(bot: str, media_id: str):
+        try:
+            obj = UserMediaData.objects.get(
+                bot=bot,
+                media_id=media_id
+            )
+            media_data = obj.to_mongo().to_dict()
+            handle_id = media_data.get('external_upload_info', {}).get('handle_id')
+
+            return handle_id
+        except Exception as e:
+            raise AppException(f"Failed to get media handle_id:{str(e)}")
+
+    @staticmethod
     def delete_media(bot, media_id: str, bucket: str = None):
         """
         Deletes a media file from the database and S3.
@@ -580,6 +578,7 @@ class UserMedia:
             filename: str,
             extension: str,
             filesize: int,
+            bsp_type: str = WhatsappBSPTypes.bsp_360dialog.value,
     ) -> UserMediaData:
         """
         Create a media document in pending state, return the instance so it can be updated later.
@@ -598,7 +597,7 @@ class UserMedia:
             sender_id=sender_id,
             bot=bot,
             external_upload_info={
-                "bsp": "360dialog",
+                "bsp": bsp_type,
                 "external_media_id": "",
                 "error": "",
             },
@@ -640,7 +639,8 @@ class UserMedia:
             sender_id: str,
             whatsapp_media_id: str,
             config: dict,
-            description: str = None
+            description: str = None,
+            user_id: str = None
     ):
         """
         Download WhatsApp media, upload to S3, save DB, and return S3 URL
@@ -649,7 +649,12 @@ class UserMedia:
 
         file_path = None
         provider = config.get("bsp_type", "meta")
-        access_token = config.get("access_token") if provider == "meta" else config.get("api_key")
+        if provider == "meta":
+            access_token = config.get("access_token")
+        elif provider == WhatsappBSPTypes.bsp_gupshup.value:
+            access_token = config.get("partner_app_token")
+        else:
+            access_token = config.get("api_key")
         from_phone_number_id = config.get("from_phone_number_id")
         client = WhatsappFactory.get_client(provider)
         download_url, headers, file_path = client(
@@ -683,6 +688,7 @@ class UserMedia:
                 "phone_number": sender_id,
                 "description": description
             },
+            user_id=user_id,
         )
 
         def background_task():

--- a/kairon/shared/constants.py
+++ b/kairon/shared/constants.py
@@ -151,6 +151,8 @@ class ElementTypes(str, Enum):
 
 class WhatsappBSPTypes(str, Enum):
     bsp_360dialog = "360dialog"
+    bsp_gupshup = "gupshup"
+    meta = "meta"
 
 
 class VoiceProviderTypes(str, Enum):

--- a/kairon/shared/data/data_objects.py
+++ b/kairon/shared/data/data_objects.py
@@ -912,7 +912,7 @@ class BotSettings(Auditlog):
     refresh_token_expiry = IntField(default=60)
     media_size_limit = IntField(default=10)
     whatsapp = StringField(
-        default="meta", choices=["meta", WhatsappBSPTypes.bsp_360dialog.value]
+        default="meta", choices=["meta", WhatsappBSPTypes.bsp_360dialog.value, WhatsappBSPTypes.bsp_gupshup.value]
     )
     notification_scheduling_limit = IntField(default=4)
     retry_broadcasting_limit = IntField(default=3)
@@ -1092,6 +1092,7 @@ class UserMediaData(Auditlog):
     filesize = IntField(default=0)
     additional_info = DictField()
     sender_id = StringField(required=True)
+    user_id = StringField(default=None)
     bot = StringField(required=True)
     timestamp = DateTimeField(default=datetime.utcnow)
     external_upload_info = DictField()
@@ -1103,6 +1104,7 @@ class UserMediaData(Auditlog):
                 "bot",
                 ("bot", "media_id"),
                 ("bot", "sender_id"),
+                ("bot", "user_id"),
                 "media_id"
             ]
         }

--- a/kairon/shared/trackers.py
+++ b/kairon/shared/trackers.py
@@ -114,6 +114,13 @@ class KMongoTrackerStore(TrackerStore, SerializedTrackerAsText):
 
         rasa_events = []
 
+        user_id = None
+        for ev in additional_events:
+            ev_dict = ev.as_dict()
+            if ev_dict.get("event") == "user":
+                user_id = ev_dict.get("metadata", {}).get("from_user_id")
+                break
+
         flattened_conversation = {
             "type": "flattened",
             "bot": self.collection,
@@ -122,6 +129,8 @@ class KMongoTrackerStore(TrackerStore, SerializedTrackerAsText):
             "data": {},
             "tag": "tracker_store",
         }
+        if user_id:
+            flattened_conversation["user_id"] = user_id
         rid = get_request_id()
         if rid:
             flattened_conversation["request_id"] = rid
@@ -144,6 +153,8 @@ class KMongoTrackerStore(TrackerStore, SerializedTrackerAsText):
                 "tag": "tracker_store",
                 "type": "bot",
             }
+            if user_id:
+                raw_event["user_id"] = user_id
             if rid:
                 raw_event["request_id"] = rid
             rasa_events.append(raw_event)

--- a/kairon/shared/utils.py
+++ b/kairon/shared/utils.py
@@ -1348,13 +1348,6 @@ class Utility:
             )
 
     @staticmethod
-    def validate_create_template_request(data: Dict):
-        required_keys = ["name", "category", "components", "language"]
-        missing_keys = [key for key in required_keys if key not in data]
-        if missing_keys:
-            raise AppException(f'Missing {", ".join(missing_keys)} in request body!')
-
-    @staticmethod
     def validate_edit_template_request(data: Dict):
         non_editable_keys = ["name", "category", "language"]
         if any(key in data for key in non_editable_keys):

--- a/kairon/shared/utils.py
+++ b/kairon/shared/utils.py
@@ -2632,6 +2632,7 @@ class MailUtility:
     ):
         mail_actions_dict = {
             "password_reset": MailUtility.__handle_password_reset,
+            "password_reset_unverified": MailUtility.__handle_password_reset_unverified,
             "password_reset_confirmation": MailUtility.__handle_password_reset_confirmation,
             "verification": MailUtility.__handle_verification,
             "verification_confirmation": MailUtility.__handle_verification_confirmation,
@@ -2758,6 +2759,14 @@ class MailUtility:
         body = Utility.email_conf["email"]["templates"]["password_reset"]
         body = body.replace("FIRST_NAME", first_name.capitalize())
         subject = Utility.email_conf["email"]["templates"]["password_reset_subject"]
+        return body, subject
+
+    @staticmethod
+    def __handle_password_reset_unverified(**kwargs):
+        first_name = kwargs.get("first_name")
+        body = Utility.email_conf["email"]["templates"]["password_reset_unverified"]
+        body = body.replace("FIRST_NAME", first_name.capitalize())
+        subject = Utility.email_conf["email"]["templates"]["password_reset_unverified_subject"]
         return body, subject
 
     @staticmethod

--- a/kairon/shared/utils.py
+++ b/kairon/shared/utils.py
@@ -2639,6 +2639,7 @@ class MailUtility:
     ):
         mail_actions_dict = {
             "password_reset": MailUtility.__handle_password_reset,
+            "password_reset_unverified": MailUtility.__handle_password_reset_unverified,
             "password_reset_confirmation": MailUtility.__handle_password_reset_confirmation,
             "verification": MailUtility.__handle_verification,
             "verification_confirmation": MailUtility.__handle_verification_confirmation,
@@ -2765,6 +2766,14 @@ class MailUtility:
         body = Utility.email_conf["email"]["templates"]["password_reset"]
         body = body.replace("FIRST_NAME", first_name.capitalize())
         subject = Utility.email_conf["email"]["templates"]["password_reset_subject"]
+        return body, subject
+
+    @staticmethod
+    def __handle_password_reset_unverified(**kwargs):
+        first_name = kwargs.get("first_name")
+        body = Utility.email_conf["email"]["templates"]["password_reset_unverified"]
+        body = body.replace("FIRST_NAME", first_name.capitalize())
+        subject = Utility.email_conf["email"]["templates"]["password_reset_unverified_subject"]
         return body, subject
 
     @staticmethod

--- a/metadata/integrations.yml
+++ b/metadata/integrations.yml
@@ -58,6 +58,19 @@ channels:
     optional_fields:
       - phone_number_id
     business_providers:
+      gupshup:
+        partner_base_url: "https://partner.gupshup.io"
+        auth_header: "token"
+        required_fields:
+          - client_name
+        optional_fields:
+          - client_id
+          - channel_id
+          - api_key
+        disabled_fields:
+          - client_id
+          - channel_id
+          - api_key
       360dialog:
         required_fields:
           - client_name

--- a/system.yaml
+++ b/system.yaml
@@ -216,6 +216,9 @@ cors:
   origin: ${ALLOWED_ORIGIN:["*"]}
 
 channels:
+  gupshup:
+    partner_email: ${GUPSHUP_PARTNER_EMAIL}
+    partner_password: ${GUPSHUP_PARTNER_PASSWORD}
   360dialog:
     partner_id: ${360_DIALOG_PARTNER_ID}
     partner_username: ${360_DIALOG_PARTNER_USERNAME}

--- a/template/emails/passwordResetUnverified.html
+++ b/template/emails/passwordResetUnverified.html
@@ -1,0 +1,324 @@
+<!-- REQUIRED PARAMS: Name, Email, URL -->
+<!-- Sub: Verify your email to reset password -->
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title></title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <style type="text/css">
+        @media screen {
+            @font-face {
+                font-family: 'Inter';
+                font-style: normal;
+                font-weight: 400;
+                font-display: swap;
+                src: url(https://fonts.gstatic.com/s/inter/v3/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa1ZL7.woff2) format('woff2');
+                unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+                    U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+            }
+
+            @font-face {
+                font-family: 'Inter';
+                font-style: normal;
+                font-weight: 700;
+                font-display: swap;
+                src: url(https://fonts.gstatic.com/s/inter/v3/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa1ZL7.woff2) format('woff2');
+                unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+                    U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+            }
+        }
+
+        /* CLIENT-SPECIFIC STYLES */
+        body,
+        table,
+        td,
+        a {
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+        }
+
+        table,
+        td {
+            mso-table-lspace: 0pt;
+            mso-table-rspace: 0pt;
+        }
+
+        img {
+            -ms-interpolation-mode: bicubic;
+        }
+
+        /* RESET STYLES */
+        img {
+            border: 0;
+            height: auto;
+            line-height: 100%;
+            outline: none;
+            text-decoration: none;
+        }
+
+        table {
+            border-collapse: collapse !important;
+        }
+
+        body {
+            height: 100% !important;
+            margin: 0 !important;
+            padding: 0 !important;
+            width: 100% !important;
+        }
+
+        /* iOS BLUE LINKS */
+        a[x-apple-data-detectors] {
+            color: inherit !important;
+            text-decoration: none !important;
+            font-size: inherit !important;
+            font-family: inherit !important;
+            font-weight: inherit !important;
+            line-height: inherit !important;
+        }
+
+        /* MOBILE STYLES */
+        @media screen and (max-width: 600px) {
+            h1 {
+                font-size: 18px !important;
+                line-height: 18px !important;
+            }
+
+            #mailheadimage {
+                width: 100%;
+            }
+        }
+
+        /* ANDROID CENTER FIX */
+        div[style*='margin: 16px 0;'] {
+            margin: 0 !important;
+        }
+    </style>
+</head>
+
+<body style="background-color: #ffffff; margin: 0 !important; padding: 0 !important">
+    <!-- HIDDEN PREHEADER TEXT -->
+    <div style="
+        display: none;
+        font-size: 1px;
+        color: #fefefe;
+        line-height: 1px;
+        font-family: 'Inter', Helvetica, Arial, sans-serif;
+        max-height: 0px;
+        max-width: 0px;
+        opacity: 0;
+        overflow: hidden;
+      ">
+        Verify your email to reset password
+    </div>
+    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+        <!-- LOGO -->
+        <tr>
+            <td bgcolor="#ffffff" align="center" style="padding: 0 10px">
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px">
+                    <tr>
+                        <td style="padding: 36px 10px 10px">
+                            <img src="BASE_URL/assets/logo/kAIron.png" alt="Kairon" width="106px" />
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        <!-- MAIN CARD -->
+        <tr>
+            <td bgcolor="#ffffff" align="center" style="padding: 0 10px">
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px">
+                    <tr>
+                        <td bgcolor="#ffffff" align="center" style="padding: 10px 20px 20px 20px">
+                            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px">
+                                <tr>
+                                    <td align="center" style="font-family: Inter, Arial, sans-serif">
+                                        <h1 style="font-size: 24px; font-weight: 600; margin: 0">
+                                            Verify your email first
+                                        </h1>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="
+                        font-family: Inter, Arial, sans-serif;
+                        font-size: 15px;
+                        padding: 16px 0;
+                      ">
+                                        <p>Hi FIRST_NAME,</p>
+                                        <p>
+                                            We received a request to reset your kAIron account password. However, your
+                                            email address has not been verified yet.
+                                        </p>
+                                        <p>
+                                            Please verify your email address first by clicking the button below. Once
+                                            verified, you can request a new password reset.
+                                        </p>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td align="center" style="
+                        font-family: Inter, Arial, sans-serif;
+                        font-size: 15px;
+                        padding: 36px 0;
+                      ">
+                                        <table border="0" cellspacing="0" cellpadding="0">
+                                            <tr>
+                                                <!-- VERIFICATION LINK BELOW -->
+                                                <td align="center" style="border-radius: 3px" bgcolor="#2F45C5">
+                                                    <a href="VERIFICATION_LINK" target="_blank" style="
+                                font-size: 18px;
+                                font-family: Inter, Arial, sans-serif;
+                                color: #ffffff;
+                                text-decoration: none;
+                                padding: 10px 20px;
+                                border-radius: 2px;
+                                display: inline-block;
+                                cursor: pointer;
+                              ">Verify Email
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td align="center"
+                                        style="color: #404040; font-family: Inter, Arial, sans-serif; font-size: 12px">
+                                        Or copy and paste this link into your browser
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <!-- VERIFICATION LINK BELOW -->
+                                    <td href="VERIFICATION_LINK" target="_blank"
+                                        style="color: #404040; font-family: Inter, Arial, sans-serif; padding: 10px 0">
+                                        <!-- VERIFICATION LINK BELOW -->
+                                        <a href="VERIFICATION_LINK" target="_blank" style="
+                          font-size: 12px;
+                          font-family: Inter, Arial, sans-serif;
+                          text-decoration: none;
+                          cursor: pointer;
+                          word-break: break-all;
+                          color: #2f45c5;
+                          cursor: pointer;
+                        ">
+                                            <!-- VERIFICATION LINK BELOW -->
+                                            VERIFICATION_LINK
+                                        </a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="
+                        font-family: Inter, Arial, sans-serif;
+                        font-size: 15px;
+                        padding: 16px 0;
+                      ">
+                                        <p style="margin-bottom: 0">Cheers,</p>
+                                        <p style="margin-top: 0">The team behind kAIron!​</p>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        <!-- FOOTER -->
+        <tr>
+            <td bgcolor="#ffffff" align="center" style="
+            padding: 5px 10px;
+            font-size: 12px;
+            color: #404040;
+            font-family: Inter, Arial, sans-serif;
+          ">
+                This email was sent to
+                <span style="text-decoration: none; color: #2f45c5">USER_EMAIL</span>
+            </td>
+        </tr>
+        <tr>
+            <td bgcolor="#ffffff" align="center" style="padding: 0 10px">
+                <table cellpadding="0" cellspacing="0" width="100%">
+                    <tr>
+                        <td align="center" style="padding: 36px 0 10px">
+                            <img src="BASE_URL/assets/emails/nimble-logo.png" alt="Digite"
+                                width="106px" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td align="center">
+                            <table cellpadding="0" cellspacing="0" align="center">
+                                <tr>
+                                    <td align="center">
+                                        <table style="display: inline-block">
+                                            <tr>
+                                                <td style="padding: 5px 10px">
+                                                    <a href="https://www.facebook.com/digite" target="_blank">
+                                                        <img src="BASE_URL/assets/emails/facebook.png"
+                                                            alt="Facebook" width="24" height="24" style="
+                                  display: block;
+                                  width: 20px !important;
+                                  height: 20px !important;
+                                " class="CToWUd" /></a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                        <table style="display: inline-block">
+                                            <tr>
+                                                <td style="padding: 5px 10px">
+                                                    <a href="https://twitter.com/digiteinc" target="_blank">
+                                                        <img src="BASE_URL/assets/emails/twitter.png"
+                                                            alt="Twitter" width="24" height="24" style="
+                                  display: block;
+                                  width: 20px !important;
+                                  height: 20px !important;
+                                " class="CToWUd" /></a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                        <table style="display: inline-block">
+                                            <tr>
+                                                <td style="padding: 5px 10px">
+                                                    <a href="https://linkedin.com/company/digite" target="_blank"><img
+                                                            src="BASE_URL/assets/emails/linkedin.png"
+                                                            alt="LinkedIn" width="24" height="24" style="
+                                  display: block;
+                                  width: 20px !important;
+                                  height: 20px !important;
+                                " class="CToWUd" /></a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                        <table style="display: inline-block">
+                                            <tr>
+                                                <td style="padding: 5px 10px">
+                                                    <a href="https://www.youtube.com/user/digiteswift" target="_blank">
+                                                        <img src="BASE_URL/assets/emails/youtube.png"
+                                                            alt="YouTube" width="24" height="24" style="
+                                  display: block;
+                                  width: 20px !important;
+                                  height: 20px !important;
+                                " class="CToWUd" />
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td align="center"
+                            style="padding: 0 0 50px; font-family: Inter, Arial, sans-serif; font-size: 12px">
+                            <p>Digité, Inc. 21060 Homestead Rd, Suite 220 Cupertino, CA, 95014, US</p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+
+</html>

--- a/tests/integration_test/services_test.py
+++ b/tests/integration_test/services_test.py
@@ -14466,6 +14466,7 @@ def test_list_broadcast():
                 'name': 'broadcast_without_filters_list',
                 'connector_type': 'whatsapp',
                 'broadcast_type': 'static',
+                'bsp_type': '360dialog',
                 'recipients_config': {'recipients': ''},
                 'template_config': [{'template_id': 'brochure_pdf', 'language': 'hi'}],
                 'collection_config': {
@@ -14488,6 +14489,7 @@ def test_list_broadcast():
                 'name': 'broadcast_with_collection_config',
                 'connector_type': 'whatsapp',
                 'broadcast_type': 'static',
+                'bsp_type': '360dialog',
                 'recipients_config': {'recipients': ''},
                 'template_config': [
                     {'template_id': 'brochure_pdf', 'language': 'hi'}
@@ -14611,6 +14613,7 @@ def test_list_broadcast_after_update():
                 'name': 'broadcast_without_filters_list',
                 'connector_type': 'whatsapp',
                 'broadcast_type': 'static',
+                'bsp_type': '360dialog',
                 'recipients_config': {'recipients': ''},
                 'template_config': [{'template_id': 'brochure_pdf', 'language': 'hi'}],
                 'collection_config': {
@@ -14633,6 +14636,7 @@ def test_list_broadcast_after_update():
                 'name': 'update_broadcast_with_collection_config',
                 'connector_type': 'whatsapp',
                 'broadcast_type': 'static',
+                'bsp_type': '360dialog',
                 'recipients_config': {'recipients': ''},
                 "scheduler_config": {
                     "expression_type": "cron",
@@ -35465,6 +35469,7 @@ def test_list_broadcast_config_after_update():
 
     print(actual["data"])
     assert actual["data"]["schedules"][2] == {'name': 'one_time_schedule_broadcast', 'connector_type': 'whatsapp', 'broadcast_type': 'static',
+         'bsp_type': '360dialog',
          'scheduler_config': {'expression_type': 'epoch', 'schedule': 2524608000, 'timezone': 'Asia/Calcutta'},
          'recipients_config': {'recipients': '916200035185,'},
          'template_config': [{'template_id': 'brochure_pdf', 'language': 'en'}], 'collection_config': {},
@@ -35692,6 +35697,7 @@ def test_list_broadcast_config():
                 "name": "first_scheduler_dynamic",
                 "connector_type": "whatsapp",
                 "broadcast_type": "dynamic",
+                "bsp_type": "360dialog",
                 "collection_config": {},
                 "scheduler_config": {
                     "expression_type": "cron",
@@ -35707,6 +35713,7 @@ def test_list_broadcast_config():
                 "name": "one_time_schedule",
                 "connector_type": "whatsapp",
                 "broadcast_type": "static",
+                "bsp_type": "360dialog",
                 "collection_config": {},
                 "recipients_config": {"recipients": "918958030541,"},
                 "retry_count": 0,
@@ -35717,6 +35724,7 @@ def test_list_broadcast_config():
                 "name": "one_time_schedule_broadcast",
                 "connector_type": "whatsapp",
                 "broadcast_type": "static",
+                "bsp_type": "360dialog",
                 "collection_config": {},
                 "recipients_config": {"recipients": "916200035185,"},
                 "retry_count": 0,
@@ -35777,6 +35785,7 @@ def test_list_broadcast_():
                 "name": "one_time_schedule",
                 "connector_type": "whatsapp",
                 "broadcast_type": "static",
+                "bsp_type": "360dialog",
                 "collection_config": {},
                 "recipients_config": {"recipients": "918958030541,"},
                 "retry_count": 0,

--- a/tests/testing_data/email.yaml
+++ b/tests/testing_data/email.yaml
@@ -13,6 +13,7 @@ email:
         confirmation_subject: ${EMAIL_TEMPLATES_CONFIRMATION_SUBJECT:"Welcome to kAIron! Please verify your account."}
         confirmed_subject: ${EMAIL_TEMPLATES_CONFIRMED_SUBJECT:"Verification complete! Build your first chatbot."}
         password_reset_subject: ${EMAIL_TEMPLATES_PASSWORD_RESET_SUBJECT:"Password Reset"}
+        password_reset_unverified_subject: ${EMAIL_TEMPLATES_PASSWORD_RESET_UNVERIFIED_SUBJECT:"Verify your email to reset password"}
         password_changed_subject: ${EMAIL_TEMPLATES_PASSWORD_CHANGED_SUBJECT:"Password Changed!"}
         add_member_subject: ${EMAIL_TEMPLATES_ADD_MEMBER_SUBJECT:"Invitation to collaborate on BOT_NAME bot"}
         add_member_confirmation_subject: ${EMAIL_TEMPLATES_ADD_MEMBER_CONFIRMATION_SUBJECT:"Invitation accepted by INVITED_PERSON_NAME"}

--- a/tests/unit_test/api/api_processor_test.py
+++ b/tests/unit_test/api/api_processor_test.py
@@ -3131,3 +3131,142 @@ class TestAccountProcessor:
         assert user_details["onboarding_status"] == "Completed"
         assert user_details["onboarding_timestamp"]
         assert user_details["is_onboarded"] is True
+
+    def test_login_token_has_jti(self):
+        from kairon.shared.authorization.data_objects import UserSessions
+        token = Authentication.create_access_token(data={"sub": "nupur.khare@digite.com", "account": pytest.account})
+        payload = Utility.decode_limited_access_token(token)
+        assert payload.get("jti") is not None
+        assert payload.get("type") == TOKEN_TYPE.LOGIN.value
+
+    def test_integration_token_has_no_jti(self):
+        token = Authentication.create_access_token(
+            data={"sub": "test_user", "bot": "test", "account": 1000, "type": TOKEN_TYPE.INTEGRATION.value},
+            token_type=TOKEN_TYPE.INTEGRATION.value
+        )
+        payload = Utility.decode_limited_access_token(token)
+        assert payload.get("jti") is None
+        assert payload.get("type") == TOKEN_TYPE.INTEGRATION.value
+
+    def test_logout_saves_user_session(self):
+        from kairon.shared.authorization.data_objects import UserSessions
+        token = Authentication.create_access_token(data={"sub": "nupur.khare@digite.com", "account": pytest.account})
+        payload = Utility.decode_limited_access_token(token)
+        jti = payload.get("jti")
+        assert jti is not None
+
+        Authentication.logout(token, "nupur.khare@digite.com")
+
+        session = UserSessions.objects(jti=jti).first()
+        assert session is not None
+        assert session.user == "nupur.khare@digite.com"
+        assert session.jti == jti
+        assert session.expires_at is not None
+        assert session.invalidated_at is not None
+
+    @pytest.mark.asyncio
+    async def test_token_rejected_after_logout(self):
+        from kairon.shared.authorization.data_objects import UserSessions
+        token = Authentication.create_access_token(data={"sub": "nupur.khare@digite.com", "account": pytest.account})
+
+        request = Request({
+            'type': 'http', 'headers': Headers({}).raw,
+            'path_params': {}, 'path': '/api/user/details', 'query_string': b''
+        })
+        user = await Authentication.get_current_user(request, token)
+        assert user.email == "nupur.khare@digite.com"
+
+        Authentication.logout(token, "nupur.khare@digite.com")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await Authentication.get_current_user(request, token)
+        assert exc_info.value.status_code == 401
+
+    def test_logout_without_jti_does_not_save_session(self):
+        from kairon.shared.authorization.data_objects import UserSessions
+        from unittest.mock import patch
+        count_before = UserSessions.objects().count()
+        with patch.object(Utility, 'decode_limited_access_token', return_value={
+            "sub": "nupur.khare@digite.com", "type": "login", "exp": 9999999999
+        }):
+            Authentication.logout("dummy_token", "nupur.khare@digite.com")
+        assert UserSessions.objects().count() == count_before
+
+    def test_handle_password_reset_request_user_not_found(self, monkeypatch):
+        Utility.email_conf["email"]["enable"] = True
+        mail_sent = []
+
+        async def _mock_send(**kwargs):
+            mail_sent.append(kwargs)
+
+        with patch.object(Utility, 'is_exist', return_value=False), \
+             patch.object(MailUtility, 'format_and_send_mail', side_effect=_mock_send):
+            loop = asyncio.new_event_loop()
+            loop.run_until_complete(AccountProcessor.handle_password_reset_request('no_such_user@example.com'))
+        assert len(mail_sent) == 0
+        Utility.email_conf["email"]["enable"] = False
+
+    def test_handle_password_reset_request_unverified_user(self, monkeypatch):
+        Utility.email_conf["email"]["enable"] = True
+        mail_sent = []
+
+        async def _mock_send(**kwargs):
+            mail_sent.append(kwargs)
+
+        fake_user = {'first_name': 'Test', 'account': 1}
+
+        def _is_exist(doc, **kwargs):
+            from kairon.shared.account.data_objects import UserEmailConfirmation
+            if doc == UserEmailConfirmation:
+                return False
+            return True
+
+        with patch.object(Utility, 'is_exist', side_effect=_is_exist), \
+             patch.object(AccountProcessor, 'get_user', return_value=fake_user), \
+             patch('kairon.shared.account.processor.UserActivityLogger') as mock_logger, \
+             patch.object(MailUtility, 'format_and_send_mail', side_effect=_mock_send):
+            mock_logger.is_password_reset_within_cooldown_period.return_value = None
+            mock_logger.is_password_reset_request_limit_exceeded.return_value = None
+            loop = asyncio.new_event_loop()
+            loop.run_until_complete(AccountProcessor.handle_password_reset_request('unverified@example.com'))
+        assert len(mail_sent) == 1
+        assert mail_sent[0]['mail_type'] == 'password_reset_unverified'
+        assert mail_sent[0]['email'] == 'unverified@example.com'
+        Utility.email_conf["email"]["enable"] = False
+
+    def test_handle_password_reset_request_verified_user(self, monkeypatch):
+        Utility.email_conf["email"]["enable"] = True
+        mail_sent = []
+
+        async def _mock_send(**kwargs):
+            mail_sent.append(kwargs)
+
+        fake_user = {'first_name': 'Test', 'account': 1}
+
+        with patch.object(Utility, 'is_exist', return_value=True), \
+             patch.object(AccountProcessor, 'get_user', return_value=fake_user), \
+             patch('kairon.shared.account.processor.UserActivityLogger') as mock_logger, \
+             patch.object(MailUtility, 'format_and_send_mail', side_effect=_mock_send):
+            mock_logger.is_password_reset_within_cooldown_period.return_value = None
+            mock_logger.is_password_reset_request_limit_exceeded.return_value = None
+            mock_logger.add_log.return_value = None
+            loop = asyncio.new_event_loop()
+            loop.run_until_complete(AccountProcessor.handle_password_reset_request('verified@example.com'))
+        assert len(mail_sent) == 1
+        assert mail_sent[0]['mail_type'] == 'password_reset'
+        assert mail_sent[0]['email'] == 'verified@example.com'
+        assert 'reset_password' in mail_sent[0]['url']
+        Utility.email_conf["email"]["enable"] = False
+
+    def test_password_reset_endpoint_returns_generic_message(self, monkeypatch):
+        async def _mock_handle(email):
+            pass
+
+        with patch.object(AccountProcessor, 'handle_password_reset_request', side_effect=_mock_handle):
+            from starlette.testclient import TestClient
+            from kairon.api.app.main import app
+            client = TestClient(app)
+            for email in ['no_such@example.com', 'unverified@example.com', 'verified@example.com']:
+                response = client.post('/api/account/password/reset', json={"data": email})
+                assert response.status_code == 200
+                assert "If the email address is registered" in response.json()["message"]

--- a/tests/unit_test/channels/broadcast_processor_test.py
+++ b/tests/unit_test/channels/broadcast_processor_test.py
@@ -213,13 +213,13 @@ class TestMessageBroadcastProcessor:
         assert isinstance(config_id, str)
         settings[0].pop("timestamp")
         settings[1].pop("timestamp")
-        assert settings == [{'name': 'first_scheduler', 'connector_type': 'whatsapp',
+        assert settings == [{'name': 'first_scheduler', 'connector_type': 'whatsapp', 'bsp_type': '360dialog',
                              "broadcast_type": "dynamic", 'retry_count': 0, 'collection_config': {},
                              'scheduler_config': {'expression_type': 'cron', 'schedule': '30 22 5 * *',
                                                   "timezone": "Asia/Kolkata"},
                              "pyscript": "send_msg('template_name', '9876543210')", "template_config": [],
                              'bot': 'test_achedule', 'user': 'test_user', 'status': True},
-                            {'name': 'second_scheduler', 'connector_type': 'slack', 'collection_config': {},
+                            {'name': 'second_scheduler', 'connector_type': 'slack', 'collection_config': {}, 'bsp_type': '360dialog',
                             'recipients_config': {'recipients': '918958030541,'}, 'retry_count': 0,
                              "broadcast_type": "static", 'template_config': [{'template_id': 'brochure_pdf', 'language': 'en'}],
                              'bot': 'test_achedule', 'user': 'test_user', 'status': True}]
@@ -228,7 +228,7 @@ class TestMessageBroadcastProcessor:
         assert isinstance(setting.pop("_id"), str)
         setting.pop("timestamp")
         assert setting == {'name': 'second_scheduler', 'connector_type': 'slack', 'retry_count': 0,
-                           'collection_config': {},
+                           'collection_config': {}, 'bsp_type': '360dialog',
                            'recipients_config': {'recipients': '918958030541,'}, 'broadcast_type': 'static',
                            'template_config': [{'template_id': 'brochure_pdf', "language": "en"}],
                            'bot': 'test_achedule', 'user': 'test_user', 'status': True}
@@ -250,7 +250,7 @@ class TestMessageBroadcastProcessor:
         assert isinstance(config_id, str)
         settings[0].pop("timestamp")
         assert settings == [{'name': 'second_scheduler', 'connector_type': 'slack',
-                             "broadcast_type": "static", 'collection_config': {},
+                             "broadcast_type": "static", 'collection_config': {}, 'bsp_type': '360dialog',
                              'recipients_config': {'recipients': '918958030541,'}, 'retry_count': 0,
                              'template_config': [{'template_id': 'brochure_pdf', "language": "en"}],
                              'bot': 'test_achedule', 'user': 'test_user', 'status': True}]
@@ -261,6 +261,7 @@ class TestMessageBroadcastProcessor:
         settings[0].pop("timestamp")
         assert settings == [{'name': 'first_scheduler', 'connector_type': 'whatsapp',
                              "broadcast_type": "dynamic", "template_config": [], 'collection_config': {},
+                             'bsp_type': '360dialog',
                              'scheduler_config': {'expression_type': 'cron', 'schedule': '30 22 5 * *', "timezone": "Asia/Kolkata"},
                              "pyscript": "send_msg('template_name', '9876543210')", 'retry_count': 0,
                              'bot': 'test_achedule', 'user': 'test_user', 'status': False}]
@@ -302,6 +303,7 @@ class TestMessageBroadcastProcessor:
                 'connector_type': 'whatsapp',
                 "broadcast_type": "dynamic",
                 'collection_config': {},
+                'bsp_type': '360dialog',
                 'retry_count': 0,
                 'scheduler_config': {
                     'expression_type': 'cron',
@@ -324,6 +326,7 @@ class TestMessageBroadcastProcessor:
             'connector_type': 'whatsapp',
             "broadcast_type": "dynamic",
             'collection_config': {},
+            'bsp_type': '360dialog',
             'retry_count': 0,
             'scheduler_config': {
                 'expression_type': 'cron',
@@ -585,6 +588,68 @@ class TestMessageBroadcastProcessor:
         MessageBroadcastProcessor.update_scheduled_task(notification_id, bot, user, config)
         updated = MessageBroadcastProcessor.get_settings(notification_id, bot)
         assert len(updated["template_config"]) == 2
+
+    def test_fetch_media_ids_delegates_to_bsp(self):
+        bot = "test_fetch_media_ids_bot"
+        user = "test_user"
+        mock_bsp = MagicMock()
+        mock_bsp.fetch_media_ids.return_value = ["media_001", "media_002"]
+        with patch(
+            "kairon.shared.chat.processor.ChatDataProcessor.get_channel_config",
+            return_value={"config": {"bsp_type": "360dialog"}},
+        ), patch(
+            "kairon.shared.channels.whatsapp.bsp.factory.BusinessServiceProviderFactory.get_instance",
+            return_value=lambda b, u: mock_bsp,
+        ):
+            result = MessageBroadcastProcessor.fetch_media_ids(bot, user)
+        assert result == ["media_001", "media_002"]
+        mock_bsp.fetch_media_ids.assert_called_once_with(bot)
+
+    def test_fetch_media_ids_defaults_bsp_type(self):
+        bot = "test_fetch_media_ids_default_bot"
+        user = "test_user"
+        mock_bsp = MagicMock()
+        mock_bsp.fetch_media_ids.return_value = []
+        with patch(
+            "kairon.shared.chat.processor.ChatDataProcessor.get_channel_config",
+            return_value={"config": {}},
+        ), patch(
+            "kairon.shared.channels.whatsapp.bsp.factory.BusinessServiceProviderFactory.get_instance",
+            return_value=lambda b, u: mock_bsp,
+        ) as mock_factory:
+            MessageBroadcastProcessor.fetch_media_ids(bot, user)
+        mock_factory.assert_called_once_with("360dialog")
+
+    def test_fetch_broadcast_media_ids_delegates_to_bsp(self):
+        bot = "test_fetch_broadcast_media_ids_bot"
+        user = "test_user"
+        mock_bsp = MagicMock()
+        mock_bsp.fetch_broadcast_media_ids.return_value = ["bcast_001", "bcast_002"]
+        with patch(
+            "kairon.shared.chat.processor.ChatDataProcessor.get_channel_config",
+            return_value={"config": {"bsp_type": "gupshup"}},
+        ), patch(
+            "kairon.shared.channels.whatsapp.bsp.factory.BusinessServiceProviderFactory.get_instance",
+            return_value=lambda b, u: mock_bsp,
+        ):
+            result = MessageBroadcastProcessor.fetch_broadcast_media_ids(bot, user)
+        assert result == ["bcast_001", "bcast_002"]
+        mock_bsp.fetch_broadcast_media_ids.assert_called_once_with(bot)
+
+    def test_fetch_broadcast_media_ids_defaults_bsp_type(self):
+        bot = "test_fetch_broadcast_media_ids_default_bot"
+        user = "test_user"
+        mock_bsp = MagicMock()
+        mock_bsp.fetch_broadcast_media_ids.return_value = []
+        with patch(
+            "kairon.shared.chat.processor.ChatDataProcessor.get_channel_config",
+            return_value={"config": {}},
+        ), patch(
+            "kairon.shared.channels.whatsapp.bsp.factory.BusinessServiceProviderFactory.get_instance",
+            return_value=lambda b, u: mock_bsp,
+        ) as mock_factory:
+            MessageBroadcastProcessor.fetch_broadcast_media_ids(bot, user)
+        mock_factory.assert_called_once_with("360dialog")
 
 
 

--- a/tests/unit_test/channels/bsp_test.py
+++ b/tests/unit_test/channels/bsp_test.py
@@ -13,6 +13,7 @@ from kairon.shared.auth import Authentication
 from kairon.shared.channels.whatsapp.bsp.base import WhatsappBusinessServiceProviderBase
 from kairon.shared.channels.whatsapp.bsp.dialog360 import BSP360Dialog
 from kairon.shared.channels.whatsapp.bsp.factory import BusinessServiceProviderFactory
+from kairon.shared.channels.whatsapp.bsp.gupshup import BSPGupshup
 from kairon.shared.chat.data_objects import Channels
 from kairon.shared.chat.processor import ChatDataProcessor
 from kairon.shared.chat.user_media import UserMedia
@@ -1592,3 +1593,859 @@ def test_delete_media_file_not_exist_raises():
 
     mock_http.assert_called_once()
 
+
+def test_bsp_360dialog_fetch_media_ids_exception():
+    bot = "bsp360_fetch_exc_bot"
+    with patch(
+        "kairon.shared.channels.whatsapp.bsp.dialog360.UserMediaData.objects",
+        side_effect=Exception("db connection lost"),
+    ):
+        with pytest.raises(AppException) as exc_info:
+            BSP360Dialog.fetch_media_ids(bot)
+    assert f"Error while fetching media ids for bot '{bot}': db connection lost" in str(exc_info.value)
+
+
+def test_bsp_360dialog_fetch_broadcast_media_ids_success():
+    from unittest.mock import MagicMock
+    bot = "bsp360_broadcast_media_bot"
+    mock_doc = MagicMock()
+    mock_doc.filename = "promo.pdf"
+    mock_doc.media_id = "bcast_media_001"
+    mock_doc.upload_status = UserMediaUploadStatus.completed.value
+    mock_doc.sender_id = "sender@test.com"
+    mock_doc.timestamp = datetime.utcnow()
+
+    mock_qs = MagicMock()
+    mock_qs.only.return_value = [mock_doc]
+
+    with patch(
+        "kairon.shared.channels.whatsapp.bsp.dialog360.UserMediaData.objects",
+        return_value=mock_qs,
+    ):
+        result = BSP360Dialog.fetch_broadcast_media_ids(bot)
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["media_id"] == "bcast_media_001"
+    assert result[0]["filename"] == "promo.pdf"
+    assert result[0]["upload_status"] == UserMediaUploadStatus.completed.value
+
+
+def test_bsp_360dialog_fetch_broadcast_media_ids_exception():
+    bot = "bsp360_broadcast_exc_bot"
+    with patch(
+        "kairon.shared.channels.whatsapp.bsp.dialog360.UserMediaData.objects",
+        side_effect=Exception("timeout"),
+    ):
+        with pytest.raises(AppException) as exc_info:
+            BSP360Dialog.fetch_broadcast_media_ids(bot)
+    assert f"Error while fetching media ids for bot '{bot}': timeout" in str(exc_info.value)
+
+
+class TestBSPGupshup:
+
+    @pytest.fixture(autouse=True, scope='class')
+    def setup(self):
+        os.environ["system_file"] = "./tests/testing_data/system.yaml"
+        Utility.load_environment()
+        Utility.load_system_metadata()
+        connect(**Utility.mongoengine_connection(Utility.environment['database']["url"]))
+
+    GS_BOT = "gs_bsp_test_bot_001"
+    GS_USER = "gs_bsp_test_user@test.com"
+
+    @pytest.fixture
+    def gupshup_channel(self):
+        encrypted_name = Utility.encrypt_message("gs_app_name")
+        Channels.objects(bot=self.GS_BOT).delete()
+        BotSettings.objects(bot=self.GS_BOT).delete()
+        BotSettings(
+            bot=self.GS_BOT, user=self.GS_USER,
+            whatsapp=WhatsappBSPTypes.bsp_gupshup.value
+        ).save()
+        Channels(
+            bot=self.GS_BOT,
+            connector_type=ChannelTypes.WHATSAPP.value,
+            config={
+                "client_name": encrypted_name,
+                "app_id": "gs_app_001",
+                "app_name": "gs_app_name",
+                "partner_app_token": "gs_partner_token_xyz",
+                "bsp_type": WhatsappBSPTypes.bsp_gupshup.value
+            },
+            user=self.GS_USER,
+            timestamp=datetime.utcnow()
+        ).save()
+        yield
+        Channels.objects(bot=self.GS_BOT).delete()
+        BotSettings.objects(bot=self.GS_BOT).delete()
+
+    # ─── validate ─────────────────────────────────────────────────────
+
+    def test_validate_success(self, monkeypatch):
+        def _get_bot_settings(*a, **kw):
+            return BotSettings(whatsapp="gupshup", bot=self.GS_BOT, user=self.GS_USER)
+        monkeypatch.setattr(MongoProcessor, 'get_bot_settings', _get_bot_settings)
+        BSPGupshup(self.GS_BOT, self.GS_USER).validate()
+
+    def test_validate_bsp_disabled(self, monkeypatch):
+        def _get_bot_settings(*a, **kw):
+            return BotSettings(whatsapp="360dialog", bot=self.GS_BOT, user=self.GS_USER)
+        monkeypatch.setattr(MongoProcessor, 'get_bot_settings', _get_bot_settings)
+        with pytest.raises(AppException, match="Feature disabled for this account"):
+            BSPGupshup(self.GS_BOT, self.GS_USER).validate()
+
+    # ─── get_account ──────────────────────────────────────────────────
+
+    def test_get_account_returns_app_id(self):
+        assert BSPGupshup(self.GS_BOT, self.GS_USER).get_account("my_app_001") == "my_app_001"
+
+    # ─── save_channel_config ──────────────────────────────────────────
+
+    def test_save_channel_config_success(self, monkeypatch):
+        captured = {}
+
+        def _save_channel_config(conf, bot, user):
+            captured['conf'] = conf
+            return "http://kairon-api.kairon.com/api/bot/whatsapp/gs_bsp_test_bot_001/token"
+
+        monkeypatch.setattr(ChatDataProcessor, 'save_channel_config', _save_channel_config)
+        BSPGupshup(self.GS_BOT, self.GS_USER).save_channel_config(
+            app_id="app_001", app_name="MyApp", partner_app_token="tok_abc"
+        )
+        assert captured['conf']['config']['app_id'] == 'app_001'
+        assert captured['conf']['config']['bsp_type'] == WhatsappBSPTypes.bsp_gupshup.value
+        assert captured['conf']['config']['partner_app_token'] == 'tok_abc'
+        assert captured['conf']['connector_type'] == ChannelTypes.WHATSAPP.value
+
+    def test_save_channel_config_defaults_app_name_to_app_id(self, monkeypatch):
+        captured = {}
+
+        def _save_channel_config(conf, bot, user):
+            captured['conf'] = conf
+            return "url"
+
+        monkeypatch.setattr(ChatDataProcessor, 'save_channel_config', _save_channel_config)
+        BSPGupshup(self.GS_BOT, self.GS_USER).save_channel_config(
+            app_id="app_002", partner_app_token="tok_xyz"
+        )
+        assert captured['conf']['config']['app_name'] == 'app_002'
+
+    def test_save_channel_config_missing_app_id(self):
+        with pytest.raises(AppException, match="app_id is required"):
+            BSPGupshup(self.GS_BOT, self.GS_USER).save_channel_config(partner_app_token="tok")
+
+    def test_save_channel_config_missing_partner_app_token(self):
+        with pytest.raises(AppException, match="partner_app_token is required"):
+            BSPGupshup(self.GS_BOT, self.GS_USER).save_channel_config(app_id="app_001")
+
+    # ─── validate_template_request ────────────────────────────────────
+
+    def test_validate_template_request_text_success(self):
+        data = {
+            "elementName": "tmpl1", "content": "Hello!", "category": "UTILITY",
+            "vertical": "Tech", "templateType": "TEXT", "example": "Hello!"
+        }
+        BSPGupshup(self.GS_BOT, self.GS_USER).validate_template_request(data)
+
+    def test_validate_template_request_text_header_with_variable_and_example_header(self):
+        data = {
+            "elementName": "t1", "content": "Hi", "category": "UTILITY",
+            "vertical": "Tech", "templateType": "TEXT", "example": "Hi",
+            "header": "Hello {{1}}", "exampleHeader": "Hello John"
+        }
+        BSPGupshup(self.GS_BOT, self.GS_USER).validate_template_request(data)
+
+    def test_validate_template_request_image_with_example_media(self):
+        data = {
+            "elementName": "t2", "content": "See image", "category": "MARKETING",
+            "vertical": "Retail", "templateType": "IMAGE", "example": "sample",
+            "exampleMedia": "handle_123"
+        }
+        BSPGupshup(self.GS_BOT, self.GS_USER).validate_template_request(data)
+
+    def test_validate_template_request_missing_keys(self):
+        data = {"elementName": "t1", "category": "UTILITY"}
+        with pytest.raises(AppException, match="Missing"):
+            BSPGupshup(self.GS_BOT, self.GS_USER).validate_template_request(data)
+
+    def test_validate_template_request_image_missing_example_media(self):
+        data = {
+            "elementName": "t2", "content": "See image", "category": "MARKETING",
+            "vertical": "Retail", "templateType": "IMAGE", "example": "sample"
+        }
+        with pytest.raises(AppException, match="exampleMedia"):
+            BSPGupshup(self.GS_BOT, self.GS_USER).validate_template_request(data)
+
+    def test_validate_template_request_text_header_variable_missing_example_header(self):
+        data = {
+            "elementName": "t3", "content": "Hi", "category": "UTILITY",
+            "vertical": "Tech", "templateType": "TEXT", "example": "Hi",
+            "header": "Hello {{1}}"
+        }
+        with pytest.raises(AppException, match="exampleHeader is required"):
+            BSPGupshup(self.GS_BOT, self.GS_USER).validate_template_request(data)
+
+    def test_validate_template_request_text_header_no_variable_ok(self):
+        data = {
+            "elementName": "t4", "content": "Hi", "category": "UTILITY",
+            "vertical": "Tech", "templateType": "TEXT", "example": "Hi",
+            "header": "Hello World"
+        }
+        BSPGupshup(self.GS_BOT, self.GS_USER).validate_template_request(data)
+
+    def test_validate_template_request_invalid_type(self):
+        data = {
+            "elementName": "t5", "content": "Hi", "category": "UTILITY",
+            "vertical": "Tech", "templateType": "AUDIO", "example": "sample"
+        }
+        with pytest.raises(AppException, match="Invalid templateType"):
+            BSPGupshup(self.GS_BOT, self.GS_USER).validate_template_request(data)
+
+    # ─── add_template ─────────────────────────────────────────────────
+
+    @responses.activate
+    def test_add_template_success(self, gupshup_channel):
+        data = {
+            "elementName": "promo_tmpl", "content": "Hello {{1}}!", "category": "MARKETING",
+            "vertical": "Retail", "templateType": "TEXT", "example": "Hello John!", "buttons": []
+        }
+        api_resp = {"id": "gs_tmpl_001", "status": "PENDING"}
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+        responses.add("POST", url=f"{base_url}/partner/app/gs_app_001/templates", json=api_resp, status=201)
+        result = BSPGupshup(self.GS_BOT, self.GS_USER).add_template(data, self.GS_BOT, self.GS_USER)
+        assert result == api_resp
+
+    @responses.activate
+    def test_add_template_api_failure(self, gupshup_channel):
+        data = {
+            "elementName": "promo_tmpl", "content": "Hello!", "category": "MARKETING",
+            "vertical": "Retail", "templateType": "TEXT", "example": "Hello!", "buttons": []
+        }
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+        responses.add("POST", url=f"{base_url}/partner/app/gs_app_001/templates",
+                      json={"error": "bad request"}, status=400)
+        with pytest.raises(AppException, match="Failed to add gupshup template"):
+            BSPGupshup(self.GS_BOT, self.GS_USER).add_template(data, self.GS_BOT, self.GS_USER)
+
+    def test_add_template_channel_not_found(self):
+        data = {
+            "elementName": "t1", "content": "Hi", "category": "UTILITY",
+            "vertical": "Tech", "templateType": "TEXT", "example": "Hi", "buttons": []
+        }
+        with pytest.raises(AppException, match="Channel not found!"):
+            BSPGupshup("no_such_bot_gs_xyz", self.GS_USER).add_template(data, "no_such_bot_gs_xyz", self.GS_USER)
+
+    def test_add_template_missing_required_keys(self, gupshup_channel):
+        data = {"elementName": "t1", "category": "UTILITY"}
+        with pytest.raises(AppException, match="Missing"):
+            BSPGupshup(self.GS_BOT, self.GS_USER).add_template(data, self.GS_BOT, self.GS_USER)
+
+    # ─── edit_template ────────────────────────────────────────────────
+
+    @responses.activate
+    def test_edit_template_success(self, gupshup_channel):
+        template_id = "gs_tmpl_edit_001"
+        data = {"content": "Updated content {{1}}"}
+        api_resp = {"id": template_id, "status": "APPROVED"}
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+        responses.add("PUT", url=f"{base_url}/partner/app/gs_app_001/templates/{template_id}",
+                      json=api_resp, status=200)
+        result = BSPGupshup(self.GS_BOT, self.GS_USER).edit_template(data, template_id)
+        assert result == api_resp
+
+    @responses.activate
+    def test_edit_template_api_failure(self, gupshup_channel):
+        template_id = "gs_tmpl_edit_002"
+        data = {"content": "Updated content"}
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+        responses.add("PUT", url=f"{base_url}/partner/app/gs_app_001/templates/{template_id}",
+                      json={"error": "not allowed"}, status=403)
+        with pytest.raises(AppException, match="Failed to edit gupshup template"):
+            BSPGupshup(self.GS_BOT, self.GS_USER).edit_template(data, template_id)
+
+    def test_edit_template_channel_not_found(self):
+        with pytest.raises(AppException, match="Channel not found!"):
+            BSPGupshup("no_such_bot_gs_xyz", self.GS_USER).edit_template({"content": "x"}, "tmpl_id")
+
+    # ─── delete_template ──────────────────────────────────────────────
+
+    @responses.activate
+    def test_delete_template_success(self, gupshup_channel):
+        template_name = "promo_tmpl_del"
+        api_resp = {"success": True}
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+        responses.add("DELETE", url=f"{base_url}/partner/app/gs_app_001/template/{template_name}",
+                      json=api_resp, status=200)
+        result = BSPGupshup(self.GS_BOT, self.GS_USER).delete_template(template_name)
+        assert result == api_resp
+
+    @responses.activate
+    def test_delete_template_api_failure(self, gupshup_channel):
+        template_name = "bad_tmpl"
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+        responses.add("DELETE", url=f"{base_url}/partner/app/gs_app_001/template/{template_name}",
+                      json={"error": "not found"}, status=404)
+        with pytest.raises(AppException, match="Failed to delete gupshup template"):
+            BSPGupshup(self.GS_BOT, self.GS_USER).delete_template(template_name)
+
+    def test_delete_template_channel_not_found(self):
+        with pytest.raises(AppException, match="Channel not found!"):
+            BSPGupshup("no_such_bot_gs_xyz", self.GS_USER).delete_template("some_tmpl")
+
+    # ─── list_templates ───────────────────────────────────────────────
+
+    @responses.activate
+    def test_list_templates_returns_waba_templates(self, gupshup_channel):
+        api_resp = {"waba_templates": [{"id": "t1", "elementName": "promo"}]}
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+        responses.add("GET", url=f"{base_url}/partner/app/gs_app_001/templates",
+                      json=api_resp, status=200)
+        result = BSPGupshup(self.GS_BOT, self.GS_USER).list_templates()
+        assert result == [{"id": "t1", "elementName": "promo"}]
+
+    @responses.activate
+    def test_list_templates_returns_templates_key_fallback(self, gupshup_channel):
+        api_resp = {"templates": [{"id": "t2", "elementName": "info"}]}
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+        responses.add("GET", url=f"{base_url}/partner/app/gs_app_001/templates",
+                      json=api_resp, status=200)
+        result = BSPGupshup(self.GS_BOT, self.GS_USER).list_templates()
+        assert result == [{"id": "t2", "elementName": "info"}]
+
+    @responses.activate
+    def test_list_templates_empty_response(self, gupshup_channel):
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+        responses.add("GET", url=f"{base_url}/partner/app/gs_app_001/templates",
+                      json={}, status=200)
+        result = BSPGupshup(self.GS_BOT, self.GS_USER).list_templates()
+        assert result == []
+
+    def test_list_templates_channel_not_found(self):
+        with pytest.raises(AppException, match="Channel not found!"):
+            BSPGupshup("no_such_bot_gs_xyz", self.GS_USER).list_templates()
+
+    # ─── get_template ─────────────────────────────────────────────────
+
+    @responses.activate
+    def test_get_template_delegates_to_list_templates(self, gupshup_channel):
+        template_id = "tmpl_specific_001"
+        api_resp = {"waba_templates": [{"id": template_id, "status": "APPROVED"}]}
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+        responses.add("GET", url=f"{base_url}/partner/app/gs_app_001/templates",
+                      json=api_resp, status=200)
+        result = BSPGupshup(self.GS_BOT, self.GS_USER).get_template(template_id)
+        assert {"id": template_id, "status": "APPROVED"} in result
+
+    # ─── __get_partner_token ──────────────────────────────────────────
+
+    @responses.activate
+    def test_get_partner_token_success(self, monkeypatch):
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+        monkeypatch.setitem(Utility.system_metadata["channels"], "gupshup",
+                            {"partner_email": "gs@test.io", "partner_password": "gs_pass"})
+        responses.add("POST", url=f"{base_url}/partner/account/login",
+                      json={"token": "partner_tok_abc"}, status=200)
+        token = BSPGupshup._BSPGupshup__get_partner_token(base_url)
+        assert token == "partner_tok_abc"
+
+    @responses.activate
+    def test_get_partner_token_login_non_200(self, monkeypatch):
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+        monkeypatch.setitem(Utility.system_metadata["channels"], "gupshup",
+                            {"partner_email": "gs@test.io", "partner_password": "bad_pass"})
+        responses.add("POST", url=f"{base_url}/partner/account/login",
+                      json={"error": "invalid credentials"}, status=401)
+        with pytest.raises(AppException, match="Gupshup partner login failed"):
+            BSPGupshup._BSPGupshup__get_partner_token(base_url)
+
+    @responses.activate
+    def test_get_partner_token_no_token_in_response(self, monkeypatch):
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+        monkeypatch.setitem(Utility.system_metadata["channels"], "gupshup",
+                            {"partner_email": "gs@test.io", "partner_password": "gs_pass"})
+        responses.add("POST", url=f"{base_url}/partner/account/login",
+                      json={"message": "ok"}, status=200)
+        with pytest.raises(AppException, match="returned no token"):
+            BSPGupshup._BSPGupshup__get_partner_token(base_url)
+
+    def test_get_partner_token_missing_credentials(self, monkeypatch):
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+        monkeypatch.setitem(Utility.system_metadata["channels"], "gupshup",
+                            {"partner_email": "", "partner_password": ""})
+        with pytest.raises(AppException, match="partner_email / partner_password not configured"):
+            BSPGupshup._BSPGupshup__get_partner_token(base_url)
+
+    # ─── post_process ─────────────────────────────────────────────────
+
+    @responses.activate
+    def test_post_process_success(self, monkeypatch, gupshup_channel):
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+        monkeypatch.setitem(Utility.system_metadata["channels"], "gupshup",
+                            {"partner_email": "gs@test.io", "partner_password": "gs_pass"})
+        monkeypatch.setitem(Utility.environment['model']['agent'], 'url', "http://kairon-api.kairon.com/")
+        responses.add("POST", url=f"{base_url}/partner/account/login",
+                      json={"token": "partner_tok_xyz"}, status=200)
+        webhook_url = f"http://kairon-api.kairon.com/api/bot/whatsapp/{self.GS_BOT}/token"
+        with patch("kairon.shared.chat.processor.ChatDataProcessor.save_channel_config",
+                   return_value=webhook_url) as mock_save, \
+             patch("kairon.shared.utils.Utility.execute_http_request") as mock_http:
+            mock_http.return_value = {"success": True}
+            result = BSPGupshup(self.GS_BOT, self.GS_USER).post_process()
+        assert result == webhook_url
+        assert "whatsapp" in result
+
+    def test_post_process_channel_not_found(self):
+        with pytest.raises(AppException):
+            BSPGupshup("no_such_bot_gs_xyz", self.GS_USER).post_process()
+
+    # ─── get_template_for_broadcast ───────────────────────────────────
+
+    @responses.activate
+    def test_get_template_for_broadcast_found(self, gupshup_channel):
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+        api_resp = {"waba_templates": [{"id": "promo_tmpl", "language": "en", "status": "APPROVED"}]}
+        responses.add("GET", url=f"{base_url}/partner/app/gs_app_001/templates",
+                      json=api_resp, status=200)
+        template, exc = BSPGupshup(self.GS_BOT, self.GS_USER).get_template_for_broadcast("promo_tmpl", "en")
+        assert template == {"id": "promo_tmpl", "language": "en", "status": "APPROVED"}
+        assert exc is None
+
+    @responses.activate
+    def test_get_template_for_broadcast_not_found(self, gupshup_channel):
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+        api_resp = {"waba_templates": [{"id": "other_tmpl", "language": "en"}]}
+        responses.add("GET", url=f"{base_url}/partner/app/gs_app_001/templates",
+                      json=api_resp, status=200)
+        template, exc = BSPGupshup(self.GS_BOT, self.GS_USER).get_template_for_broadcast("promo_tmpl", "en")
+        assert template == {}
+        assert exc is None
+
+    def test_get_template_for_broadcast_list_error(self, gupshup_channel):
+        with patch.object(BSPGupshup, 'list_templates', side_effect=Exception("API down")):
+            template, exc = BSPGupshup(self.GS_BOT, self.GS_USER).get_template_for_broadcast("promo_tmpl", "en")
+        assert template == {}
+        assert exc is not None
+
+    # ─── to_log_template ──────────────────────────────────────────────
+
+    def test_to_log_template_text_with_header_body_footer(self):
+        import json as _json
+        raw = {
+            "templateType": "TEXT",
+            "containerMeta": _json.dumps({
+                "header": "Hello Header", "data": "Body text {{1}}", "footer": "Footer text"
+            })
+        }
+        result = BSPGupshup(self.GS_BOT, self.GS_USER).to_log_template(raw)
+        types = [c["type"] for c in result]
+        assert "HEADER" in types and "BODY" in types and "FOOTER" in types
+
+    def test_to_log_template_image_header(self):
+        import json as _json
+        raw = {"templateType": "IMAGE", "containerMeta": _json.dumps({"data": "Caption"})}
+        result = BSPGupshup(self.GS_BOT, self.GS_USER).to_log_template(raw)
+        assert result[0] == {"type": "HEADER", "format": "IMAGE"}
+
+    def test_to_log_template_video_header(self):
+        import json as _json
+        raw = {"templateType": "VIDEO", "containerMeta": _json.dumps({})}
+        result = BSPGupshup(self.GS_BOT, self.GS_USER).to_log_template(raw)
+        assert result[0] == {"type": "HEADER", "format": "VIDEO"}
+
+    def test_to_log_template_document_header(self):
+        import json as _json
+        raw = {"templateType": "DOCUMENT", "containerMeta": _json.dumps({})}
+        result = BSPGupshup(self.GS_BOT, self.GS_USER).to_log_template(raw)
+        assert result[0] == {"type": "HEADER", "format": "DOCUMENT"}
+
+    def test_to_log_template_with_buttons(self):
+        import json as _json
+        raw = {
+            "templateType": "TEXT",
+            "containerMeta": _json.dumps({
+                "data": "Hello",
+                "buttons": [{"type": "QUICK_REPLY", "text": "Yes"}, {"type": "QUICK_REPLY", "text": "No"}]
+            })
+        }
+        result = BSPGupshup(self.GS_BOT, self.GS_USER).to_log_template(raw)
+        assert any(c["type"] == "BUTTONS" for c in result)
+
+    def test_to_log_template_not_a_dict(self):
+        result = BSPGupshup(self.GS_BOT, self.GS_USER).to_log_template("not a dict")
+        assert result == []
+
+    def test_to_log_template_invalid_container_meta_json(self):
+        raw = {"templateType": "TEXT", "containerMeta": "not-json"}
+        result = BSPGupshup(self.GS_BOT, self.GS_USER).to_log_template(raw)
+        assert isinstance(result, list)
+
+    # ─── _resolve_runtime_params ──────────────────────────────────────
+
+    def test_resolve_runtime_params_dict_data(self):
+        import json as _json
+        template_config = {"data": _json.dumps({"1": "John", "2": "Acme Corp"})}
+        body_params, media_id = BSPGupshup._resolve_runtime_params(template_config, {})
+        assert body_params == ["John", "Acme Corp"]
+        assert media_id is None
+
+    def test_resolve_runtime_params_components_list(self):
+        import json as _json
+        components = [
+            {"type": "body", "parameters": [{"type": "text", "text": "Alice"}, {"type": "text", "text": "Corp"}]}
+        ]
+        template_config = {"data": _json.dumps([components])}
+        body_params, media_id = BSPGupshup._resolve_runtime_params(template_config, {})
+        assert "Alice" in body_params and "Corp" in body_params
+
+    def test_resolve_runtime_params_falls_back_to_sample_text(self):
+        template_config = {"data": "[]"}
+        container_meta = {
+            "data": "Hi {{1}}, welcome to {{2}}!",
+            "sampleText": "Hi John, welcome to Acme!"
+        }
+        body_params, media_id = BSPGupshup._resolve_runtime_params(template_config, container_meta)
+        assert len(body_params) == 2
+
+    def test_resolve_runtime_params_falls_back_to_sample_media(self):
+        template_config = {"data": "[]"}
+        container_meta = {"sampleMedia": "handle_media_001"}
+        body_params, media_id = BSPGupshup._resolve_runtime_params(template_config, container_meta)
+        assert media_id == "handle_media_001"
+
+    # ─── _extract_components_params ───────────────────────────────────
+
+    def test_extract_components_params_body_text_and_image_header(self):
+        components = [
+            {"type": "body", "parameters": [{"type": "text", "text": "Alice"}]},
+            {"type": "header", "parameters": [{"type": "image", "image": {"id": "img_handle_001"}}]}
+        ]
+        body_params, media_id = BSPGupshup._extract_components_params(components)
+        assert body_params == ["Alice"]
+        assert media_id == "img_handle_001"
+
+    def test_extract_components_params_video_header(self):
+        components = [
+            {"type": "header", "parameters": [{"type": "video", "video": {"id": "vid_handle_001"}}]}
+        ]
+        body_params, media_id = BSPGupshup._extract_components_params(components)
+        assert media_id == "vid_handle_001"
+
+    def test_extract_components_params_empty(self):
+        body_params, media_id = BSPGupshup._extract_components_params([])
+        assert body_params == [] and media_id is None
+
+    # ─── _extract_sample_text_params ──────────────────────────────────
+
+    def test_extract_sample_text_params_two_placeholders(self):
+        container_meta = {
+            "data": "Hi {{1}}, your order {{2}} is confirmed.",
+            "sampleText": "Hi John, your order ORD123 is confirmed."
+        }
+        result = BSPGupshup._extract_sample_text_params(container_meta)
+        assert len(result) == 2
+
+    def test_extract_sample_text_params_no_placeholders(self):
+        container_meta = {"data": "Hello World!", "sampleText": "Hello World!"}
+        result = BSPGupshup._extract_sample_text_params(container_meta)
+        assert result == []
+
+    def test_extract_sample_text_params_empty_sample_text(self):
+        container_meta = {"data": "Hello {{1}}!", "sampleText": ""}
+        result = BSPGupshup._extract_sample_text_params(container_meta)
+        assert result == []
+
+    # ─── _build_template_payload ──────────────────────────────────────
+
+    def test_build_template_payload_text_substitutes_params(self):
+        template, message = BSPGupshup._build_template_payload(
+            "tmpl_001", ["John", "Acme"], None, "TEXT", {"data": "Hi {{1}} from {{2}}!"}
+        )
+        assert template == {"id": "tmpl_001", "params": ["John", "Acme"]}
+        assert message["type"] == "text"
+        assert "John" in message["text"] and "Acme" in message["text"]
+
+    def test_build_template_payload_image_with_media(self):
+        template, message = BSPGupshup._build_template_payload(
+            "tmpl_002", [], "img_handle_001", "IMAGE", {}
+        )
+        assert message["type"] == "image"
+        assert message["image"]["id"] == "img_handle_001"
+
+    def test_build_template_payload_video_with_media(self):
+        template, message = BSPGupshup._build_template_payload(
+            "tmpl_003", [], "vid_handle_001", "VIDEO", {}
+        )
+        assert message["type"] == "video"
+        assert message["video"]["id"] == "vid_handle_001"
+
+    def test_build_template_payload_document_with_media(self):
+        template, message = BSPGupshup._build_template_payload(
+            "tmpl_004", [], "doc_handle_001", "DOCUMENT", {}
+        )
+        assert message["type"] == "document"
+        assert message["document"]["id"] == "doc_handle_001"
+
+    def test_build_template_payload_text_no_params(self):
+        template, message = BSPGupshup._build_template_payload(
+            "tmpl_005", [], None, "TEXT", {"data": "Hello World!"}
+        )
+        assert message["type"] == "text"
+        assert message["text"] == "Hello World!"
+
+    # ─── get_broadcast_template_params ────────────────────────────────
+
+    def test_get_broadcast_template_params_text_with_sample_text(self):
+        import json as _json
+        raw_template = {
+            "id": "bc_tmpl_001", "templateType": "TEXT",
+            "containerMeta": _json.dumps({
+                "data": "Hi {{1}}, your code is {{2}}.",
+                "sampleText": "Hi John, your code is ABC123."
+            })
+        }
+        template_config = {"template_id": "bc_tmpl_001", "data": "[]"}
+        template, message = BSPGupshup(self.GS_BOT, self.GS_USER).get_broadcast_template_params(
+            raw_template, template_config)
+        assert template["id"] == "bc_tmpl_001"
+        assert message["type"] == "text"
+
+    def test_get_broadcast_template_params_image_uses_sample_media(self):
+        import json as _json
+        raw_template = {
+            "id": "bc_tmpl_002", "templateType": "IMAGE",
+            "containerMeta": _json.dumps({"data": "Check image", "sampleMedia": "img_handle_bc"})
+        }
+        template_config = {"template_id": "bc_tmpl_002", "data": "[]"}
+        template, message = BSPGupshup(self.GS_BOT, self.GS_USER).get_broadcast_template_params(
+            raw_template, template_config)
+        assert message["type"] == "image"
+        assert message["image"]["id"] == "img_handle_bc"
+
+    def test_get_broadcast_template_params_non_dict_raw_template(self):
+        template_config = {"template_id": "bc_tmpl_003", "data": "[]"}
+        template, message = BSPGupshup(self.GS_BOT, self.GS_USER).get_broadcast_template_params(
+            None, template_config)
+        assert template["id"] == "bc_tmpl_003"
+
+    # ─── fetch_media_ids ──────────────────────────────────────────────
+
+    def test_fetch_media_ids_returns_completed_broadcast_media(self):
+        bot = "gs_fetch_media_ids_bot"
+        UserMediaData.objects(bot=bot).delete()
+        UserMediaData(
+            bot=bot, media_id="handle_001", filename="promo.pdf", extension="application/pdf",
+            sender_id="user_a", upload_status=UserMediaUploadStatus.completed.value,
+            upload_type=UserMediaUploadType.broadcast.value,
+            external_upload_info={"handle_id": "ext_handle_abc"},
+            timestamp=datetime.utcnow()
+        ).save()
+        result = BSPGupshup.fetch_media_ids(bot)
+        assert len(result) == 1
+        assert result[0]["handle_id"] == "ext_handle_abc"
+        assert result[0]["filename"] == "promo.pdf"
+        UserMediaData.objects(bot=bot).delete()
+
+    def test_fetch_media_ids_excludes_failed_uploads(self):
+        bot = "gs_fetch_media_ids_excl_bot"
+        UserMediaData.objects(bot=bot).delete()
+        UserMediaData(
+            bot=bot, media_id="failed_001", filename="fail.pdf", extension="application/pdf",
+            sender_id="user_b", upload_status=UserMediaUploadStatus.failed.value,
+            upload_type=UserMediaUploadType.broadcast.value,
+            timestamp=datetime.utcnow()
+        ).save()
+        result = BSPGupshup.fetch_media_ids(bot)
+        assert result == []
+        UserMediaData.objects(bot=bot).delete()
+
+    def test_fetch_media_ids_empty_returns_empty_list(self):
+        result = BSPGupshup.fetch_media_ids("bot_with_zero_media_gs_xyz")
+        assert result == []
+
+    # ─── fetch_broadcast_media_ids ────────────────────────────────────
+
+    def test_fetch_broadcast_media_ids_success(self):
+        bot = "gs_fetch_bc_media_ids_bot"
+        UserMediaData.objects(bot=bot).delete()
+        UserMediaData(
+            bot=bot, media_id="ext_media_001", filename="video.mp4", extension="video/mp4",
+            sender_id="user_c", upload_status=UserMediaUploadStatus.completed.value,
+            upload_type=UserMediaUploadType.broadcast.value,
+            timestamp=datetime.utcnow()
+        ).save()
+        result = BSPGupshup.fetch_broadcast_media_ids(bot)
+        assert len(result) == 1
+        assert result[0]["media_id"] == "ext_media_001"
+        UserMediaData.objects(bot=bot).delete()
+
+    def test_fetch_broadcast_media_ids_excludes_empty_media_id(self):
+        bot = "gs_fetch_bc_media_excl_bot"
+        UserMediaData.objects(bot=bot).delete()
+        UserMediaData(
+            bot=bot, media_id="", filename="img.png", extension="image/png",
+            sender_id="user_d", upload_status=UserMediaUploadStatus.completed.value,
+            upload_type=UserMediaUploadType.broadcast.value,
+            timestamp=datetime.utcnow()
+        ).save()
+        result = BSPGupshup.fetch_broadcast_media_ids(bot)
+        assert result == []
+        UserMediaData.objects(bot=bot).delete()
+
+    # ─── delete_media_file ────────────────────────────────────────────
+
+    def test_delete_media_file_gupshup_success(self):
+        channel_config = {"config": {"app_id": "gs_app_001", "partner_app_token": "gs_tok"}}
+        with patch("kairon.shared.utils.Utility.execute_http_request") as mock_http:
+            mock_http.return_value = None
+            result = BSPGupshup.delete_media_file("gs_media_001", channel_config)
+        assert result == "Media file deleted successfully"
+        mock_http.assert_called_once()
+
+    def test_delete_media_file_gupshup_raises_on_failure(self):
+        channel_config = {"config": {"app_id": "gs_app_001", "partner_app_token": "gs_tok"}}
+        with patch("kairon.shared.utils.Utility.execute_http_request") as mock_http:
+            mock_http.side_effect = AppException("media file does not exist for this media id.")
+            with pytest.raises(AppException, match="media file does not exist"):
+                BSPGupshup.delete_media_file("bad_media_id", channel_config)
+
+    # ─── upload_media_file ────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_upload_media_file_missing_partner_token(self):
+        channel_config = {"config": {"app_id": "gs_app_001"}}
+        with pytest.raises(AppException, match="partner app token not found"):
+            await BSPGupshup.upload_media_file(
+                bot="gs_upload_bot", channel_config=channel_config, sender_id="user",
+                filename="test.pdf", extension="application/pdf"
+            )
+
+    @pytest.mark.asyncio
+    @responses.activate
+    async def test_upload_media_file_upload_request_fails(self):
+        from unittest.mock import MagicMock
+        bot = "gs_upload_fail_bot_002"
+        filename = "fail.pdf"
+        extension = "application/pdf"
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+
+        os.makedirs(f"media_upload_records/{bot}", exist_ok=True)
+        with open(f"media_upload_records/{bot}/{filename}", "wb") as f:
+            f.write(b"%PDF dummy")
+
+        channel_config = {"config": {"app_id": "gs_app_001", "partner_app_token": "gs_partner_tok"}}
+        responses.add("POST", url=f"{base_url}/partner/app/gs_app_001/upload/media",
+                      json={"error": "upload failed"}, status=400)
+
+        with patch("kairon.shared.channels.whatsapp.bsp.gupshup.UserMedia.create_media_doc") as mock_doc:
+            mock_doc_inst = MagicMock()
+            mock_doc.return_value = mock_doc_inst
+            with pytest.raises(AppException):
+                await BSPGupshup.upload_media_file(
+                    bot=bot, channel_config=channel_config, sender_id="user",
+                    filename=filename, extension=extension, filesize=50
+                )
+            mock_doc_inst.update.assert_called()
+
+    @pytest.mark.asyncio
+    @responses.activate
+    async def test_upload_media_file_success(self):
+        from unittest.mock import MagicMock
+        bot = "gs_upload_success_bot_003"
+        filename = "promo.pdf"
+        extension = "application/pdf"
+        base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
+
+        os.makedirs(f"media_upload_records/{bot}", exist_ok=True)
+        with open(f"media_upload_records/{bot}/{filename}", "wb") as f:
+            f.write(b"%PDF-1.4 dummy content")
+
+        channel_config = {"config": {"app_id": "gs_app_001", "partner_app_token": "gs_partner_tok"}}
+        responses.add("POST", url=f"{base_url}/partner/app/gs_app_001/upload/media",
+                      json={"handleId": "handle_upload_001"}, status=200)
+        responses.add("POST", url=f"{base_url}/partner/app/gs_app_001/media",
+                      json={"mediaId": "ext_media_upload_001"}, status=200)
+
+        storage_env = {"storage": {"whatsapp_media": {"bucket": "test-bucket"}}}
+        with patch("kairon.shared.channels.whatsapp.bsp.gupshup.UserMedia.create_media_doc") as mock_doc, \
+             patch("kairon.shared.channels.whatsapp.bsp.gupshup.UserMedia.save_media_content") as mock_save, \
+             mock.patch.dict(Utility.environment, storage_env):
+            mock_doc_inst = MagicMock()
+            mock_doc.return_value = mock_doc_inst
+            mock_save.return_value = "https://s3.aws/test/promo.pdf"
+            result = await BSPGupshup.upload_media_file(
+                bot=bot, channel_config=channel_config, sender_id="user",
+                filename=filename, extension=extension, filesize=100
+            )
+        assert result == "ext_media_upload_001"
+
+
+class TestDataRouterMediaEndpoints:
+    BOT = "data_router_test_bot_001"
+    USER = "data_router_test_user_001"
+
+    def _make_user(self):
+        from unittest.mock import MagicMock
+        user = MagicMock()
+        user.get_bot.return_value = self.BOT
+        user.get_user.return_value = self.USER
+        return user
+
+    @pytest.mark.asyncio
+    async def test_get_media_ids_exception_case(self):
+        from kairon.api.app.routers.bot.data import get_media_ids
+        user = self._make_user()
+        with patch(
+            "kairon.api.app.routers.bot.data.MessageBroadcastProcessor.fetch_media_ids",
+            side_effect=Exception("channel not found"),
+        ):
+            with pytest.raises(AppException) as exc_info:
+                await get_media_ids(current_user=user)
+        assert "Error while fetching media ids: channel not found" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_get_whatsapp_media_ids_success(self):
+        from kairon.api.app.routers.bot.data import get_whatsapp_media_ids
+        user = self._make_user()
+        with patch(
+            "kairon.api.app.routers.bot.data.MessageBroadcastProcessor.fetch_broadcast_media_ids",
+            return_value=["media_001", "media_002"],
+        ):
+            result = await get_whatsapp_media_ids(current_user=user)
+        assert result.data == ["media_001", "media_002"]
+        assert result.message == "List of media ids"
+
+    @pytest.mark.asyncio
+    async def test_get_whatsapp_media_ids_exception_case(self):
+        from kairon.api.app.routers.bot.data import get_whatsapp_media_ids
+        user = self._make_user()
+        with patch(
+            "kairon.api.app.routers.bot.data.MessageBroadcastProcessor.fetch_broadcast_media_ids",
+            side_effect=Exception("bsp config missing"),
+        ):
+            with pytest.raises(AppException) as exc_info:
+                await get_whatsapp_media_ids(current_user=user)
+        assert "Error while fetching media ids: bsp config missing" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_fetch_media_handle_id_success(self):
+        from kairon.api.app.routers.bot.data import fetch_media_handle_id
+        user = self._make_user()
+        with patch(
+            "kairon.api.app.routers.bot.data.UserMedia.get_media_handle_id",
+            return_value="handle_xyz_001",
+        ):
+            result = await fetch_media_handle_id(media_id="media_doc_id_001", current_user=user)
+        assert result.data == {"handle_id": "handle_xyz_001"}
+        assert result.message == "Successfully fetched media details"
+
+    @pytest.mark.asyncio
+    async def test_fetch_media_handle_id_not_found(self):
+        from kairon.api.app.routers.bot.data import fetch_media_handle_id
+        user = self._make_user()
+        with patch(
+            "kairon.api.app.routers.bot.data.UserMedia.get_media_handle_id",
+            side_effect=AppException("Media not found"),
+        ):
+            with pytest.raises(AppException) as exc_info:
+                await fetch_media_handle_id(media_id="nonexistent_id", current_user=user)
+        assert "Media not found" in str(exc_info.value)

--- a/tests/unit_test/channels/gupshup_test.py
+++ b/tests/unit_test/channels/gupshup_test.py
@@ -1,0 +1,978 @@
+"""Tests for Gupshup WhatsApp BSP integration changes on branch meta_bsuid_change.
+
+Covers:
+- WhatsappCloud BSUID recipient field routing ("." in phone → "recipient", else "to")
+- BSPGupshup chat client (send_action, send_action_async, send_gupshup_template_message,
+  _build_gupshup_message, get_url, mark_as_read, typing_indicator, get_media_info)
+- WhatsappBroadcast Gupshup routing (send_template_message, send_template_message_retry,
+  ChannelLogs creation)
+- Whatsapp handler Gupshup paths (handle_gupshup_native_payload, message_received routing,
+  __get_access_token, from_user_id fallback)
+- UserMedia.get_media_handle_id
+- ChatDataProcessor.save_whatsapp_audit_log user_id propagation
+"""
+
+import asyncio
+import os
+from unittest import mock
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+from mongoengine import connect, disconnect
+
+from kairon import Utility
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_environment():
+    os.environ["system_file"] = "./tests/testing_data/system.yaml"
+    Utility.load_environment()
+    Utility.load_system_metadata()
+    connect(**Utility.mongoengine_connection())
+    # Inject Gupshup metadata if not present (test env may not have full config)
+    gs = Utility.system_metadata.setdefault("channels", {}).setdefault("whatsapp", {}) \
+        .setdefault("business_providers", {})
+    gs.setdefault("gupshup", {
+        "partner_base_url": "https://partner.gupshup.io",
+        "auth_header": "token",
+    })
+    yield
+    disconnect()
+
+
+# ---------------------------------------------------------------------------
+# WhatsappCloud — BSUID recipient field routing
+# ---------------------------------------------------------------------------
+
+class TestWhatsappCloudBSUIDRouting:
+    """send/send_async use 'recipient' when phone_number contains '.', else 'to'."""
+
+    @pytest.fixture
+    def cloud(self):
+        from kairon.chat.handlers.channels.clients.whatsapp.cloud import WhatsappCloud
+        return WhatsappCloud(access_token="token123", from_phone_number_id="9100000001")
+
+    def test_send_uses_to_for_plain_phone(self, cloud):
+        with patch.object(cloud, "send_action", return_value={"messages": [{"id": "m1"}]}) as mock_send:
+            cloud.send(payload={"body": "hi"}, to_phone_number="919876543210", messaging_type="text")
+        called_payload = mock_send.call_args[0][0]
+        assert "to" in called_payload
+        assert "recipient" not in called_payload
+        assert called_payload["to"] == "919876543210"
+
+    def test_send_uses_recipient_for_bsuid(self, cloud):
+        with patch.object(cloud, "send_action", return_value={"messages": [{"id": "m1"}]}) as mock_send:
+            cloud.send(payload={"body": "hi"}, to_phone_number="abc.def.xyz", messaging_type="text")
+        called_payload = mock_send.call_args[0][0]
+        assert "recipient" in called_payload
+        assert "to" not in called_payload
+        assert called_payload["recipient"] == "abc.def.xyz"
+
+    @pytest.mark.asyncio
+    async def test_send_async_uses_to_for_plain_phone(self, cloud):
+        url = f"{cloud.app}/{cloud.from_phone_number_id}/messages?access_token={cloud.access_token}"
+        from aioresponses import aioresponses
+        with aioresponses() as m:
+            m.post(url, payload={"messages": [{"id": "x1"}]}, status=200)
+            await cloud.send_async(
+                payload={"body": "hello"},
+                to_phone_number="919876543210",
+                messaging_type="text"
+            )
+        # verify the posted body used "to"
+        # (aioresponses captures request; check via call_args pattern instead)
+
+    @pytest.mark.asyncio
+    async def test_send_async_uses_recipient_for_bsuid(self, cloud):
+        from aioresponses import aioresponses
+        url = f"{cloud.app}/{cloud.from_phone_number_id}/messages?access_token={cloud.access_token}"
+        with aioresponses() as m:
+            m.post(url, payload={"messages": [{"id": "x2"}]}, status=200)
+            ok, status, resp = await cloud.send_async(
+                payload={"body": "hello"},
+                to_phone_number="abc.123.bsuid",
+                messaging_type="text"
+            )
+        assert ok is True
+
+    def test_send_template_message_uses_recipient_for_bsuid(self, cloud):
+        with patch.object(cloud, "send_action", return_value={"messages": [{"id": "t1"}]}) as mock_send:
+            cloud.send_template_message(namespace="ns", name="tmpl", to_phone_number="abc.123.bsuid")
+        called_payload = mock_send.call_args[0][0]
+        assert called_payload.get("recipient") == "abc.123.bsuid"
+        assert "to" not in called_payload
+
+
+# ---------------------------------------------------------------------------
+# BSPGupshup chat client
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def gupshup_client():
+    from kairon.chat.handlers.channels.clients.whatsapp.gupshup import BSPGupshup as GupshupClient
+    cfg = {
+        "config": {
+            "app_id": "app_001",
+            "app_name": "TestApp",
+            "phone_number": "919000000001",
+            "partner_app_token": "tok_abc",
+            "bsp_type": "gupshup",
+        },
+        "connector_type": "whatsapp",
+    }
+    return GupshupClient(access_token="tok_abc", config=cfg)
+
+
+class TestGupshupClientInit:
+
+    def test_init_with_nested_config(self):
+        from kairon.chat.handlers.channels.clients.whatsapp.gupshup import BSPGupshup as GupshupClient
+        cfg = {
+            "config": {"app_id": "appX", "app_name": "AppX", "phone_number": "9100001"},
+            "connector_type": "whatsapp",
+        }
+        client = GupshupClient(access_token="tokenX", config=cfg)
+        assert client.app_id == "appX"
+        assert client.app_name == "AppX"
+        assert client.phone_number == "9100001"
+
+    def test_init_with_flat_config(self):
+        from kairon.chat.handlers.channels.clients.whatsapp.gupshup import BSPGupshup as GupshupClient
+        cfg = {"app_id": "appY", "app_name": "AppY", "phone_number": "9100002"}
+        client = GupshupClient(access_token="tokenY", config=cfg)
+        assert client.app_id == "appY"
+
+    def test_client_type_is_gupshup(self, gupshup_client):
+        assert gupshup_client.client_type == "gupshup"
+
+    def test_auth_args_uses_token_header(self, gupshup_client):
+        auth = gupshup_client.auth_args
+        assert "token" in auth
+        assert auth["token"] == "tok_abc"
+
+
+class TestGupshupClientGetUrl:
+
+    def test_get_url_message(self, gupshup_client):
+        url = gupshup_client.get_url("message")
+        assert url == "https://partner.gupshup.io/partner/app/app_001/msg"
+
+    def test_get_url_template(self, gupshup_client):
+        url = gupshup_client.get_url("template")
+        assert url == "https://partner.gupshup.io/partner/app/app_001/template/msg"
+
+    def test_get_url_unknown_raises(self, gupshup_client):
+        with pytest.raises(ValueError, match="Unknown api_type"):
+            gupshup_client.get_url("unknown")
+
+
+class TestBuildGupshupMessage:
+
+    def test_text_message(self, gupshup_client):
+        result = gupshup_client._build_gupshup_message("text", {"body": "Hello"})
+        assert result == {"type": "text", "text": "Hello"}
+
+    def test_image_message(self, gupshup_client):
+        result = gupshup_client._build_gupshup_message("image", {"link": "http://img.png", "caption": "Cap"})
+        assert result["type"] == "image"
+        assert result["originalUrl"] == "http://img.png"
+        assert result["caption"] == "Cap"
+
+    def test_document_message(self, gupshup_client):
+        result = gupshup_client._build_gupshup_message("document", {"link": "http://doc.pdf", "filename": "doc.pdf"})
+        assert result["type"] == "file"
+        assert result["url"] == "http://doc.pdf"
+        assert result["filename"] == "doc.pdf"
+
+    def test_audio_message(self, gupshup_client):
+        result = gupshup_client._build_gupshup_message("audio", {"link": "http://audio.mp3"})
+        assert result == {"type": "audio", "url": "http://audio.mp3"}
+
+    def test_video_message(self, gupshup_client):
+        result = gupshup_client._build_gupshup_message("video", {"link": "http://vid.mp4", "caption": "vid"})
+        assert result["type"] == "video"
+        assert result["url"] == "http://vid.mp4"
+
+    def test_location_message(self, gupshup_client):
+        result = gupshup_client._build_gupshup_message("location", {
+            "longitude": 77.5, "latitude": 12.9, "name": "Loc", "address": "Addr"
+        })
+        assert result["type"] == "location"
+        assert result["longitude"] == 77.5
+        assert result["latitude"] == 12.9
+
+    def test_unsupported_type_returns_passthrough(self, gupshup_client):
+        result = gupshup_client._build_gupshup_message("sticker", {})
+        assert result == {"type": "sticker"}
+
+
+class TestGupshupClientSendAction:
+
+    def test_send_action_posts_form_encoded(self, gupshup_client):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"status": "submitted", "messageId": "msg1"}
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            result = gupshup_client.send_action({"type": "text", "text": {"body": "hi"}, "to": "919000000002"})
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args[1]
+        assert "data" in call_kwargs          # form-encoded, not json=
+        assert "json" not in call_kwargs
+        form = call_kwargs["data"]
+        assert form["source"] == gupshup_client.phone_number
+        assert result == {"status": "submitted", "messageId": "msg1"}
+
+    def test_send_action_destination_prefers_to_field(self, gupshup_client):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {}
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            gupshup_client.send_action({"type": "text", "text": {"body": "hi"}, "to": "919111111111"})
+        form = mock_post.call_args[1]["data"]
+        assert form["destination"] == "919111111111"
+
+    def test_send_action_destination_falls_back_to_recipient(self, gupshup_client):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {}
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            gupshup_client.send_action({"type": "text", "text": {"body": "hi"}, "recipient": "uid.bsuid"})
+        form = mock_post.call_args[1]["data"]
+        assert form["destination"] == "uid.bsuid"
+
+
+class TestGupshupClientSendActionAsync:
+
+    @pytest.mark.asyncio
+    async def test_send_action_async_success(self, gupshup_client):
+        from aioresponses import aioresponses
+        url = "https://partner.gupshup.io/partner/app/app_001/msg"
+        with aioresponses() as m:
+            m.post(url, payload={"messageId": "gm1", "status": "submitted"}, status=200)
+            ok, status, resp = await gupshup_client.send_action_async(
+                {"source": "919000000001", "destination": "919000000002"},
+                url=url, use_form=True
+            )
+        assert ok is True
+        assert status == 200
+        assert resp["messageId"] == "gm1"
+
+    @pytest.mark.asyncio
+    async def test_send_action_async_failure_4xx(self, gupshup_client):
+        from aioresponses import aioresponses
+        url = "https://partner.gupshup.io/partner/app/app_001/msg"
+        with aioresponses() as m:
+            m.post(url, payload={"error": "bad request"}, status=400)
+            m.post(url, payload={"error": "bad request"}, status=400)
+            m.post(url, payload={"error": "bad request"}, status=400)
+            ok, status, resp = await gupshup_client.send_action_async(
+                {"source": "919000000001", "destination": "919000000002"},
+                url=url, use_form=True, attempts=3
+            )
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_send_action_async_success_202(self, gupshup_client):
+        from aioresponses import aioresponses
+        url = "https://partner.gupshup.io/partner/app/app_001/msg"
+        with aioresponses() as m:
+            m.post(url, payload={"messageId": "gm2", "status": "submitted"}, status=202)
+            ok, status, resp = await gupshup_client.send_action_async(
+                {"source": "919000000001", "destination": "919000000002"},
+                url=url, use_form=True
+            )
+        assert ok is True
+        assert status == 202
+        assert resp["messageId"] == "gm2"
+
+    @pytest.mark.asyncio
+    async def test_send_action_async_client_connection_error(self, gupshup_client):
+        from aiohttp import ClientConnectionError
+        with patch("kairon.chat.handlers.channels.clients.whatsapp.gupshup.RetryClient") as mock_retry:
+            mock_inst = mock_retry.return_value.__aenter__.return_value = MagicMock()
+            mock_inst.post.side_effect = ClientConnectionError("conn refused")
+            ok, status, resp = await gupshup_client.send_action_async(
+                {}, url="https://partner.gupshup.io/msg", use_form=True
+            )
+        assert ok is False
+        assert "error" in resp
+
+    @pytest.mark.asyncio
+    async def test_send_action_async_else_branch_json_parse_fails_falls_back_to_text(self, gupshup_client):
+        """Non-200/202 response where .json() raises — should fall back to .text()."""
+        from aioresponses import aioresponses
+        url = "https://partner.gupshup.io/partner/app/app_001/msg"
+        with aioresponses() as m:
+            m.post(url, body=b"internal server error", status=500,
+                   headers={"Content-Type": "text/plain"})
+            m.post(url, body=b"internal server error", status=500,
+                   headers={"Content-Type": "text/plain"})
+            m.post(url, body=b"internal server error", status=500,
+                   headers={"Content-Type": "text/plain"})
+            ok, status, resp = await gupshup_client.send_action_async(
+                {"source": "919000000001", "destination": "919000000002"},
+                url=url, use_form=True, attempts=3
+            )
+        assert ok is False
+        assert status == 500
+
+    @pytest.mark.asyncio
+    async def test_send_action_async_client_response_error(self, gupshup_client):
+        from aiohttp import ClientResponseError
+        with patch("kairon.chat.handlers.channels.clients.whatsapp.gupshup.RetryClient") as mock_retry:
+            mock_inst = mock_retry.return_value.__aenter__.return_value = MagicMock()
+            mock_inst.post.side_effect = ClientResponseError(
+                request_info=MagicMock(), history=(), status=503, message="service unavailable"
+            )
+            ok, status, resp = await gupshup_client.send_action_async(
+                {}, url="https://partner.gupshup.io/msg", use_form=True
+            )
+        assert ok is False
+        assert "error" in resp
+
+    @pytest.mark.asyncio
+    async def test_send_action_async_client_error(self, gupshup_client):
+        from aiohttp import ClientError
+        with patch("kairon.chat.handlers.channels.clients.whatsapp.gupshup.RetryClient") as mock_retry:
+            mock_inst = mock_retry.return_value.__aenter__.return_value = MagicMock()
+            mock_inst.post.side_effect = ClientError("generic client error")
+            ok, status, resp = await gupshup_client.send_action_async(
+                {}, url="https://partner.gupshup.io/msg", use_form=True
+            )
+        assert ok is False
+        assert "error" in resp
+
+    @pytest.mark.asyncio
+    async def test_send_action_async_generic_exception(self, gupshup_client):
+        with patch("kairon.chat.handlers.channels.clients.whatsapp.gupshup.RetryClient") as mock_retry:
+            mock_inst = mock_retry.return_value.__aenter__.return_value = MagicMock()
+            mock_inst.post.side_effect = RuntimeError("unexpected failure")
+            ok, status, resp = await gupshup_client.send_action_async(
+                {}, url="https://partner.gupshup.io/msg", use_form=True
+            )
+        assert ok is False
+        assert "error" in resp
+
+
+class TestGupshupClientSendAsync:
+
+    @pytest.mark.asyncio
+    async def test_send_async_posts_form_encoded(self, gupshup_client):
+        """send_async builds form data from _build_gupshup_message and delegates to send_action_async."""
+        with patch.object(gupshup_client, "send_action_async", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = (True, 200, {"messageId": "sa1"})
+            ok, status, resp = await gupshup_client.send_async(
+                payload={"body": "hello"}, to_phone_number="919000000002", messaging_type="text"
+            )
+        assert ok is True
+        call_kwargs = mock_send.call_args[1]
+        assert call_kwargs["use_form"] is True
+        import json
+        msg = json.loads(mock_send.call_args[1]["payload"]["message"])
+        assert msg["type"] == "text"
+        assert msg["text"] == "hello"
+
+    @pytest.mark.asyncio
+    async def test_send_async_invalid_messaging_type_raises(self, gupshup_client):
+        with pytest.raises(ValueError, match="not a valid"):
+            await gupshup_client.send_async(
+                payload={}, to_phone_number="919000000002", messaging_type="unsupported_type"
+            )
+
+    @pytest.mark.asyncio
+    async def test_send_async_passes_phone_number_as_source(self, gupshup_client):
+        with patch.object(gupshup_client, "send_action_async", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = (True, 200, {})
+            await gupshup_client.send_async(
+                payload={"link": "http://img.png"}, to_phone_number="919000000002", messaging_type="image"
+            )
+        payload = mock_send.call_args[1]["payload"]
+        assert payload["source"] == gupshup_client.phone_number
+        assert payload["destination"] == "919000000002"
+
+
+class TestGupshupSendTemplateMsgAsync:
+
+    @pytest.mark.asyncio
+    async def test_send_template_message_async_with_components(self, gupshup_client):
+        components = [{"type": "body", "parameters": [{"type": "text", "text": "val"}]}]
+        with patch.object(gupshup_client, "send_async", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = (True, 200, {"messageId": "tm1"})
+            ok, status, resp = await gupshup_client.send_template_message_async(
+                name="order_update", to_phone_number="919000000002",
+                language_code="en", components=components
+            )
+        assert ok is True
+        call_payload = mock_send.call_args[0][0]
+        assert call_payload["name"] == "order_update"
+        assert call_payload["language"]["code"] == "en"
+        assert call_payload["components"] == components
+
+    @pytest.mark.asyncio
+    async def test_send_template_message_async_without_components(self, gupshup_client):
+        with patch.object(gupshup_client, "send_async", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = (True, 202, {"messageId": "tm2"})
+            ok, status, resp = await gupshup_client.send_template_message_async(
+                name="promo_msg", to_phone_number="919000000003", language_code="hi"
+            )
+        assert ok is True
+        call_payload = mock_send.call_args[0][0]
+        assert "components" not in call_payload
+        assert call_payload["name"] == "promo_msg"
+        assert call_payload["language"]["code"] == "hi"
+
+    @pytest.mark.asyncio
+    async def test_send_template_message_async_routes_to_template_messaging_type(self, gupshup_client):
+        with patch.object(gupshup_client, "send_async", new_callable=AsyncMock) as mock_send:
+            mock_send.return_value = (True, 200, {})
+            await gupshup_client.send_template_message_async(
+                name="tmpl", to_phone_number="919000000002"
+            )
+        assert mock_send.call_args[1]["messaging_type"] == "template"
+
+
+class TestGupshupTemplateMessage:
+
+    @pytest.mark.asyncio
+    async def test_send_gupshup_template_message_success(self, gupshup_client):
+        template_part = {"id": "tmpl-uuid", "params": ["val1"]}
+        message_part = {"type": "text", "text": "Hello val1"}
+        components = (template_part, message_part)
+
+        async def mock_send_action_async(payload, url, headers, use_form):
+            assert use_form is True
+            assert payload["destination"] == "919000000002"
+            assert payload["source"] == gupshup_client.phone_number
+            import json
+            template_json = json.loads(payload["template"])
+            assert template_json == template_part
+            return True, 200, {"messageId": "t1", "status": "submitted"}
+
+        with patch.object(gupshup_client, "send_action_async", side_effect=mock_send_action_async):
+            ok, status, resp = await gupshup_client.send_gupshup_template_message("919000000002", components)
+
+        assert ok is True
+        assert resp["messageId"] == "t1"
+
+    @pytest.mark.asyncio
+    async def test_send_gupshup_template_message_text_excludes_message_field(self, gupshup_client):
+        """text-type message part should NOT be included in the data payload."""
+        template_part = {"id": "tmpl-uuid", "params": []}
+        message_part = {"type": "text"}
+        components = (template_part, message_part)
+
+        captured = {}
+
+        async def mock_send_action_async(payload, url, headers, use_form):
+            captured["payload"] = payload
+            return True, 200, {"messageId": "t2"}
+
+        with patch.object(gupshup_client, "send_action_async", side_effect=mock_send_action_async):
+            await gupshup_client.send_gupshup_template_message("919000000002", components)
+
+        assert "message" not in captured["payload"]
+
+    @pytest.mark.asyncio
+    async def test_send_gupshup_template_message_media_includes_message_field(self, gupshup_client):
+        """non-text message part (image) SHOULD be included in the data payload."""
+        template_part = {"id": "tmpl-uuid", "params": []}
+        message_part = {"type": "image", "image": {"id": "media-handle"}}
+        components = (template_part, message_part)
+
+        captured = {}
+
+        async def mock_send_action_async(payload, url, headers, use_form):
+            captured["payload"] = payload
+            return True, 200, {"messageId": "t3"}
+
+        with patch.object(gupshup_client, "send_action_async", side_effect=mock_send_action_async):
+            await gupshup_client.send_gupshup_template_message("919000000002", components)
+
+        assert "message" in captured["payload"]
+
+
+class TestBSPGupshupSendBroadcastTemplateAsync:
+    """Unit tests for BSPGupshup.send_broadcast_template_async routing."""
+
+    @pytest.mark.asyncio
+    async def test_tuple_routes_to_gupshup_template(self, gupshup_client):
+        components = ({"id": "tmpl-1", "params": []}, {"type": "text"})
+        with patch.object(gupshup_client, "send_gupshup_template_message", new_callable=AsyncMock,
+                          return_value=(True, 202, {"messageId": "t1"})) as mock_gs, \
+             patch.object(gupshup_client, "send_template_message_async", new_callable=AsyncMock) as mock_std:
+            ok, code, resp = await gupshup_client.send_broadcast_template_async(
+                "tmpl_id", "919000000002", "en", components
+            )
+        mock_gs.assert_called_once_with("919000000002", components)
+        mock_std.assert_not_called()
+        assert ok is True
+
+    @pytest.mark.asyncio
+    async def test_list_of_two_dicts_routes_to_standard(self, gupshup_client):
+        # Only tuple triggers Gupshup template path; a list routes to standard
+        components = [{"id": "tmpl-1", "params": []}, {"type": "text"}]
+        with patch.object(gupshup_client, "send_gupshup_template_message", new_callable=AsyncMock) as mock_gs, \
+             patch.object(gupshup_client, "send_template_message_async", new_callable=AsyncMock,
+                          return_value=(True, 200, {})) as mock_std:
+            await gupshup_client.send_broadcast_template_async(
+                "tmpl_id", "919000000002", "en", components, "ns"
+            )
+        mock_gs.assert_not_called()
+        mock_std.assert_called_once_with("tmpl_id", "919000000002", "en", components, "ns")
+
+    @pytest.mark.asyncio
+    async def test_regular_component_list_routes_to_standard(self, gupshup_client):
+        # Standard Meta-style components list (not a 2-dict Gupshup pair)
+        components = [{"type": "body", "parameters": [{"type": "text", "text": "val"}]}]
+        with patch.object(gupshup_client, "send_gupshup_template_message", new_callable=AsyncMock) as mock_gs, \
+             patch.object(gupshup_client, "send_template_message_async", new_callable=AsyncMock,
+                          return_value=(True, 200, {})) as mock_std:
+            await gupshup_client.send_broadcast_template_async(
+                "tmpl_id", "919000000002", "en", components, "ns"
+            )
+        mock_gs.assert_not_called()
+        mock_std.assert_called_once_with("tmpl_id", "919000000002", "en", components, "ns")
+
+    @pytest.mark.asyncio
+    async def test_none_components_routes_to_standard(self, gupshup_client):
+        with patch.object(gupshup_client, "send_gupshup_template_message", new_callable=AsyncMock) as mock_gs, \
+             patch.object(gupshup_client, "send_template_message_async", new_callable=AsyncMock,
+                          return_value=(True, 200, {})) as mock_std:
+            await gupshup_client.send_broadcast_template_async(
+                "tmpl_id", "919000000002", "en", None
+            )
+        mock_gs.assert_not_called()
+        mock_std.assert_called_once()
+
+
+class TestGupshupClientV3Methods:
+
+    def test_mark_as_read_posts_to_v3_url(self, gupshup_client):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"status": "ok"}
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            result = gupshup_client.mark_as_read("msg_id_123")
+        url = mock_post.call_args[0][0]
+        assert "v3/message" in url
+        body = mock_post.call_args[1]["json"]
+        assert body["status"] == "read"
+        assert body["message_id"] == "msg_id_123"
+
+    def test_typing_indicator_includes_typing_field(self, gupshup_client):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"status": "ok"}
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            result = gupshup_client.typing_indicator("msg_id_456")
+        body = mock_post.call_args[1]["json"]
+        assert body.get("typing_indicator", {}).get("type") == "text"
+        assert body["message_id"] == "msg_id_456"
+
+    def test_v3_headers_use_authorization(self, gupshup_client):
+        headers = gupshup_client._v3_headers()
+        assert "Authorization" in headers
+        assert headers["Authorization"] == gupshup_client.access_token
+
+
+class TestGupshupGetMediaInfo:
+
+    def test_get_media_info_success(self, gupshup_client):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"url": "https://cdn.gupshup.io/media/abc.jpg", "mime_type": "image/jpeg"}
+        with patch("requests.get", return_value=mock_resp):
+            url, headers, file_path = gupshup_client.get_media_info("whatsapp_media_id_1", config={})
+        assert url == "https://cdn.gupshup.io/media/abc.jpg"
+        assert "whatsapp_media_id_1" in file_path
+        assert "Authorization" in headers
+
+    def test_get_media_info_with_media_data_skips_api_call(self, gupshup_client):
+        media_data = {"url": "https://cdn.gupshup.io/media/xyz.jpg", "mime_type": "image/jpeg"}
+        with patch("requests.get") as mock_get:
+            url, headers, file_path = gupshup_client.get_media_info("media_id_2", config={}, media_data=media_data)
+        mock_get.assert_not_called()
+        assert url == "https://cdn.gupshup.io/media/xyz.jpg"
+        assert "media_id_2" in file_path
+
+    def test_get_media_info_non_200_raises(self, gupshup_client):
+        from kairon.exceptions import AppException
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        with patch("requests.get", return_value=mock_resp):
+            with pytest.raises(AppException, match="Failed to get media info"):
+                gupshup_client.get_media_info("bad_id", config={})
+
+
+# ---------------------------------------------------------------------------
+# WhatsappBroadcast — Gupshup routing
+# ---------------------------------------------------------------------------
+
+class TestWhatsappBroadcastGupshupRouting:
+
+    def _make_broadcast(self, bsp_type="gupshup"):
+        from kairon.shared.channels.broadcast.whatsapp import WhatsappBroadcast
+        config = {
+            "broadcast": Utility.environment.get("broadcast", {}),
+            "notifications": {},
+            "bsp_type": bsp_type,
+        }
+        wb = WhatsappBroadcast("test_bot", "test_user", config, "evt_id", "ref_id")
+        wb.channel_client = MagicMock()
+        return wb
+
+    @pytest.mark.asyncio
+    async def test_send_template_message_gupshup_calls_gupshup_method(self):
+        wb = self._make_broadcast(bsp_type="gupshup")
+        template_components = ({"id": "tmpl-1"}, {"type": "text"})  # tuple signals Gupshup
+
+        wb.channel_client.send_broadcast_template_async = AsyncMock(return_value=(True, 200, {"messageId": "gm1"}))
+
+        with patch("kairon.shared.channels.broadcast.whatsapp.MessageBroadcastProcessor.add_event_log"):
+            ok, code, resp = await wb.send_template_message(
+                "tmpl_id", "9190000001", "en", template_components, "ns"
+            )
+
+        wb.channel_client.send_broadcast_template_async.assert_called_once_with(
+            "tmpl_id", "9190000001", "en", template_components, "ns"
+        )
+        assert ok is True
+
+    @pytest.mark.asyncio
+    async def test_send_template_message_gupshup_non_tuple_uses_standard_path(self):
+        wb = self._make_broadcast(bsp_type="gupshup")
+        components = [{"type": "body", "parameters": []}]  # list, not tuple
+
+        wb.channel_client.send_broadcast_template_async = AsyncMock(return_value=(True, 200, {}))
+
+        with patch("kairon.shared.channels.broadcast.whatsapp.MessageBroadcastProcessor.add_event_log"):
+            ok, code, resp = await wb.send_template_message(
+                "tmpl_id", "9190000001", "en", components, "ns"
+            )
+
+        wb.channel_client.send_broadcast_template_async.assert_called_once_with(
+            "tmpl_id", "9190000001", "en", components, "ns"
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_template_message_360dialog_uses_standard_path(self):
+        wb = self._make_broadcast(bsp_type="360dialog")
+        components = {"type": "body"}
+
+        wb.channel_client.send_broadcast_template_async = AsyncMock(return_value=(True, 200, {}))
+
+        with patch("kairon.shared.channels.broadcast.whatsapp.MessageBroadcastProcessor.add_event_log"):
+            ok, code, resp = await wb.send_template_message(
+                "tmpl_id", "9190000001", "en", components, "ns"
+            )
+
+        wb.channel_client.send_broadcast_template_async.assert_called_once_with(
+            "tmpl_id", "9190000001", "en", components, "ns"
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_template_message_retry_gupshup_path(self):
+        wb = self._make_broadcast(bsp_type="gupshup")
+        template_components = ({"id": "tmpl-1"}, {"type": "text"})
+
+        wb.channel_client.send_broadcast_template_async = AsyncMock(return_value=(True, 200, {}))
+
+        with patch("kairon.shared.channels.broadcast.whatsapp.MessageBroadcastProcessor.add_event_log"):
+            ok, code, resp = await wb.send_template_message_retry(
+                "tmpl_id", "9190000001", retry_count=1, template="t",
+                language_code="en", components=template_components, namespace="ns"
+            )
+
+        wb.channel_client.send_broadcast_template_async.assert_called_once_with(
+            "tmpl_id", "9190000001", "en", template_components, "ns"
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_template_message_retry_gupshup_list_components_resend(self):
+        # Simulates resend after MongoDB round-trip: tuple stored as list
+        wb = self._make_broadcast(bsp_type="gupshup")
+        components = [{"id": "tmpl-1", "params": []}, {"type": "text"}]  # list, not tuple
+
+        wb.channel_client.send_broadcast_template_async = AsyncMock(return_value=(True, 202, {"messageId": "rs1"}))
+
+        with patch("kairon.shared.channels.broadcast.whatsapp.MessageBroadcastProcessor.add_event_log"):
+            ok, code, resp = await wb.send_template_message_retry(
+                "tmpl_id", "9190000001", retry_count=1, template="t",
+                language_code="en", components=components, namespace="ns"
+            )
+
+        wb.channel_client.send_broadcast_template_async.assert_called_once_with(
+            "tmpl_id", "9190000001", "en", components, "ns"
+        )
+        assert ok is True
+        assert code == 202
+
+    @pytest.mark.asyncio
+    async def test_send_template_message_retry_360dialog_path(self):
+        wb = self._make_broadcast(bsp_type="360dialog")
+        components = {"type": "body"}
+
+        wb.channel_client.send_broadcast_template_async = AsyncMock(return_value=(True, 200, {}))
+
+        with patch("kairon.shared.channels.broadcast.whatsapp.MessageBroadcastProcessor.add_event_log"):
+            ok, code, resp = await wb.send_template_message_retry(
+                "tmpl_id", "9190000001", retry_count=1, template="t",
+                language_code="en", components=components, namespace="ns"
+            )
+
+        wb.channel_client.send_broadcast_template_async.assert_called_once_with(
+            "tmpl_id", "9190000001", "en", components, "ns"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Whatsapp handler — Gupshup-specific paths
+# ---------------------------------------------------------------------------
+
+class TestWhatsappHandlerGupshupPaths:
+
+    # Whatsapp.__init__ takes the inner flat config dict (bsp_type, tokens, etc.),
+    # not the outer channel document {connector_type, config: {...}}.
+    @pytest.fixture
+    def gupshup_config(self):
+        return {
+            "bsp_type": "gupshup",
+            "app_id": "app_001",
+            "app_name": "TestApp",
+            "phone_number": "919000000001",
+            "partner_app_token": "partner_tok_xyz",
+        }
+
+    def test_get_access_token_returns_partner_app_token_for_gupshup(self, gupshup_config):
+        from kairon.chat.handlers.channels.whatsapp import Whatsapp
+        handler = Whatsapp(gupshup_config)
+        token = handler._Whatsapp__get_access_token()
+        assert token == "partner_tok_xyz"
+
+    def test_get_access_token_returns_api_key_for_360dialog(self):
+        from kairon.chat.handlers.channels.whatsapp import Whatsapp
+        config = {"bsp_type": "360dialog", "api_key": "dialog_key"}
+        handler = Whatsapp(config)
+        token = handler._Whatsapp__get_access_token()
+        assert token == "dialog_key"
+
+    def test_get_access_token_returns_access_token_for_meta(self):
+        from kairon.chat.handlers.channels.whatsapp import Whatsapp
+        config = {"bsp_type": "meta", "access_token": "meta_tok"}
+        handler = Whatsapp(config)
+        token = handler._Whatsapp__get_access_token()
+        assert token == "meta_tok"
+
+    def test_handle_payload_non_gupshup_native_routes_to_meta_handler(self, gupshup_config):
+        from kairon.chat.handlers.channels.whatsapp import Whatsapp
+
+        # For non-gupshup-native, use meta config so app_secret check is skipped
+        config = {"bsp_type": "gupshup", "partner_app_token": "tok"}
+        handler = Whatsapp(config)
+        payload = {"object": "whatsapp_business_account", "entry": []}
+
+        mock_request = MagicMock()
+        mock_request.json = AsyncMock(return_value=payload)
+        mock_request.body = AsyncMock(return_value=b"")
+        mock_request.headers = {}
+
+        with patch.object(handler, "handle_meta_payload") as mock_meta, \
+             patch("kairon.chat.handlers.channels.whatsapp.ActorFactory") as mock_actor_factory:
+            mock_actor = MagicMock()
+            mock_actor_factory.get_instance.return_value = mock_actor
+            import asyncio
+            asyncio.get_event_loop().run_until_complete(
+                handler.handle_payload(mock_request, {"channel_type": "whatsapp"}, "test_bot")
+            )
+            args = mock_actor.execute.call_args[0]
+            assert args[0] == handler.handle_meta_payload
+
+    @pytest.mark.asyncio
+    async def test_message_processing_uses_from_user_id_when_from_absent(self, gupshup_config):
+        """message.get('from') or message.get('from_user_id') — BSUIDs arrive as from_user_id."""
+        from kairon.chat.handlers.channels.whatsapp import Whatsapp, WhatsappBot
+
+        handler = Whatsapp(gupshup_config)
+        payload = {
+            "object": "whatsapp_business_account",
+            "entry": [{
+                "id": "WBA_ID",
+                "changes": [{
+                    "value": {
+                        "messaging_product": "whatsapp",
+                        "metadata": {"display_phone_number": "9190001", "phone_number_id": "ph1"},
+                        "contacts": [{"profile": {"name": "user"}, "wa_id": "wa1"}],
+                        "messages": [{
+                            "from_user_id": "bsuid.abc.123",   # no "from" field
+                            "id": "wamsg1",
+                            "timestamp": "1234567890",
+                            "text": {"body": "hello"},
+                            "type": "text",
+                        }]
+                    },
+                    "field": "messages"
+                }]
+            }]
+        }
+
+        captured_sender = []
+
+        async def mock_handle_user_message(text, sender_id, metadata, bot, media_ids=None):
+            captured_sender.append(sender_id)
+
+        handler._handle_user_message = mock_handle_user_message
+
+        with patch.object(WhatsappBot, "mark_as_read"), \
+             patch("kairon.chat.handlers.channels.clients.whatsapp.factory.WhatsappFactory.get_client") as mock_factory:
+            mock_client_cls = MagicMock()
+            mock_factory.return_value = mock_client_cls
+            mock_client_cls.return_value = MagicMock()
+            await handler.handle_meta_payload(
+                payload, {"channel_type": "whatsapp"}, "test_bot"
+            )
+
+        assert captured_sender == ["bsuid.abc.123"]
+
+
+# ---------------------------------------------------------------------------
+# UserMedia — get_media_handle_id
+# ---------------------------------------------------------------------------
+
+class TestUserMediaGetMediaHandleId:
+
+    def test_get_media_handle_id_returns_handle(self):
+        from kairon.shared.chat.user_media import UserMedia
+        from kairon.shared.data.data_objects import UserMediaData
+
+        mock_doc = MagicMock()
+        mock_doc.to_mongo.return_value.to_dict.return_value = {
+            "external_upload_info": {"handle_id": "handle_abc123"}
+        }
+
+        with patch.object(UserMediaData, "objects") as mock_objects:
+            mock_objects.get.return_value = mock_doc
+            handle_id = UserMedia.get_media_handle_id("bot1", "media_id_1")
+
+        assert handle_id == "handle_abc123"
+
+    def test_get_media_handle_id_raises_on_not_found(self):
+        from kairon.shared.chat.user_media import UserMedia
+        from kairon.shared.data.data_objects import UserMediaData
+        from kairon.exceptions import AppException
+        from mongoengine import DoesNotExist
+
+        with patch.object(UserMediaData, "objects") as mock_objects:
+            mock_objects.get.side_effect = DoesNotExist("not found")
+            with pytest.raises(AppException, match="Failed to get media handle_id"):
+                UserMedia.get_media_handle_id("bot1", "nonexistent_media_id")
+
+    def test_get_media_handle_id_missing_handle_returns_none(self):
+        from kairon.shared.chat.user_media import UserMedia
+        from kairon.shared.data.data_objects import UserMediaData
+
+        mock_doc = MagicMock()
+        mock_doc.to_mongo.return_value.to_dict.return_value = {
+            "external_upload_info": {}  # no handle_id key
+        }
+
+        with patch.object(UserMediaData, "objects") as mock_objects:
+            mock_objects.get.return_value = mock_doc
+            handle_id = UserMedia.get_media_handle_id("bot1", "media_id_2")
+
+        assert handle_id is None
+
+
+# ---------------------------------------------------------------------------
+# UserMedia — bsp_type in create_media_doc
+# ---------------------------------------------------------------------------
+
+class TestUserMediaCreateMediaDoc:
+
+    def test_create_media_doc_defaults_to_360dialog(self):
+        from kairon.shared.chat.user_media import UserMedia
+        from kairon.shared.data.data_objects import UserMediaData
+
+        mock_doc = MagicMock()
+        with patch.object(UserMediaData, "save", return_value=None), \
+             patch("kairon.shared.chat.user_media.UserMediaData") as mock_cls:
+            mock_cls.return_value = mock_doc
+            UserMedia.create_media_doc("bot", "sender", "file.jpg", "image/jpeg", 1024)
+            kwargs = mock_cls.call_args[1]
+            assert kwargs["external_upload_info"]["bsp"] == "360dialog"
+
+    def test_create_media_doc_uses_provided_bsp_type(self):
+        from kairon.shared.chat.user_media import UserMedia
+        from kairon.shared.data.data_objects import UserMediaData
+        from kairon.shared.constants import WhatsappBSPTypes
+
+        mock_doc = MagicMock()
+        with patch("kairon.shared.chat.user_media.UserMediaData") as mock_cls:
+            mock_cls.return_value = mock_doc
+            UserMedia.create_media_doc(
+                "bot", "sender", "file.jpg", "image/jpeg", 1024,
+                bsp_type=WhatsappBSPTypes.bsp_gupshup.value
+            )
+            kwargs = mock_cls.call_args[1]
+            assert kwargs["external_upload_info"]["bsp"] == "gupshup"
+
+
+# ---------------------------------------------------------------------------
+# ChatDataProcessor — user_id propagation in save_whatsapp_audit_log
+# ---------------------------------------------------------------------------
+
+class TestChatDataProcessorAuditLog:
+
+    def test_save_whatsapp_audit_log_persists_user_id(self):
+        from kairon.shared.chat.processor import ChatDataProcessor
+        from kairon.shared.chat.data_objects import ChannelLogs
+
+        status_data = {
+            "id": "msg_001",
+            "status": "delivered",
+            "recipient_user_id": "bsuid.xyz.123",
+        }
+
+        with patch.object(ChannelLogs, "save", return_value=None), \
+             patch("kairon.shared.chat.processor.ChannelLogs") as mock_cls:
+            mock_instance = MagicMock()
+            mock_cls.return_value = mock_instance
+            ChatDataProcessor.save_whatsapp_audit_log(
+                status_data, "bot1", "9190001", "9190002", "whatsapp"
+            )
+            kwargs = mock_cls.call_args[1]
+            assert kwargs.get("user_id") == "bsuid.xyz.123"
+
+    def test_save_whatsapp_audit_log_user_id_none_when_absent(self):
+        from kairon.shared.chat.processor import ChatDataProcessor
+
+        status_data = {"id": "msg_002", "status": "sent"}  # no recipient_user_id
+
+        with patch("kairon.shared.chat.processor.ChannelLogs") as mock_cls:
+            mock_instance = MagicMock()
+            mock_cls.return_value = mock_instance
+            ChatDataProcessor.save_whatsapp_audit_log(
+                status_data, "bot1", "9190001", "9190002", "whatsapp"
+            )
+            kwargs = mock_cls.call_args[1]
+            assert kwargs.get("user_id") is None
+
+
+# ---------------------------------------------------------------------------
+# WhatsappBSPTypes constant
+# ---------------------------------------------------------------------------
+
+class TestWhatsappBSPTypesEnum:
+
+    def test_bsp_gupshup_value(self):
+        from kairon.shared.constants import WhatsappBSPTypes
+        assert WhatsappBSPTypes.bsp_gupshup.value == "gupshup"
+
+    def test_bsp_360dialog_value_unchanged(self):
+        from kairon.shared.constants import WhatsappBSPTypes
+        assert WhatsappBSPTypes.bsp_360dialog.value == "360dialog"
+
+
+# ---------------------------------------------------------------------------
+# ChannelTypes.VOICE constant
+# ---------------------------------------------------------------------------
+
+class TestChannelTypesVoice:
+
+    def test_voice_channel_type_added(self):
+        from kairon.shared.constants import ChannelTypes
+        assert ChannelTypes.VOICE.value == "voice"

--- a/tests/unit_test/channels/mail_channel_test.py
+++ b/tests/unit_test/channels/mail_channel_test.py
@@ -28,24 +28,27 @@ from kairon.shared.constants import ChannelTypes
 
 
 class TestMailChannel:
-    @pytest.fixture(autouse=True, scope='class')
-    def setup(self):
-        connect(**Utility.mongoengine_connection(Utility.environment['database']["url"]))
-        a = Account.objects.create(name="mail_channel_test_user_acc", user="mail_channel_test_user_acc")
-        bot = Bot.objects.create(name="mail_channel_test_bot", user="mail_channel_test_user_acc", status=True,
-                                 account=a.id)
-        pytest.mail_test_bot = str(bot.id)
-        BotSettings(bot=pytest.mail_test_bot, user="mail_channel_test_user_acc").save()
-        yield
+    bot_id = ""
+    user = "mail_channel_test_user"
 
-        BotSettings.objects(user="mail_channel_test_user_acc").delete()
-        Bot.objects(user="mail_channel_test_user_acc").delete()
-        Account.objects(user="mail_channel_test_user_acc").delete()
+    @classmethod
+    def setup_class(cls):
+        connect(**Utility.mongoengine_connection(Utility.environment['database']["url"]))
+
+        a = Account(name="mail_channel_test_user_acc", user=cls.user).save()
+        bot = Bot(name="mail_channel_test_bot", user=cls.user, status=True,
+                                 account=a.id).save()
+        BotSettings(bot=str(bot.id), user=cls.user).save()
+        cls.bot_id = str(bot.id)
+
+    @classmethod
+    def teardown_class(cls):
+        BotSettings.objects(user=cls.user).delete()
+        Bot.objects(user=cls.user).delete()
+        Account.objects(user=cls.user).delete()
         Channels.objects(connector_type=ChannelTypes.MAIL.value).delete()
 
-
         disconnect()
-
 
 
 
@@ -68,7 +71,7 @@ class TestMailChannel:
             }
         }
 
-        bot_id = pytest.mail_test_bot
+        bot_id = self.bot_id
         mp = MailProcessor(bot=bot_id)
         mp.login_imap()
 
@@ -98,7 +101,7 @@ class TestMailChannel:
             }
         }
 
-        bot_id = pytest.mail_test_bot
+        bot_id = self.bot_id
         mp = MailProcessor(bot=bot_id)
 
         mp.login_imap()
@@ -123,7 +126,7 @@ class TestMailChannel:
             }
         }
 
-        bot_id = pytest.mail_test_bot
+        bot_id = self.bot_id
         mp = MailProcessor(bot=bot_id)
 
         mp.login_smtp()
@@ -149,7 +152,7 @@ class TestMailChannel:
             }
         }
 
-        bot_id = pytest.mail_test_bot
+        bot_id = self.bot_id
         mp = MailProcessor(bot=bot_id)
 
         mp.login_smtp()
@@ -167,7 +170,7 @@ class TestMailChannel:
         mock_smtp_instance = MagicMock()
         mock_smtp.return_value = mock_smtp_instance
 
-        mail_response_log = MailResponseLog(bot=pytest.mail_test_bot,
+        mail_response_log = MailResponseLog(bot=self.bot_id,
                                             sender_id="recipient@test.com",
                                             user="mail_channel_test_user_acc",
                                             uid=123
@@ -183,7 +186,7 @@ class TestMailChannel:
                 'smtp_port': 587
             }
         }
-        bot_id = pytest.mail_test_bot
+        bot_id = self.bot_id
         mp = MailProcessor(bot=bot_id)
         mp.login_smtp()
 
@@ -204,7 +207,7 @@ class TestMailChannel:
         mock_smtp_instance = MagicMock()
         mock_smtp.return_value = mock_smtp_instance
 
-        mail_response_log = MailResponseLog(bot=pytest.mail_test_bot,
+        mail_response_log = MailResponseLog(bot=self.bot_id,
                                             sender_id="recipient@test.com",
                                             user="mail_channel_test_user_acc",
                                             uid=123
@@ -220,7 +223,7 @@ class TestMailChannel:
             }
         }
 
-        bot_id = pytest.mail_test_bot
+        bot_id = self.bot_id
         mp = MailProcessor(bot=bot_id)
         mp.login_smtp()
 
@@ -246,14 +249,14 @@ class TestMailChannel:
             }
         }
 
-        mail_response_log = MailResponseLog(bot=pytest.mail_test_bot,
+        mail_response_log = MailResponseLog(bot=self.bot_id,
                                             sender_id="recipient@test.com",
                                             user="mail_channel_test_user_acc",
                                             uid=123
                                             )
         mail_response_log.save()
 
-        bot_id = pytest.mail_test_bot
+        bot_id = self.bot_id
         mp = MailProcessor(bot=bot_id)
 
         rasa_chat_response = {
@@ -278,7 +281,7 @@ class TestMailChannel:
     @patch("kairon.shared.chat.processor.ChatDataProcessor.get_channel_config")
     @pytest.mark.asyncio
     async def test_generate_criteria(self, mock_get_channel_config):
-        bot_id = pytest.mail_test_bot
+        bot_id = self.bot_id
         mock_get_channel_config.return_value = {
             'config': {
                 'email_account': "mail_channel_test_user_acc@testuser.com",
@@ -324,7 +327,7 @@ class TestMailChannel:
     def test_generate_criteria_with_last_email_uid_zero(self, mock_get_channel_config):
         import pytz
         from datetime import datetime
-        bot_id = pytest.mail_test_bot
+        bot_id = self.bot_id
 
         mock_get_channel_config.return_value = {
             'config': {
@@ -365,7 +368,7 @@ class TestMailChannel:
         """
         import pytz
         IST = pytz.timezone("Asia/Kolkata")
-        bot_id = pytest.mail_test_bot
+        bot_id = self.bot_id
         mock_get_channel_config.return_value = {
             'config': {
                 'email_account': "mail_channel_test_user_acc@testuser.com",
@@ -396,7 +399,7 @@ class TestMailChannel:
     async def test_read_mails(self, mock_get_channel_config,
                                   mock_mailbox, mock_process_message_task,
                                  mock_logout_imap):
-        bot_id = pytest.mail_test_bot
+        bot_id = self.bot_id
 
         mock_get_channel_config.return_value = {
             'config': {
@@ -427,7 +430,7 @@ class TestMailChannel:
         assert mails[0]["mail_id"] == "test@example.com"
         assert mails[0]["date"] == "2023-10-10"
         assert mails[0]["body"] == "Test Body"
-        assert user == 'mail_channel_test_user_acc'
+        assert user == 'mail_channel_test_user'
 
 
 
@@ -440,7 +443,7 @@ class TestMailChannel:
     async def test_read_mails_no_messages(self, mock_get_channel_config,
                                               mock_mailbox, mock_process_message_task,
                                              mock_logout_imap):
-        bot_id = pytest.mail_test_bot
+        bot_id = self.bot_id
 
         mock_get_channel_config.return_value = {
             'config': {
@@ -459,7 +462,7 @@ class TestMailChannel:
 
         mails, user = MailProcessor.read_mails(bot_id)
         assert len(mails) == 0
-        assert user == 'mail_channel_test_user_acc'
+        assert user == 'mail_channel_test_user'
 
         mock_logout_imap.assert_called_once()
 
@@ -473,7 +476,7 @@ class TestMailChannel:
     @pytest.mark.asyncio
     async def test_process_messages(self, mock_process_messages_via_bot, mock_send_mail, mock_logout_smtp, mock_login_smtp, mock_get_channel_config):
 
-        mail_response_log = MailResponseLog(bot=pytest.mail_test_bot,
+        mail_response_log = MailResponseLog(bot=self.bot_id,
                                             sender_id="recipient@test.com",
                                             user="mail_channel_test_user_acc",
                                             uid=123
@@ -489,7 +492,7 @@ class TestMailChannel:
             }
         }
 
-        bot = pytest.mail_test_bot
+        bot = self.bot_id
         batch = [{"mail_id": "test@example.com", "subject": "Test Subject", "date": "2023-10-10", "body": "Test Body", "log_id": str(mail_response_log.id)}]
 
         mock_process_messages_via_bot.return_value = [{"text": "hello world"}], []
@@ -565,7 +568,7 @@ class TestMailChannel:
         assert not result
 
     def test_get_mail_channel_state_data_existing_state(self):
-        bot_id = pytest.mail_test_bot
+        bot_id = self.bot_id
         mock_state = MagicMock()
 
         with patch.object(MailChannelStateData, 'objects') as mock_objects:
@@ -576,7 +579,7 @@ class TestMailChannel:
             mock_objects.return_value.first.assert_called_once()
 
     def test_get_mail_channel_state_data_new_state(self):
-        bot_id = pytest.mail_test_bot
+        bot_id = self.bot_id
         mock_state = MagicMock()
         mock_state.bot = bot_id
         mock_state.state = "some_state"
@@ -643,11 +646,6 @@ class TestMailChannel:
                 MailProcessor.get_log(bot_id, offset, limit)
 
             assert str(excinfo.value) == "Test Exception"
-
-        BotSettings.objects(user="mail_channel_test_user_acc").delete()
-        Bot.objects(user="mail_channel_test_user_acc").delete()
-        Account.objects(user="mail_channel_test_user_acc").delete()
-        Channels.objects(connector_type=ChannelTypes.MAIL.value).delete()
 
 
 

--- a/tests/unit_test/channels/whatsapp_broadcast_test.py
+++ b/tests/unit_test/channels/whatsapp_broadcast_test.py
@@ -1,6 +1,6 @@
 import asyncio
 import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 import pytest
 from aiohttp import ClientConnectionError, ClientError
 from aioresponses import aioresponses
@@ -13,6 +13,7 @@ from kairon.shared.chat.agent.agent_flow import AgenticFlow
 from kairon.shared.chat.broadcast.constants import MessageBroadcastLogType
 from kairon.shared.chat.broadcast.data_objects import MessageBroadcastLogs
 from kairon.shared.chat.broadcast.processor import MessageBroadcastProcessor
+from kairon.shared.constants import WhatsappBSPTypes
 from kairon.shared.data.constant import EVENT_STATUS
 
 
@@ -443,7 +444,7 @@ async def test_send_template_message():
 
     with patch.object(WhatsappBroadcast, '_WhatsappBroadcast__get_client', return_value=MagicMock()) as mock_get_client, \
          patch.object(whatsapp_broadcast, 'channel_client', new_callable=MagicMock) as mock_channel_client, \
-         patch.object(whatsapp_broadcast.channel_client, 'send_template_message_async', side_effect=mock_send_template_message_async) as mock_send_template_message_async, \
+         patch.object(whatsapp_broadcast.channel_client, 'send_broadcast_template_async', new=AsyncMock(side_effect=mock_send_template_message_async)) as mock_send_broadcast, \
          patch.object(whatsapp_broadcast, 'log_failed_messages') as mock_log_failed_messages:
 
         status_flag, status_code, response = await whatsapp_broadcast.send_template_message(template_id, recipient, language_code, components, namespace)
@@ -452,7 +453,7 @@ async def test_send_template_message():
         assert status_code == 200
         assert response == {}
 
-        mock_send_template_message_async.assert_called_once_with(template_id, recipient, language_code, components, namespace)
+        mock_send_broadcast.assert_called_once_with(template_id, recipient, language_code, components, namespace)
         mock_log_failed_messages.assert_not_called()
 
     del Utility.environment['notifications']
@@ -487,7 +488,7 @@ async def test_send_template_message_retry():
 
     with patch.object(WhatsappBroadcast, '_WhatsappBroadcast__get_client', return_value=MagicMock()) as mock_get_client, \
          patch.object(whatsapp_broadcast, 'channel_client', new_callable=MagicMock) as mock_channel_client, \
-         patch.object(whatsapp_broadcast.channel_client, 'send_template_message_async', side_effect=mock_send_template_message_async) as mock_send_template_message_async, \
+         patch.object(whatsapp_broadcast.channel_client, 'send_broadcast_template_async', new=AsyncMock(side_effect=mock_send_template_message_async)) as mock_send_broadcast, \
          patch.object(whatsapp_broadcast, 'log_failed_messages') as mock_log_failed_messages:
 
         status_flag, status_code, response = await whatsapp_broadcast.send_template_message_retry(template_id, recipient, retry_count, template, language_code, components, namespace)
@@ -496,7 +497,7 @@ async def test_send_template_message_retry():
         assert status_code == 200
         assert response == {}
 
-        mock_send_template_message_async.assert_called_once_with(template_id, recipient, language_code, components, namespace)
+        mock_send_broadcast.assert_called_once_with(template_id, recipient, language_code, components, namespace)
         mock_log_failed_messages.assert_not_called()
 
     del Utility.environment['notifications']
@@ -597,7 +598,7 @@ async def test_send_using_flow():
 
         broadcast._WhatsappBroadcast__send_using_flow(recipients)
 
-        mock_get_template.assert_called_once_with("template_1", "en")
+        mock_get_template.assert_called_once_with("template_1", "en", "360dialog")
         mock_initiate_broadcast.assert_called_once()
         mock_add_event_log.assert_called()
         mock_update_broadcast_logs_with_template.assert_called()
@@ -636,7 +637,7 @@ async def test_send_template_message_success_with_flow():
 
     with patch.object(WhatsappBroadcast, '_WhatsappBroadcast__get_client', return_value=MagicMock()) as mock_get_client, \
          patch.object(whatsapp_broadcast, 'channel_client', new_callable=MagicMock) as mock_channel_client, \
-         patch.object(whatsapp_broadcast.channel_client, 'send_template_message_async', side_effect=mock_send_template_message_async) as mock_send_template_message_async, \
+         patch.object(whatsapp_broadcast.channel_client, 'send_broadcast_template_async', new=AsyncMock(side_effect=mock_send_template_message_async)) as mock_send_broadcast, \
          patch.object(MessageBroadcastProcessor, 'add_event_log') as mock_add_event_log, \
             patch.object(AgenticFlow, '__init__', return_value=None) as mock_init, \
             patch.object(AgenticFlow, 'execute_rule', side_effect=mock_execute_rule) as mock_execute_rule:
@@ -647,7 +648,7 @@ async def test_send_template_message_success_with_flow():
         assert status_code == 200
         assert response == {}
 
-        mock_send_template_message_async.assert_called_once_with(template_id, recipient, language_code, components, namespace)
+        mock_send_broadcast.assert_called_once_with(template_id, recipient, language_code, components, namespace)
         mock_add_event_log.assert_called_once()
 
 @pytest.mark.asyncio
@@ -678,9 +679,9 @@ async def test_send_template_message_success_with_flow():
 
     with patch.object(WhatsappBroadcast, '_WhatsappBroadcast__get_client', return_value=MagicMock()) as mock_get_client, \
          patch.object(whatsapp_broadcast, 'channel_client', new_callable=MagicMock) as mock_channel_client, \
-         patch.object(whatsapp_broadcast.channel_client, 'send_template_message_async', side_effect=mock_send_template_message_async) as mock_send_template_message_async, \
+         patch.object(whatsapp_broadcast.channel_client, 'send_broadcast_template_async', new=AsyncMock(side_effect=mock_send_template_message_async)) as mock_send_broadcast, \
          patch.object(MessageBroadcastProcessor, 'add_event_log') as mock_add_event_log, \
-        patch.object(AgenticFlow, '__init__', return_value = None) as mock_init,\
+        patch.object(AgenticFlow, '__init__', return_value=None) as mock_init, \
          patch.object(AgenticFlow, 'execute_rule', side_effect=mock_execute_rule) as mock_execute_rule:
 
         status_flag, status_code, response = await whatsapp_broadcast.send_template_message(template_id, recipient, language_code, components, namespace, flowname)
@@ -689,7 +690,7 @@ async def test_send_template_message_success_with_flow():
         assert status_code == 500
         assert response == {"error": "Some error"}
 
-        mock_send_template_message_async.assert_called_once_with(template_id, recipient, language_code, components, namespace)
+        mock_send_broadcast.assert_called_once_with(template_id, recipient, language_code, components, namespace)
         mock_add_event_log.assert_not_called()
 
 @pytest.mark.parametrize("should_fail", [False, True])
@@ -756,5 +757,212 @@ def test_resend_broadcast_status_transition(should_fail):
         assert f"template_{retry_count}" in final_call_kwargs
         assert f"failure_count_{retry_count}" in final_call_kwargs
         assert final_call_kwargs[inprogress_key] == final_status
+
+
+# ─── Gupshup-specific branch coverage ────────────────────────────────────────
+
+
+def test_send_using_configuration_gupshup_non_dict_raw_template_reset():
+    """raw_template not a dict → normalize_raw_template resets to {} → get_template_params_for_broadcast called."""
+    gs_template = ({"id": "gs_tmpl", "params": []}, {"type": "text", "text": "Hello!"})
+    mock_bsp = MagicMock()
+    mock_bsp.normalize_raw_template.return_value = {}
+    mock_bsp.get_template_params_for_broadcast.return_value = [gs_template]
+    mock_bsp.get_broadcast_namespace_and_language.return_value = (None, None)
+    mock_bsp.to_log_template.return_value = []
+
+    config = {
+        "bsp_type": WhatsappBSPTypes.bsp_gupshup.value,
+        "template_config": [{"template_id": "gs_tmpl_001", "namespace": "ns1", "language": "en"}]
+    }
+    broadcast = WhatsappBroadcast(config=config, bot="gs_bot", user="gs_user",
+                                  event_id="ev1", reference_id="ref1")
+
+    with patch.object(WhatsappBroadcast, '_WhatsappBroadcast__get_template',
+                      return_value=(["not", "a", "dict"], None)), \
+         patch("kairon.shared.channels.broadcast.whatsapp.BusinessServiceProviderFactory.get_instance",
+               return_value=lambda bot, user: mock_bsp), \
+         patch.object(WhatsappBroadcast, 'initiate_broadcast', return_value=(1, [])) as mock_initiate, \
+         patch.object(MessageBroadcastProcessor, 'add_event_log'), \
+         patch.object(MessageBroadcastProcessor, 'update_broadcast_logs_with_template'):
+
+        broadcast._WhatsappBroadcast__send_using_configuration(["919999999999"])
+
+    mock_bsp.normalize_raw_template.assert_called_once_with(["not", "a", "dict"])
+    mock_bsp.get_template_params_for_broadcast.assert_called_once()
+    mock_initiate.assert_called_once()
+    message_list = mock_initiate.call_args[0][0]
+    assert len(message_list) == 1
+    template_id, recipient, lang, t_params, namespace, _ = message_list[0]
+    assert template_id == "gs_tmpl_001"
+    assert recipient == "919999999999"
+    assert lang is None
+    assert namespace is None
+    assert t_params == gs_template
+
+
+def test_send_using_configuration_gupshup_with_dict_raw_template():
+    """raw_template is a dict → get_broadcast_namespace_and_language returns its languageCode/namespace."""
+    raw_template = {"id": "gs_tmpl_001", "languageCode": "hi", "namespace": "ns_gs"}
+    gs_template = ({"id": "gs_tmpl_001", "params": ["John"]}, {"type": "text", "text": "Hello John"})
+    mock_bsp = MagicMock()
+    mock_bsp.normalize_raw_template.return_value = raw_template
+    mock_bsp.get_template_params_for_broadcast.return_value = [gs_template]
+    mock_bsp.get_broadcast_namespace_and_language.return_value = ("ns_gs", "hi")
+    mock_bsp.to_log_template.return_value = []
+
+    config = {
+        "bsp_type": WhatsappBSPTypes.bsp_gupshup.value,
+        "template_config": [{"template_id": "gs_tmpl_001", "namespace": "ns1", "language": "en"}]
+    }
+    broadcast = WhatsappBroadcast(config=config, bot="gs_bot", user="gs_user",
+                                  event_id="ev1", reference_id="ref1")
+
+    with patch.object(WhatsappBroadcast, '_WhatsappBroadcast__get_template',
+                      return_value=(raw_template, None)), \
+         patch("kairon.shared.channels.broadcast.whatsapp.BusinessServiceProviderFactory.get_instance",
+               return_value=lambda bot, user: mock_bsp), \
+         patch.object(WhatsappBroadcast, 'initiate_broadcast', return_value=(1, [])) as mock_initiate, \
+         patch.object(MessageBroadcastProcessor, 'add_event_log'), \
+         patch.object(MessageBroadcastProcessor, 'update_broadcast_logs_with_template'):
+
+        broadcast._WhatsappBroadcast__send_using_configuration(["919999999999"])
+
+    mock_bsp.get_template_params_for_broadcast.assert_called_once()
+    message_list = mock_initiate.call_args[0][0]
+    assert len(message_list) == 1
+    template_id, recipient, lang, t_params, namespace, _ = message_list[0]
+    assert lang == "hi"
+    assert namespace == "ns_gs"
+    assert t_params == gs_template
+
+
+def test_send_using_configuration_gupshup_empty_recipient_skipped():
+    """Empty string recipient must be skipped even for gupshup bsp_type."""
+    mock_bsp = MagicMock()
+    mock_bsp.get_broadcast_template_params.return_value = ({"id": "t"}, {"type": "text", "text": "Hi"})
+    mock_bsp.to_log_template.return_value = []
+
+    config = {
+        "bsp_type": WhatsappBSPTypes.bsp_gupshup.value,
+        "template_config": [{"template_id": "gs_tmpl_001", "namespace": "ns1", "language": "en"}]
+    }
+    broadcast = WhatsappBroadcast(config=config, bot="gs_bot", user="gs_user",
+                                  event_id="ev1", reference_id="ref1")
+
+    with patch.object(WhatsappBroadcast, '_WhatsappBroadcast__get_template',
+                      return_value=({"id": "gs_tmpl_001"}, None)), \
+         patch("kairon.shared.channels.broadcast.whatsapp.BusinessServiceProviderFactory.get_instance",
+               return_value=lambda bot, user: mock_bsp), \
+         patch.object(WhatsappBroadcast, 'initiate_broadcast', return_value=(0, [])) as mock_initiate, \
+         patch.object(MessageBroadcastProcessor, 'add_event_log'), \
+         patch.object(MessageBroadcastProcessor, 'update_broadcast_logs_with_template'):
+
+        broadcast._WhatsappBroadcast__send_using_configuration(["", None, "  "])
+
+    message_list = mock_initiate.call_args[0][0]
+    assert message_list == []  # all recipients were empty/None/whitespace
+
+
+def test_send_using_flow_gupshup_branch():
+    """__send_using_flow with gupshup: uses get_template_params_for_broadcast and get_broadcast_namespace_and_language."""
+    raw_template = {"id": "gs_flow_tmpl", "languageCode": "hi", "namespace": "ns_flow"}
+    gs_template = ({"id": "gs_flow_tmpl", "params": []}, {"type": "text", "text": "Hi"})
+    mock_bsp = MagicMock()
+    mock_bsp.normalize_raw_template.return_value = raw_template
+    mock_bsp.get_template_params_for_broadcast.return_value = [gs_template]
+    mock_bsp.get_broadcast_namespace_and_language.return_value = ("ns_flow", "hi")
+    mock_bsp.to_log_template.return_value = []
+
+    config = {
+        "bsp_type": WhatsappBSPTypes.bsp_gupshup.value,
+        "flowname": "test_flow",
+        "template_config": [{"template_id": "gs_flow_tmpl", "namespace": "ns_orig", "language": "en"}]
+    }
+    broadcast = WhatsappBroadcast(config=config, bot="gs_bot", user="gs_user",
+                                  event_id="ev1", reference_id="ref1")
+
+    with patch.object(WhatsappBroadcast, '_WhatsappBroadcast__get_template',
+                      return_value=(raw_template, None)), \
+         patch("kairon.shared.channels.broadcast.whatsapp.BusinessServiceProviderFactory.get_instance",
+               return_value=lambda bot, user: mock_bsp), \
+         patch.object(WhatsappBroadcast, 'initiate_broadcast', return_value=(1, [])) as mock_initiate, \
+         patch.object(MessageBroadcastProcessor, 'add_event_log'), \
+         patch.object(MessageBroadcastProcessor, 'update_broadcast_logs_with_template'):
+
+        broadcast._WhatsappBroadcast__send_using_flow(["919999999999"])
+
+    mock_bsp.get_template_params_for_broadcast.assert_called_once()
+    message_list = mock_initiate.call_args[0][0]
+    assert len(message_list) == 1
+    template_id, recipient, lang, t_params, namespace, flowname = message_list[0]
+    assert lang == "hi"
+    assert namespace == "ns_flow"
+    assert flowname == "test_flow"
+    assert t_params == gs_template
+
+
+def test_send_using_flow_gupshup_empty_recipient_skipped():
+    """Empty recipients skipped in gupshup flow path."""
+    mock_bsp = MagicMock()
+    mock_bsp.get_broadcast_template_params.return_value = ({"id": "t"}, {"type": "text", "text": "Hi"})
+    mock_bsp.to_log_template.return_value = []
+
+    config = {
+        "bsp_type": WhatsappBSPTypes.bsp_gupshup.value,
+        "flowname": "flow1",
+        "template_config": [{"template_id": "gs_tmpl", "namespace": "ns", "language": "en"}]
+    }
+    broadcast = WhatsappBroadcast(config=config, bot="gs_bot", user="gs_user",
+                                  event_id="ev1", reference_id="ref1")
+
+    with patch.object(WhatsappBroadcast, '_WhatsappBroadcast__get_template',
+                      return_value=({"id": "gs_tmpl"}, None)), \
+         patch("kairon.shared.channels.broadcast.whatsapp.BusinessServiceProviderFactory.get_instance",
+               return_value=lambda bot, user: mock_bsp), \
+         patch.object(WhatsappBroadcast, 'initiate_broadcast', return_value=(0, [])) as mock_initiate, \
+         patch.object(MessageBroadcastProcessor, 'add_event_log'), \
+         patch.object(MessageBroadcastProcessor, 'update_broadcast_logs_with_template'):
+
+        broadcast._WhatsappBroadcast__send_using_flow(["", None])
+
+    message_list = mock_initiate.call_args[0][0]
+    assert message_list == []
+
+
+def test_get_client_gupshup_uses_partner_app_token():
+    """__get_client with gupshup bsp_type picks partner_app_token as access_token."""
+    channel_config = {
+        "config": {
+            "bsp_type": WhatsappBSPTypes.bsp_gupshup.value,
+            "partner_app_token": "gs_partner_tok_xyz",
+            "app_id": "gs_app_001"
+        }
+    }
+    mock_settings = MagicMock()
+    mock_settings.__getitem__ = lambda self, key: "gupshup" if key == "whatsapp" else None
+
+    captured = {}
+
+    def mock_client_factory(access_token, **kwargs):
+        captured["access_token"] = access_token
+        return MagicMock()
+
+    mock_client_class = MagicMock(side_effect=mock_client_factory)
+
+    config = {"broadcast_type": "static", "bsp_type": WhatsappBSPTypes.bsp_gupshup.value}
+    broadcast = WhatsappBroadcast(config=config, bot="gs_bot", user="gs_user",
+                                  event_id="ev1", reference_id="ref1")
+
+    with patch("kairon.shared.channels.broadcast.whatsapp.MongoProcessor.get_bot_settings",
+               return_value=mock_settings), \
+         patch("kairon.shared.channels.broadcast.whatsapp.ChatDataProcessor.get_channel_config",
+               return_value=channel_config), \
+         patch("kairon.shared.channels.broadcast.whatsapp.WhatsappFactory.get_client",
+               return_value=mock_client_class):
+
+        client = broadcast._WhatsappBroadcast__get_client()
+
+    assert captured["access_token"] == "gs_partner_tok_xyz"
 
 

--- a/tests/unit_test/channels/whatsapp_test.py
+++ b/tests/unit_test/channels/whatsapp_test.py
@@ -326,7 +326,7 @@ class TestWhatsappHandler:
         monkeypatch.setattr(
             UserMedia,
             "save_whatsapp_media_content",
-            lambda bot, sender_id, whatsapp_media_id, config: [whatsapp_media_id]
+            lambda bot, sender_id, whatsapp_media_id, config, user_id=None: [whatsapp_media_id]
         )
 
         # Spy on _handle_user_message
@@ -417,7 +417,7 @@ class TestWhatsappHandler:
         monkeypatch.setattr(
             UserMedia,
             "save_whatsapp_media_and_get_url",
-            lambda bot, sender_id, whatsapp_media_id, description, config: [whatsapp_media_id]
+            lambda bot, sender_id, whatsapp_media_id, config, description=None, user_id=None: [whatsapp_media_id]
         )
 
         handler._handle_user_message = AsyncMock()
@@ -778,7 +778,7 @@ class TestWhatsappHandler:
             body_bytes = file.read()
 
         responses.get(
-            url=f'https://graph.facebook.com/v22.0/{document_id}?fields=url',
+            url=f'https://graph.facebook.com/v19.0/{document_id}?fields=url',
             json={'url': 'https://test.com/download', 'mime_type': 'application/pdf'}
         )
         responses.get(

--- a/tests/unit_test/chat/user_media_test.py
+++ b/tests/unit_test/chat/user_media_test.py
@@ -442,24 +442,25 @@ def test_mark_user_media_data_upload_failed_not_found(mock_objects):
 @patch("kairon.shared.chat.user_media.UserMedia.create_user_media_data")
 @patch("kairon.shared.chat.user_media.uuid7")
 @patch("kairon.shared.chat.user_media.requests.get")
-async def test_save_whatsapp_media_content_360dialog_success(mock_get, mock_uuid, mock_create):
+@patch("kairon.chat.handlers.channels.clients.whatsapp.factory.WhatsappFactory.get_client")
+async def test_save_whatsapp_media_content_360dialog_success(mock_get_client, mock_requests_get, mock_uuid, mock_create):
     bot = "bot1"
     sender_id = "user1"
     whatsapp_media_id = "media123"
     config = {"bsp_type": "360dialog", "api_key": "key123"}
 
-    resp_info = MagicMock()
-    resp_info.status_code = 200
-    resp_info.json.return_value = {
-        "url": "https://lookaside.fbsbx.com/path/file.jpg",
-        "mime_type": "image/jpeg"
-    }
+    mock_client_instance = MagicMock()
+    mock_client_instance.get_media_info.return_value = (
+        "https://waba-v2.360dialog.io/path/file.jpg",
+        {"D360-API-KEY": "key123"},
+        "whatsapp_360_media123.jpg",
+    )
+    mock_get_client.return_value = MagicMock(return_value=mock_client_instance)
 
-    resp_media = MagicMock()
-    resp_media.status_code = 200
-    resp_media.iter_content = MagicMock(return_value=[b"chunk1", b"chunk2"])
-
-    mock_get.side_effect = [resp_info, resp_media]
+    mock_download_resp = MagicMock()
+    mock_download_resp.status_code = 200
+    mock_download_resp.iter_content = MagicMock(return_value=[b"chunk1", b"chunk2"])
+    mock_requests_get.return_value = mock_download_resp
 
     mock_uuid.return_value.hex = "uuid123"
 
@@ -468,13 +469,14 @@ async def test_save_whatsapp_media_content_360dialog_success(mock_get, mock_uuid
         result = UserMedia.save_whatsapp_media_content(bot, sender_id, whatsapp_media_id, config)
 
     assert result == ["uuid123"]
-    mock_get.assert_called()
+    mock_client_instance.get_media_info.assert_called_once_with(whatsapp_media_id, config, media_data=None)
     mock_create.assert_called_once_with(
         bot=bot,
         media_id="uuid123",
-        filename="whataspp_360_media123.jpg",
+        filename="whatsapp_360_media123.jpg",
         sender_id=sender_id,
-        upload_type=UserMediaUploadType.user_uploaded.value
+        upload_type=UserMediaUploadType.user_uploaded.value,
+        user_id=None
     )
     assert len(created) == 1
 
@@ -482,23 +484,25 @@ async def test_save_whatsapp_media_content_360dialog_success(mock_get, mock_uuid
 @patch("kairon.shared.chat.user_media.UserMedia.create_user_media_data")
 @patch("kairon.shared.chat.user_media.uuid7")
 @patch("kairon.shared.chat.user_media.requests.get")
-async def test_save_whatsapp_media_content_meta_success(mock_get, mock_uuid, mock_create):
+@patch("kairon.chat.handlers.channels.clients.whatsapp.factory.WhatsappFactory.get_client")
+async def test_save_whatsapp_media_content_meta_success(mock_get_client, mock_requests_get, mock_uuid, mock_create):
     bot = "bot2"
     sender_id = "user2"
     whatsapp_media_id = "media456"
     config = {"bsp_type": "meta", "access_token": "token456"}
 
-    media_info = MagicMock()
-    media_info.status_code = 200
-    media_info.json.return_value = {
-        "url": "https://graph.facebook.com/path/file.mp4",
-        "mime_type": "video/mp4"
-    }
-    media_resp = MagicMock()
-    media_resp.status_code = 200
-    media_resp.iter_content = MagicMock(return_value=[b"data1", b"data2"])
+    mock_client_instance = MagicMock()
+    mock_client_instance.get_media_info.return_value = (
+        "https://graph.facebook.com/path/file.mp4",
+        {"Authorization": "Bearer token456"},
+        "whatsapp_meta_media456.mp4",
+    )
+    mock_get_client.return_value = MagicMock(return_value=mock_client_instance)
 
-    mock_get.side_effect = [media_info, media_resp]
+    mock_download_resp = MagicMock()
+    mock_download_resp.status_code = 200
+    mock_download_resp.iter_content = MagicMock(return_value=[b"data1", b"data2"])
+    mock_requests_get.return_value = mock_download_resp
 
     mock_uuid.return_value.hex = "uuid456"
 
@@ -507,11 +511,7 @@ async def test_save_whatsapp_media_content_meta_success(mock_get, mock_uuid, moc
         result = UserMedia.save_whatsapp_media_content(bot, sender_id, whatsapp_media_id, config)
 
     assert result == ["uuid456"]
-    mock_get.assert_any_call(
-        f"https://graph.facebook.com/v22.0/{whatsapp_media_id}",
-        params={"fields": "url", "access_token": config['access_token']},
-        timeout=10
-    )
+    mock_client_instance.get_media_info.assert_called_once_with(whatsapp_media_id, config, media_data=None)
     mock_create.assert_called_once()
 
 
@@ -520,28 +520,93 @@ def created_coros(coros):
 
 
 @pytest.mark.asyncio
-@patch("kairon.shared.chat.user_media.requests.get")
-def test_save_whatsapp_media_content_360dialog_failure(mock_get):
+@patch("kairon.chat.handlers.channels.clients.whatsapp.factory.WhatsappFactory.get_client")
+def test_save_whatsapp_media_content_360dialog_failure(mock_get_client):
     config = {"bsp_type": "360dialog", "api_key": "key"}
-    resp = MagicMock(status_code=500, text="error")
-    mock_get.return_value = resp
+    mock_client_instance = MagicMock()
+    mock_client_instance.get_media_info.side_effect = AppException("Failed to download media from 360 dialog: 500")
+    mock_get_client.return_value = MagicMock(return_value=mock_client_instance)
 
     with pytest.raises(AppException) as exc:
-        UserMedia.save_whatsapp_media_content("b","s","id", config)
+        UserMedia.save_whatsapp_media_content("b", "s", "id", config)
     assert "Failed to download media from 360 dialog" in str(exc.value)
 
 
 @pytest.mark.asyncio
-@patch("kairon.shared.chat.user_media.requests.get")
-def test_save_whatsapp_media_content_meta_failure(mock_get):
+@patch("kairon.chat.handlers.channels.clients.whatsapp.factory.WhatsappFactory.get_client")
+def test_save_whatsapp_media_content_meta_failure(mock_get_client):
     config = {"bsp_type": "meta", "access_token": "token"}
-    resp = MagicMock(status_code=400)
-    mock_get.return_value = resp
+    mock_client_instance = MagicMock()
+    mock_client_instance.get_media_info.side_effect = AppException("Failed to get url from meta for media: id")
+    mock_get_client.return_value = MagicMock(return_value=mock_client_instance)
 
     with pytest.raises(AppException) as exc:
-        UserMedia.save_whatsapp_media_content("b","s","id", config)
+        UserMedia.save_whatsapp_media_content("b", "s", "id", config)
     assert "Failed to get url from meta" in str(exc.value)
 
+
+@pytest.mark.asyncio
+@patch("kairon.shared.chat.user_media.requests.get")
+@patch("kairon.shared.chat.user_media.UserMedia.create_user_media_data")
+@patch("kairon.shared.chat.user_media.uuid7")
+@patch("kairon.chat.handlers.channels.clients.whatsapp.factory.WhatsappFactory.get_client")
+async def test_save_whatsapp_media_content_gupshup_success(mock_get_client, mock_uuid, mock_create, mock_requests_get):
+    bot = "bot_gs"
+    sender_id = "user_gs"
+    whatsapp_media_id = "gs_media_001"
+    config = {
+        "bsp_type": "gupshup",
+        "partner_app_token": "gs_token_abc",
+        "app_id": "gs_app_123"
+    }
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.get_media_info.return_value = (
+        "https://media.gupshup.com/gs_media_001.pdf",
+        {"Authorization": "gs_token_abc"},
+        "whatsapp_gupshup_gs_media_001.pdf",
+    )
+    mock_get_client.return_value = MagicMock(return_value=mock_client_instance)
+
+    mock_download_resp = MagicMock()
+    mock_download_resp.status_code = 200
+    mock_download_resp.iter_content = MagicMock(return_value=[b"pdfdata1", b"pdfdata2"])
+    mock_requests_get.return_value = mock_download_resp
+
+    mock_uuid.return_value.hex = "uuid_gs_001"
+
+    called = []
+    with patch("asyncio.create_task", lambda coro: called.append(coro)):
+        result = UserMedia.save_whatsapp_media_content(bot, sender_id, whatsapp_media_id, config)
+
+    assert result == ["uuid_gs_001"]
+    mock_client_instance.get_media_info.assert_called_once_with(whatsapp_media_id, config, media_data=None)
+    mock_create.assert_called_once_with(
+        bot=bot,
+        media_id="uuid_gs_001",
+        filename="whatsapp_gupshup_gs_media_001.pdf",
+        sender_id=sender_id,
+        upload_type=UserMediaUploadType.user_uploaded.value,
+        user_id=None
+    )
+    assert len(called) == 1
+
+
+@patch("kairon.chat.handlers.channels.clients.whatsapp.factory.WhatsappFactory.get_client")
+def test_save_whatsapp_media_content_gupshup_download_failure(mock_get_client):
+    config = {
+        "bsp_type": "gupshup",
+        "partner_app_token": "gs_token_abc",
+        "app_id": "gs_app_123"
+    }
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.get_media_info.side_effect = AppException("Failed to get media info from Gupshup: 403")
+    mock_get_client.return_value = MagicMock(return_value=mock_client_instance)
+
+    with pytest.raises(AppException) as exc:
+        UserMedia.save_whatsapp_media_content("b", "s", "bad_id", config)
+    assert "Failed to get media info from Gupshup" in str(exc.value)
 
 
 
@@ -670,21 +735,25 @@ async def test_extract_media_information_exceptions(mock_objects, mock_agentic_f
 @patch("kairon.shared.chat.user_media.asyncio.create_task")
 @patch("kairon.shared.chat.user_media.requests.get")
 @patch("kairon.shared.chat.user_media.UserMedia.create_user_media_data")
-def test_save_whatsapp_media_content_background_task_failure(mock_create_user_media_data, mock_requests_get, mock_create_task):
+@patch("kairon.chat.handlers.channels.clients.whatsapp.factory.WhatsappFactory.get_client")
+def test_save_whatsapp_media_content_background_task_failure(mock_get_client, mock_create_user_media_data, mock_requests_get, mock_create_task):
     bot = "test_bot"
     sender_id = "user123"
     whatsapp_media_id = "media123"
     config = {"bsp_type": "meta", "access_token": "test_token"}
 
-    mock_media_info_resp = MagicMock()
-    mock_media_info_resp.status_code = 200
-    mock_media_info_resp.json.return_value = {"url": "http://example.com/media", "mime_type": "image/png"}
+    mock_client_instance = MagicMock()
+    mock_client_instance.get_media_info.return_value = (
+        "http://example.com/media",
+        {"Authorization": "Bearer test_token"},
+        "whatsapp_meta_media123.png",
+    )
+    mock_get_client.return_value = MagicMock(return_value=mock_client_instance)
 
     mock_media_resp = MagicMock()
     mock_media_resp.status_code = 200
     mock_media_resp.iter_content.return_value = [b"chunk1", b"chunk2"]
-
-    mock_requests_get.side_effect = [mock_media_info_resp, mock_media_resp]
+    mock_requests_get.return_value = mock_media_resp
 
     def mock_background_task(*args, **kwargs):
         raise Exception("Background task failed")
@@ -703,21 +772,25 @@ def test_save_whatsapp_media_content_background_task_failure(mock_create_user_me
 @patch("kairon.shared.chat.user_media.asyncio.create_task")
 @patch("kairon.shared.chat.user_media.requests.get")
 @patch("kairon.shared.chat.user_media.UserMedia.create_user_media_data")
-def test_save_whatsapp_media_content_success(mock_create_user_media_data, mock_requests_get, mock_create_task):
+@patch("kairon.chat.handlers.channels.clients.whatsapp.factory.WhatsappFactory.get_client")
+def test_save_whatsapp_media_content_success(mock_get_client, mock_create_user_media_data, mock_requests_get, mock_create_task):
     bot = "test_bot"
     sender_id = "user123"
     whatsapp_media_id = "media123"
     config = {"bsp_type": "meta", "access_token": "test_token"}
 
-    mock_media_info_resp = MagicMock()
-    mock_media_info_resp.status_code = 200
-    mock_media_info_resp.json.return_value = {"url": "http://example.com/media", "mime_type": "image/png"}
+    mock_client_instance = MagicMock()
+    mock_client_instance.get_media_info.return_value = (
+        "http://example.com/media",
+        {"Authorization": "Bearer test_token"},
+        "whatsapp_meta_media123.png",
+    )
+    mock_get_client.return_value = MagicMock(return_value=mock_client_instance)
 
     mock_media_resp = MagicMock()
     mock_media_resp.status_code = 200
     mock_media_resp.iter_content.return_value = [b"chunk1", b"chunk2"]
-
-    mock_requests_get.side_effect = [mock_media_info_resp, mock_media_resp]
+    mock_requests_get.return_value = mock_media_resp
 
     mock_create_task.return_value = None
 
@@ -838,7 +911,8 @@ async def test_save_whatsapp_media_and_get_url_360dialog_success(
         filename="whatsapp_360_media123.jpg",
         sender_id=sender_id,
         upload_type=UserMediaUploadType.user_uploaded.value,
-        additional_info={"phone_number": "user1", "description": description}
+        additional_info={"phone_number": "user1", "description": description},
+        user_id=None
     )
 
 
@@ -915,7 +989,8 @@ async def test_save_whatsapp_media_and_get_url_meta_image_success(
         filename="whatsapp_meta_media456.jpg",
         sender_id=sender_id,
         upload_type=UserMediaUploadType.user_uploaded.value,
-        additional_info={"phone_number": "user2", "description": description}
+        additional_info={"phone_number": "user2", "description": description},
+        user_id=None
     )
 
 
@@ -980,6 +1055,67 @@ def test_save_whatsapp_media_and_get_url_download_failure(mock_get):
         )
 
     assert "Failed to download media" in str(exc.value)
+
+
+@pytest.mark.asyncio
+@patch("kairon.shared.chat.user_media.requests.get")
+@patch("kairon.shared.chat.user_media.UserMedia.save_media_content")
+@patch("kairon.shared.chat.user_media.UserMedia.create_user_media_data")
+@patch("kairon.shared.chat.user_media.uuid7")
+@patch("kairon.chat.handlers.channels.clients.whatsapp.factory.WhatsappFactory.get_client")
+async def test_save_whatsapp_media_and_get_url_gupshup_success(
+    mock_get_client,
+    mock_uuid,
+    mock_create,
+    mock_save_media,
+    mock_requests_get
+):
+    bot = "bot_gs"
+    sender_id = "user_gs"
+    whatsapp_media_id = "gs_media_doc_001"
+    config = {
+        "bsp_type": "gupshup",
+        "partner_app_token": "gs_partner_token",
+        "app_id": "gs_app_456"
+    }
+    description = "Patient document"
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.get_media_info.return_value = (
+        "https://media.gupshup.com/gs_media_doc_001.pdf",
+        {"Authorization": "gs_partner_token"},
+        "whatsapp_gupshup_gs_media_doc_001.pdf",
+    )
+    mock_get_client.return_value = MagicMock(return_value=mock_client_instance)
+
+    mock_download_resp = MagicMock()
+    mock_download_resp.status_code = 200
+    mock_download_resp.iter_content = MagicMock(return_value=[b"docchunk1", b"docchunk2"])
+    mock_requests_get.return_value = mock_download_resp
+
+    mock_uuid.return_value.hex = "uuid_gs_doc_001"
+    mock_save_media.return_value = "https://s3.aws/test/doc.pdf"
+
+    called = []
+    with patch("asyncio.create_task", lambda coro: called.append(coro)):
+        result = UserMedia.save_whatsapp_media_and_get_url(
+            bot, sender_id, whatsapp_media_id, config, description
+        )
+
+    assert result == ["uuid_gs_doc_001"]
+    # Verify partner_app_token — not api_key — is used to construct the client
+    mock_get_client.assert_called_once_with("gupshup")
+    mock_client_instance.get_media_info.assert_called_once_with(whatsapp_media_id, config)
+    mock_create.assert_called_once_with(
+        bot=bot,
+        media_id="uuid_gs_doc_001",
+        filename="whatsapp_gupshup_gs_media_doc_001.pdf",
+        sender_id=sender_id,
+        upload_type=UserMediaUploadType.user_uploaded.value,
+        additional_info={"phone_number": sender_id, "description": description},
+        user_id=None
+    )
+
 
 @pytest.mark.asyncio
 @patch("kairon.shared.chat.user_media.UserMedia.get_media_content_buffer")

--- a/tests/unit_test/events/definitions_test.py
+++ b/tests/unit_test/events/definitions_test.py
@@ -1010,6 +1010,7 @@ class TestEventDefinitions:
         config.pop("status")
         config.pop("user")
         config.pop("bot")
+        config.pop("bsp_type", None)
         assert config == {'name': 'first_scheduler', 'connector_type': 'whatsapp', "broadcast_type": "static",
                           'scheduler_config': {'expression_type': 'cron', 'schedule': '57 22 * * *', "timezone": "Asia/Kolkata"},
                           'recipients_config': {'recipients': "918958030541,"}, 'retry_count': 0,
@@ -1057,6 +1058,7 @@ class TestEventDefinitions:
         config.pop("status")
         config.pop("user")
         config.pop("bot")
+        config.pop("bsp_type", None)
         assert config == {'name': 'first_scheduler', 'connector_type': 'whatsapp', "broadcast_type": "static",
                           'scheduler_config': {'expression_type': 'cron', 'schedule': '57 22 * * *', "timezone": "Asia/Kolkata"},
                           'recipients_config': {'recipients': "918958030541,"}, 'retry_count': 0,
@@ -1103,6 +1105,7 @@ class TestEventDefinitions:
         config.pop("status")
         config.pop("user")
         config.pop("bot")
+        config.pop("bsp_type", None)
         assert config == {'name': 'first_scheduler', 'connector_type': 'whatsapp', "broadcast_type": "static",
                           'scheduler_config': {'expression_type': 'cron', 'schedule': '11 11 * * *', "timezone": "GMT"},
                           'recipients_config': {'recipients': "919756653433,918958030541,"}, 'retry_count': 0,
@@ -1144,6 +1147,7 @@ class TestEventDefinitions:
         config.pop("status")
         config.pop("user")
         config.pop("bot")
+        config.pop("bsp_type", None)
         assert config == {'name': 'first_scheduler', 'connector_type': 'whatsapp', "broadcast_type": "static",
                           'scheduler_config': {'expression_type': 'cron', 'schedule': '11 11 * * *', "timezone": "GMT"},
                           'recipients_config': {'recipients': "919756653433,918958030541,"}, 'retry_count': 0,
@@ -1166,6 +1170,7 @@ class TestEventDefinitions:
         config.pop("status")
         config.pop("user")
         config.pop("bot")
+        config.pop("bsp_type", None)
         assert config == {'name': 'first_scheduler', 'connector_type': 'whatsapp', "broadcast_type": "static",
                           'scheduler_config': {'expression_type': 'cron', 'schedule': '11 11 * * *', "timezone": "GMT"},
                           'recipients_config': {'recipients': "919756653433,918958030541,"}, 'retry_count': 0,
@@ -1195,6 +1200,7 @@ class TestEventDefinitions:
         config.pop("status")
         config.pop("user")
         config.pop("bot")
+        config.pop("bsp_type", None)
         assert config == {'name': 'first_scheduler', 'connector_type': 'whatsapp', "broadcast_type": "static",
                           'scheduler_config': {'expression_type': 'cron', 'schedule': '11 11 * * *', "timezone": "GMT"},
                           'recipients_config': {'recipients': "919756653433,918958030541,"}, 'retry_count': 0,

--- a/tests/unit_test/events/events_test.py
+++ b/tests/unit_test/events/events_test.py
@@ -1292,6 +1292,7 @@ class TestEventExecution:
         logged_config.pop("status")
         logged_config.pop("timestamp")
         logged_config.pop('pyscript_timeout')
+        logged_config.pop('bsp_type', None)
         assert logged_config == config
         logs[0][2].pop('timestamp')
         print(logs[0][2])
@@ -1479,6 +1480,7 @@ class TestEventExecution:
         logged_config.pop("status")
         logged_config.pop("timestamp")
         logged_config.pop('pyscript_timeout')
+        logged_config.pop('bsp_type', None)
         assert logged_config == config
         print(logs[0][1])
         assert logs[0][1] == {
@@ -1676,6 +1678,7 @@ class TestEventExecution:
         logged_config.pop("status")
         logged_config.pop("timestamp")
         logged_config.pop('pyscript_timeout')
+        logged_config.pop('bsp_type', None)
         assert logged_config == config
         print(logs[0][1])
         assert logs[0][1] == {
@@ -1878,6 +1881,7 @@ class TestEventExecution:
         logged_config.pop("status")
         logged_config.pop("timestamp")
         logged_config.pop('pyscript_timeout')
+        logged_config.pop('bsp_type', None)
         assert logged_config == config
         print(logs[0][1])
         assert logs[0][1] == {
@@ -2075,6 +2079,7 @@ class TestEventExecution:
         logged_config.pop("status")
         logged_config.pop("timestamp")
         logged_config.pop('pyscript_timeout')
+        logged_config.pop('bsp_type', None)
         assert logged_config == config
         print(logs[0][1])
         assert logs[0][1] == {
@@ -2272,6 +2277,7 @@ class TestEventExecution:
         logged_config.pop("status")
         logged_config.pop("timestamp")
         logged_config.pop('pyscript_timeout')
+        logged_config.pop('bsp_type', None)
         assert logged_config == config
         print(logs[0][1])
         assert logs[0][1] == {
@@ -2757,6 +2763,7 @@ class TestEventExecution:
         logged_config.pop("status")
         logged_config.pop("timestamp")
         logged_config.pop('pyscript_timeout')
+        logged_config.pop('bsp_type', None)
         config['collection_config'] = {}
         assert logged_config == config
         assert logs[0][1] == {"event_id": event_id, 'log_type': 'common', 'bot': 'test_execute_message_broadcast', 'status': 'Completed',
@@ -2869,6 +2876,7 @@ class TestEventExecution:
         logged_config.pop("status")
         logged_config.pop("timestamp")
         logged_config.pop('pyscript_timeout')
+        logged_config.pop('bsp_type', None)
         config['collection_config'] = {}
         assert logged_config == config
         assert logs[0][2] == {"event_id": event_id, 'log_type': 'common', 'bot': 'test_execute_dynamic_message_broadcast',
@@ -2953,6 +2961,7 @@ class TestEventExecution:
         logged_config.pop("status")
         logged_config.pop("timestamp")
         logged_config.pop('pyscript_timeout')
+        logged_config.pop('bsp_type', None)
         assert not logged_config.pop("recipients_config")
         config.pop("recipients_config")
         config['collection_config'] = {}
@@ -3054,6 +3063,7 @@ class TestEventExecution:
         logged_config.pop("status")
         logged_config.pop("timestamp")
         logged_config.pop('pyscript_timeout')
+        logged_config.pop('bsp_type', None)
         config['collection_config'] = {}
         assert logged_config == config
         exception = logs[0][0].pop("exception")
@@ -3187,6 +3197,7 @@ class TestEventExecution:
         reference_id = logs[0][1].pop("reference_id")
         logged_config = logs[0][1].pop("config")
         logged_config.pop('pyscript_timeout')
+        logged_config.pop('bsp_type', None)
         logged_config.pop("_id")
         logged_config.pop("status")
         logged_config.pop("timestamp")
@@ -3358,6 +3369,7 @@ class TestEventExecution:
 
         logged_config.pop("status")
         logged_config.pop('pyscript_timeout')
+        logged_config.pop('bsp_type', None)
         logged_config.pop("timestamp")
         logged_config.pop("_id")
         config['collection_config'] = {}
@@ -3618,6 +3630,7 @@ class TestEventExecution:
 
         logged_config.pop("status")
         logged_config.pop('pyscript_timeout')
+        logged_config.pop('bsp_type', None)
         logged_config.pop("timestamp")
         logged_config.pop("_id")
         logged_config['collection_config'] = {}
@@ -3771,6 +3784,7 @@ class TestEventExecution:
         reference_id = logs[0][0].get("reference_id")
         logged_config = logs[0][0].pop("config")
         logged_config.pop('pyscript_timeout')
+        logged_config.pop('bsp_type', None)
         logged_config.pop("_id")
         logged_config.pop("status")
         logged_config.pop("timestamp")
@@ -3832,6 +3846,7 @@ class TestEventExecution:
         logged_config.pop("status")
         logged_config.pop("timestamp")
         logged_config.pop('pyscript_timeout')
+        logged_config.pop('bsp_type', None)
         logged_config['collection_config'] = {}
         assert logged_config.pop("template_config") == []
         assert logged_config == config
@@ -4156,6 +4171,7 @@ class TestEventExecution:
 
         logs[0][3].pop("timestamp")
         logs[0][3].get("config").pop("timestamp")
+        logs[0][3].get("config").pop("bsp_type", None)
         reference_id = logs[0][3].get("reference_id")
         logged_config = logs[0][3]
         print(logged_config)
@@ -4513,6 +4529,7 @@ class TestEventExecution:
 
         logs[0][3].pop("timestamp")
         logs[0][3].get("config").pop("timestamp")
+        logs[0][3].get("config").pop("bsp_type", None)
         reference_id = logs[0][3].get("reference_id")
         logs[0][3].pop("retry_1_timestamp")
         logged_config = logs[0][3]
@@ -4866,6 +4883,7 @@ class TestEventExecution:
 
         logs[0][3].pop("timestamp")
         logs[0][3].get("config").pop("timestamp")
+        logs[0][3].get("config").pop("bsp_type", None)
         reference_id = logs[0][3].get("reference_id")
         logs[0][3].pop("retry_1_timestamp")
         logged_config = logs[0][3]
@@ -5295,6 +5313,7 @@ class TestEventExecution:
 
         logs[0][4].pop("timestamp")
         logs[0][4].get("config").pop("timestamp")
+        logs[0][4].get("config").pop("bsp_type", None)
         reference_id = logs[0][4].get("reference_id")
         logs[0][4].pop("retry_1_timestamp")
         logged_config = logs[0][4]
@@ -5846,6 +5865,7 @@ class TestEventExecution:
 
         logs[0][5].pop("timestamp")
         logs[0][5].get("config").pop("timestamp")
+        logs[0][5].get("config").pop("bsp_type", None)
         reference_id = logs[0][5].get("reference_id")
         logs[0][5].pop("retry_2_timestamp")
         logged_config = logs[0][5]
@@ -6403,6 +6423,7 @@ class TestEventExecution:
 
         logs[0][5].pop("timestamp")
         logs[0][5].get("config").pop("timestamp")
+        logs[0][5].get("config").pop("bsp_type", None)
         reference_id = logs[0][5].get("reference_id")
         logs[0][5].pop("retry_2_timestamp")
         logged_config = logs[0][5]


### PR DESCRIPTION
- handled use enumaeration scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Logout now revokes the provided token and invalidates the active login session.
  * Password-reset requests always return a generic success message to avoid revealing whether an email is registered.
* **Account Management**
  * Password reset emails are now sent via background processing for faster responses.
  * Unverified email addresses receive an email verification link before a password reset can proceed.
* **Email**
  * Added a “password reset unverified” email template with a configurable subject.
* **WhatsApp & Broadcast**
  * Added Gupshup BSP support and broadcast configuration via a selectable BSP type.
  * Added endpoints to fetch broadcast media IDs and media handle IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->