### PR TITLE
added access limit for Collection and Store page metadata

### DIFF
--- a/kairon/actions/definitions/store_page.py
+++ b/kairon/actions/definitions/store_page.py
@@ -48,7 +48,14 @@ class ActionStorePage(ActionsBase):
                 raise ActionFailure(f"Slot '{identifier_slot}' is absent or empty for sender {tracker.sender_id}")
 
             encrypted_id = Utility.encrypt_message(str(identifier_value))
-            token = Authentication.create_store_page_token(data={"sub": tracker.sender_id, "bot": self.bot}, access_limit=["/api/bot/.+/customer_data/.*"])
+            token = Authentication.create_store_page_token(
+                data={"sub": tracker.sender_id, "bot": self.bot},
+                access_limit=[
+                    "/api/bot/.+/customer_data/.*",
+                    "/api/bot/.+/store_page/metadata",
+                    "/api/bot/.+/data/collection/.*",
+                ],
+            )
 
             slots["user_identifier"] = encrypted_id
             slots["temp_token"] = token

--- a/kairon/api/app/routers/bot/bot.py
+++ b/kairon/api/app/routers/bot/bot.py
@@ -1,6 +1,6 @@
 import os
 from datetime import date, datetime
-from typing import List, Optional, Dict, Text
+from typing import List, Optional, Dict, Text, Union
 
 from fastapi import APIRouter, BackgroundTasks, Path, Security, Request, Body, Query
 from fastapi import UploadFile
@@ -37,7 +37,7 @@ from kairon.shared.data.assets_processor import AssetsProcessor
 from kairon.shared.data.audit.processor import AuditDataProcessor
 from kairon.shared.data.constant import ENDPOINT_TYPE, ModelTestType, \
     AuditlogActions, LogTypes
-from kairon.shared.data.data_objects import TrainingExamples, ModelTraining, Rules
+from kairon.shared.data.data_objects import TrainingExamples, ModelTraining, Rules, CustomerDetails
 from kairon.shared.data.model_processor import ModelProcessor
 from kairon.shared.data.processor import MongoProcessor
 from kairon.shared.events.processor import ExecutorProcessor
@@ -1775,11 +1775,12 @@ async def get_flow_tag(
 
 @router.get("/store_page/metadata", response_model=Response)
 async def get_store_page_metadata(
-        current_user: User = Security(Authentication.get_current_user_and_bot, scopes=TESTER_ACCESS)
+        bot: str,
+        current_user: Union[User, CustomerDetails] = Security(Authentication.get_current_user_or_store_page_token, scopes=TESTER_ACCESS)
 ):
     """
     Fetches store page metadata for the bot
     """
-    metadata = mongo_processor.get_store_page_metadata(current_user.get_bot())
+    metadata = mongo_processor.get_store_page_metadata(bot)
     return Response(data=metadata)
 

--- a/kairon/api/app/routers/bot/data.py
+++ b/kairon/api/app/routers/bot/data.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Optional
+from typing import List, Optional, Union
 from fastapi import UploadFile, File, Security, APIRouter, Query, HTTPException, Path
 from starlette.requests import Request
 from starlette.responses import FileResponse
@@ -22,6 +22,7 @@ from kairon.shared.constants import DESIGNER_ACCESS
 from kairon.shared.data.data_models import POSIntegrationRequest, BulkCollectionDataRequest
 from kairon.shared.data.collection_processor import DataProcessor
 from kairon.shared.data.data_models import  BulkDeleteRequest
+from kairon.shared.data.data_objects import CustomerDetails
 from kairon.shared.data.processor import MongoProcessor
 from kairon.shared.models import User, VaultSyncType
 from kairon.shared.utils import Utility
@@ -265,41 +266,44 @@ async def delete_collection_data(
 
 @router.get("/collection", response_model=Response)
 async def list_collection_data(
-        current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
+        bot: str,
+        current_user: Union[User, CustomerDetails] = Security(Authentication.get_current_user_or_store_page_token, scopes=DESIGNER_ACCESS),
 ):
     """
     Fetches collection data of the bot
     """
-    return {"data": list(DataProcessor.list_collection_data(current_user.get_bot()))}
+    return {"data": list(DataProcessor.list_collection_data(bot))}
 
 
 @router.get("/collection/{collection_name}/metadata", response_model=Response)
 async def get_collection_metadata(
+        bot: str,
         collection_name: str,
-        current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
+        current_user: Union[User, CustomerDetails] = Security(Authentication.get_current_user_or_store_page_token, scopes=DESIGNER_ACCESS),
 ):
     """
     Fetches collection data of the bot
     """
-    return {"data": DataProcessor.get_crud_metadata(bot=current_user.get_bot(), collection_name=collection_name)}
+    return {"data": DataProcessor.get_crud_metadata(bot=bot, collection_name=collection_name)}
 
 
 @router.get("/collection/{collection_name}", response_model=Response)
 async def get_collection_data(
+        bot: str,
         collection_name: str,
         key: List[str] = Query([]), value: List[str] = Query([]),
         start_idx: int = 0, page_size: int = 10,
-        current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
+        current_user: Union[User, CustomerDetails] = Security(Authentication.get_current_user_or_store_page_token, scopes=DESIGNER_ACCESS),
 ):
     """
     Fetches collection data based on the multiple filters provided
     """
-    data = list(DataProcessor.get_collection_data(current_user.get_bot(),
+    data = list(DataProcessor.get_collection_data(bot,
                                                   collection_name=collection_name,
                                                   key=key, value=value, start_idx=start_idx,
                                                   page_size=page_size))
     query = {
-        "bot": current_user.get_bot(),
+        "bot": bot,
         "collection_name": collection_name.lower()
     }
     query.update({
@@ -310,16 +314,17 @@ async def get_collection_data(
 
 @router.get("/collection/{collection_name}/filter", response_model=Response)
 async def get_collection_data_with_timestamp(
+        bot: str,
         collection_name: str,
         filters = Query(default='{}'),
         start_time: str = Query(default=None),
         end_time: str = Query(default=None),
-        current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
+        current_user: Union[User, CustomerDetails] = Security(Authentication.get_current_user_or_store_page_token, scopes=DESIGNER_ACCESS),
 ):
     """
     Fetches collection data based on the multiple filters provided
     """
-    return {"data": list(DataProcessor.get_collection_data_with_timestamp(bot=current_user.get_bot(),
+    return {"data": list(DataProcessor.get_collection_data_with_timestamp(bot=bot,
                                                                                    data_filter=filters,
                                                                                  collection_name=collection_name,
                                                                                    start_time=start_time,
@@ -328,36 +333,39 @@ async def get_collection_data_with_timestamp(
 
 @router.get("/collection/data/{collection_id}", response_model=Response)
 async def get_collection_data_with_id(
+        bot: str,
         collection_id: str,
-        current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS),
+        current_user: Union[User, CustomerDetails] = Security(Authentication.get_current_user_or_store_page_token, scopes=DESIGNER_ACCESS),
 ):
     """
     Fetches collection data based on the collection_id provided
     """
-    return {"data": DataProcessor.get_collection_data_with_id(current_user.get_bot(),
+    return {"data": DataProcessor.get_collection_data_with_id(bot,
                                                                     collection_id=collection_id)}
 
 @router.get("/collections/all", response_model=Response)
 async def get_all_collections(
-    current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS)
+        bot: str,
+        current_user: Union[User, CustomerDetails] = Security(Authentication.get_current_user_or_store_page_token, scopes=DESIGNER_ACCESS)
 ):
     """
     List all collection names for the bot.
     """
-    names = DataProcessor.get_all_collections(current_user.get_bot())
+    names = DataProcessor.get_all_collections(bot)
     return Response(data=names)
 
 @router.get("/collections/{collection_name}/filter/count", response_model=Response)
 async def get_collection_filter_count(
+    bot: str,
     collection_name: str,
     filters: Optional[str] = Query(None),
-    current_user: User = Security(Authentication.get_current_user_and_bot, scopes=DESIGNER_ACCESS)
+    current_user: Union[User, CustomerDetails] = Security(Authentication.get_current_user_or_store_page_token, scopes=DESIGNER_ACCESS)
 ):
     """
     Count of filtered records
     """
     count = DataProcessor.get_collection_filter_data_count(
-        current_user.get_bot(),
+        bot,
         collection_name,
         filters
     )

--- a/kairon/shared/auth.py
+++ b/kairon/shared/auth.py
@@ -181,6 +181,25 @@ class Authentication:
         return encoded_jwt
 
     @staticmethod
+    async def get_current_user_or_store_page_token(
+        security_scopes: SecurityScopes,
+        request: Request,
+        token: str = Depends(DataUtility.oauth2_scheme),
+    ):
+        from kairon.shared.data.constant import TOKEN_TYPE
+        raw_token = (request.headers.get("authorization") or token or "")
+        if raw_token.lower().startswith("bearer "):
+            raw_token = raw_token[7:]
+        if raw_token:
+            try:
+                claims = Utility.decode_limited_access_token(raw_token)
+                if claims.get("type") == TOKEN_TYPE.STORE_PAGE.value:
+                    return Authentication.validate_store_page_token(request)
+            except Exception:
+                pass
+        return await Authentication.get_current_user_and_bot(security_scopes, request, token)
+
+    @staticmethod
     def validate_store_page_token(request: Request):
         from kairon.shared.data.data_objects import CustomerDetails
         token = (request.query_params.get("authorization") or

--- a/kairon/shared/auth.py
+++ b/kairon/shared/auth.py
@@ -12,7 +12,6 @@ from jwt import PyJWTError, encode
 from loguru import logger
 from mongoengine import DoesNotExist
 
-from kairon.shared.data.data_objects import BotSettings
 from pydantic import SecretStr
 from starlette.status import HTTP_401_UNAUTHORIZED
 
@@ -159,6 +158,7 @@ class Authentication:
     @staticmethod
     def create_store_page_token(*, data: dict, token_type: TOKEN_TYPE = TOKEN_TYPE.STORE_PAGE.value,
                                 token_expire: int = 15, access_limit: list = None):
+        from kairon.shared.data.data_objects import BotSettings
         bot_settings = BotSettings.objects(bot=str(data.get("bot"))).get()
         store_page_token_expiry = bot_settings.store_page_token_expiry
         secret_key = Utility.environment['security']["secret_key"]

--- a/kairon/shared/auth.py
+++ b/kairon/shared/auth.py
@@ -186,7 +186,6 @@ class Authentication:
         request: Request,
         token: str = Depends(DataUtility.oauth2_scheme),
     ):
-        from kairon.shared.data.constant import TOKEN_TYPE
         raw_token = (request.headers.get("authorization") or token or "")
         if raw_token.lower().startswith("bearer "):
             raw_token = raw_token[7:]
@@ -195,8 +194,11 @@ class Authentication:
                 claims = Utility.decode_limited_access_token(raw_token)
                 if claims.get("type") == TOKEN_TYPE.STORE_PAGE.value:
                     return Authentication.validate_store_page_token(request)
-            except Exception:
-                pass
+            except Exception as e:
+                raise HTTPException(
+                    status_code=HTTP_401_UNAUTHORIZED,
+                    detail=f"Invalid token: {e}"
+                )
         return await Authentication.get_current_user_and_bot(security_scopes, request, token)
 
     @staticmethod

--- a/kairon/shared/data/customer_order_processor.py
+++ b/kairon/shared/data/customer_order_processor.py
@@ -65,7 +65,14 @@ class CustomerOrderProcessor:
         from kairon.shared.auth import Authentication
         catalog_base = Utility.environment.get("store_page").get("url")
         encrypted_id = Utility.encrypt_message(plain_sender_id)
-        token = Authentication.create_store_page_token(data={"sub": plain_sender_id, "bot": bot}, access_limit=["/api/bot/.+/customer_data/.*"])
+        token = Authentication.create_store_page_token(
+            data={"sub": plain_sender_id, "bot": bot},
+            access_limit=[
+                "/api/bot/.+/customer_data/.*",
+                "/api/bot/.+/store_page/metadata",
+                "/api/bot/.+/data/collection/.*",
+            ],
+        )
         return f"{catalog_base}/{page_name}/{bot}/{encrypted_id}/{token}"
 
     @staticmethod

--- a/tests/unit_test/api/customer_orders_router_test.py
+++ b/tests/unit_test/api/customer_orders_router_test.py
@@ -31,6 +31,7 @@ from kairon.api.app.routers.bot.customer_orders import (
     update_order_status,
     upsert_customer,
 )
+from kairon.api.app.routers.bot.bot import get_store_page_metadata
 
 BOT = "router_test_bot"
 
@@ -292,3 +293,41 @@ class TestFilterOrdersRouter:
             bot=BOT, persona_type=None, filters={}, page=1, page_size=20
         )
         assert result.data == []
+
+
+class TestGetStorePageMetadataRouter:
+
+    @pytest.mark.asyncio
+    async def test_get_store_page_metadata_with_store_page_token(self):
+        """Store page token (CustomerDetails) path — uses bot from path param."""
+        expected = {"store_name": "My Shop", "logo_url": "https://example.com/logo.png"}
+        mock_customer = MagicMock()
+        with patch(
+            "kairon.api.app.routers.bot.bot.mongo_processor.get_store_page_metadata",
+            return_value=expected,
+        ) as mock_proc:
+            result = await get_store_page_metadata(bot=BOT, current_user=mock_customer)
+        mock_proc.assert_called_once_with(BOT)
+        assert result.data == expected
+
+    @pytest.mark.asyncio
+    async def test_get_store_page_metadata_with_user_token(self):
+        """Regular user token (User) path — uses bot from path param."""
+        expected = {"store_name": "Bot Store"}
+        with patch(
+            "kairon.api.app.routers.bot.bot.mongo_processor.get_store_page_metadata",
+            return_value=expected,
+        ) as mock_proc:
+            result = await get_store_page_metadata(bot=BOT, current_user=_MOCK_USER)
+        mock_proc.assert_called_once_with(BOT)
+        assert result.data == expected
+
+    @pytest.mark.asyncio
+    async def test_get_store_page_metadata_not_found_raises(self):
+        from kairon.exceptions import AppException
+        with patch(
+            "kairon.api.app.routers.bot.bot.mongo_processor.get_store_page_metadata",
+            side_effect=AppException("Store page metadata not found"),
+        ):
+            with pytest.raises(AppException, match="Store page metadata not found"):
+                await get_store_page_metadata(bot=BOT, current_user=_MOCK_USER)

--- a/tests/unit_test/api/customer_orders_router_test.py
+++ b/tests/unit_test/api/customer_orders_router_test.py
@@ -32,6 +32,15 @@ from kairon.api.app.routers.bot.customer_orders import (
     upsert_customer,
 )
 from kairon.api.app.routers.bot.bot import get_store_page_metadata
+from kairon.api.app.routers.bot.data import (
+    list_collection_data,
+    get_collection_metadata,
+    get_collection_data,
+    get_collection_data_with_timestamp,
+    get_collection_data_with_id,
+    get_all_collections,
+    get_collection_filter_count,
+)
 
 BOT = "router_test_bot"
 
@@ -331,3 +340,103 @@ class TestGetStorePageMetadataRouter:
         ):
             with pytest.raises(AppException, match="Store page metadata not found"):
                 await get_store_page_metadata(bot=BOT, current_user=_MOCK_USER)
+
+
+_DATA_PROC = "kairon.api.app.routers.bot.data.DataProcessor"
+
+
+class TestCollectionDataRouter:
+
+    @pytest.mark.asyncio
+    async def test_list_collection_data_with_store_page_token(self):
+        expected = [{"name": "menu"}, {"name": "items"}]
+        with patch(f"{_DATA_PROC}.list_collection_data", return_value=expected) as mock_proc:
+            result = await list_collection_data(bot=BOT, current_user=MagicMock())
+        mock_proc.assert_called_once_with(BOT)
+        assert result["data"] == expected
+
+    @pytest.mark.asyncio
+    async def test_list_collection_data_with_user_token(self):
+        with patch(f"{_DATA_PROC}.list_collection_data", return_value=[]) as mock_proc:
+            result = await list_collection_data(bot=BOT, current_user=_MOCK_USER)
+        mock_proc.assert_called_once_with(BOT)
+        assert result["data"] == []
+
+    @pytest.mark.asyncio
+    async def test_get_collection_metadata_success(self):
+        expected = {"fields": ["name", "price"]}
+        with patch(f"{_DATA_PROC}.get_crud_metadata", return_value=expected) as mock_proc:
+            result = await get_collection_metadata(bot=BOT, collection_name="menu", current_user=MagicMock())
+        mock_proc.assert_called_once_with(bot=BOT, collection_name="menu")
+        assert result["data"] == expected
+
+    @pytest.mark.asyncio
+    async def test_get_collection_metadata_raises(self):
+        with patch(f"{_DATA_PROC}.get_crud_metadata", side_effect=AppException("Collection not found")):
+            with pytest.raises(AppException, match="Collection not found"):
+                await get_collection_metadata(bot=BOT, collection_name="missing", current_user=MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_get_collection_data_success(self):
+        rows = [{"data": {"name": "Burger", "price": 10}}]
+        with patch(f"{_DATA_PROC}.get_collection_data", return_value=rows):
+            with patch("kairon.api.app.routers.bot.data.CollectionData") as mock_cd:
+                mock_cd.objects.return_value.count.return_value = 1
+                result = await get_collection_data(
+                    bot=BOT, collection_name="menu",
+                    key=[], value=[], start_idx=0, page_size=10,
+                    current_user=MagicMock(),
+                )
+        assert result["data"]["logs"] == rows
+        assert result["data"]["total"] == 1
+
+    @pytest.mark.asyncio
+    async def test_get_collection_data_with_timestamp_success(self):
+        rows = [{"data": {"name": "Pizza"}}]
+        with patch(f"{_DATA_PROC}.get_collection_data_with_timestamp", return_value=rows) as mock_proc:
+            result = await get_collection_data_with_timestamp(
+                bot=BOT, collection_name="menu",
+                filters="{}", start_time=None, end_time=None,
+                current_user=MagicMock(),
+            )
+        mock_proc.assert_called_once_with(bot=BOT, data_filter="{}", collection_name="menu", start_time=None, end_time=None)
+        assert result["data"] == rows
+
+    @pytest.mark.asyncio
+    async def test_get_collection_data_with_id_success(self):
+        expected = {"_id": "abc123", "data": {"name": "Burger"}}
+        with patch(f"{_DATA_PROC}.get_collection_data_with_id", return_value=expected) as mock_proc:
+            result = await get_collection_data_with_id(bot=BOT, collection_id="abc123", current_user=MagicMock())
+        mock_proc.assert_called_once_with(BOT, collection_id="abc123")
+        assert result["data"] == expected
+
+    @pytest.mark.asyncio
+    async def test_get_collection_data_with_id_raises(self):
+        with patch(f"{_DATA_PROC}.get_collection_data_with_id", side_effect=AppException("Record not found")):
+            with pytest.raises(AppException, match="Record not found"):
+                await get_collection_data_with_id(bot=BOT, collection_id="bad_id", current_user=MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_get_all_collections_success(self):
+        expected = ["menu", "items", "specials"]
+        with patch(f"{_DATA_PROC}.get_all_collections", return_value=expected) as mock_proc:
+            result = await get_all_collections(bot=BOT, current_user=MagicMock())
+        mock_proc.assert_called_once_with(BOT)
+        assert result.data == expected
+
+    @pytest.mark.asyncio
+    async def test_get_collection_filter_count_success(self):
+        with patch(f"{_DATA_PROC}.get_collection_filter_data_count", return_value=42) as mock_proc:
+            result = await get_collection_filter_count(
+                bot=BOT, collection_name="menu", filters=None, current_user=MagicMock()
+            )
+        mock_proc.assert_called_once_with(BOT, "menu", None)
+        assert result.data == {"count": 42}
+
+    @pytest.mark.asyncio
+    async def test_get_collection_filter_count_raises(self):
+        with patch(f"{_DATA_PROC}.get_collection_filter_data_count", side_effect=AppException("Invalid filters")):
+            with pytest.raises(AppException, match="Invalid filters"):
+                await get_collection_filter_count(
+                    bot=BOT, collection_name="menu", filters="{bad}", current_user=MagicMock()
+                )

--- a/tests/unit_test/data_processor/customer_order_processor_test.py
+++ b/tests/unit_test/data_processor/customer_order_processor_test.py
@@ -648,7 +648,7 @@ class TestGenerateStorePageUrl:
         bot = "url_gen_bot"
         plain_sender = "url_user1"
         page_name = "catalog"
-        with patch("kairon.shared.auth.BotSettings") as mock_bs:
+        with patch("kairon.shared.data.data_objects.BotSettings") as mock_bs:
             mock_bs.objects.return_value.get.return_value = self._MOCK_BS
             url = CustomerOrderProcessor._generate_store_page_url(bot, plain_sender, page_name)
         catalog_base = Utility.environment.get("store_page", {}).get("url", "")
@@ -658,7 +658,7 @@ class TestGenerateStorePageUrl:
         bot = "url_gen_bot2"
         plain_sender = "url_user2"
         page_name = "shop"
-        with patch("kairon.shared.auth.BotSettings") as mock_bs:
+        with patch("kairon.shared.data.data_objects.BotSettings") as mock_bs:
             mock_bs.objects.return_value.get.return_value = self._MOCK_BS
             url = CustomerOrderProcessor._generate_store_page_url(bot, plain_sender, page_name)
         catalog_base = Utility.environment.get("store_page", {}).get("url", "")
@@ -671,7 +671,7 @@ class TestGenerateStorePageUrl:
         bot = "url_gen_bot3"
         plain_sender = "url_user3"
         page_name = "store"
-        with patch("kairon.shared.auth.BotSettings") as mock_bs:
+        with patch("kairon.shared.data.data_objects.BotSettings") as mock_bs:
             mock_bs.objects.return_value.get.return_value = self._MOCK_BS
             url = CustomerOrderProcessor._generate_store_page_url(bot, plain_sender, page_name)
         token = url.split("/")[-1]
@@ -818,7 +818,7 @@ class TestCreateOrderPaymentEnabled:
         mock_resp.json.return_value = {"id": "pay_xyz", "short_url": "https://rzp.io/xyz"}
         with patch("kairon.shared.data.customer_order_processor.http_requests.post") as mock_post:
             mock_post.return_value = mock_resp
-            with patch("kairon.shared.auth.BotSettings") as mock_bs:
+            with patch("kairon.shared.data.data_objects.BotSettings") as mock_bs:
                 mock_bs.objects.return_value.get.return_value = MagicMock(store_page_token_expiry=15)
                 result = CustomerOrderProcessor.create_order(
                     bot=self.bot, sender_id=self.enc,
@@ -838,7 +838,7 @@ class TestCreateOrderPaymentEnabled:
         mock_resp.text = "Unauthorized"
         with patch("kairon.shared.data.customer_order_processor.http_requests.post") as mock_post:
             mock_post.return_value = mock_resp
-            with patch("kairon.shared.auth.BotSettings") as mock_bs:
+            with patch("kairon.shared.data.data_objects.BotSettings") as mock_bs:
                 mock_bs.objects.return_value.get.return_value = MagicMock(store_page_token_expiry=15)
                 with pytest.raises(AppException, match="Razorpay API error 401"):
                     CustomerOrderProcessor.create_order(
@@ -852,7 +852,7 @@ class TestCreateOrderPaymentEnabled:
         self._save_razorpay_action()
         with patch("kairon.shared.data.customer_order_processor.http_requests.post") as mock_post:
             mock_post.side_effect = ConnectionError("network error")
-            with patch("kairon.shared.auth.BotSettings") as mock_bs:
+            with patch("kairon.shared.data.data_objects.BotSettings") as mock_bs:
                 mock_bs.objects.return_value.get.return_value = MagicMock(store_page_token_expiry=15)
                 with patch("kairon.shared.data.customer_order_processor.logger") as mock_log:
                     result = CustomerOrderProcessor.create_order(

--- a/tests/unit_test/data_processor/store_page_token_validation_test.py
+++ b/tests/unit_test/data_processor/store_page_token_validation_test.py
@@ -200,22 +200,19 @@ class TestGetCurrentUserOrStorePageToken:
         assert result is mock_user
 
     @pytest.mark.asyncio
-    async def test_routes_to_user_auth_when_token_decode_fails(self):
-        mock_user = MagicMock()
+    async def test_raises_401_when_token_decode_fails(self):
         mock_security_scopes = MagicMock(scopes=[])
         bad_token = "not.a.valid.jwt"
         req = MockRequest(token=bad_token, bot=self.BOT)
 
-        with patch("kairon.shared.utils.Utility.decode_limited_access_token", side_effect=Exception("decode failed")):
-            with patch.object(Authentication, "get_current_user_and_bot", new=AsyncMock(return_value=mock_user)) as mock_user_auth:
-                result = await Authentication.get_current_user_or_store_page_token(
-                    security_scopes=mock_security_scopes,
-                    request=req,
-                    token=bad_token,
-                )
+        with pytest.raises(HTTPException) as exc_info:
+            await Authentication.get_current_user_or_store_page_token(
+                security_scopes=mock_security_scopes,
+                request=req,
+                token=bad_token,
+            )
 
-        mock_user_auth.assert_called_once_with(mock_security_scopes, req, bad_token)
-        assert result is mock_user
+        assert exc_info.value.status_code == 401
 
     @pytest.mark.asyncio
     async def test_routes_to_user_auth_when_no_token(self):

--- a/tests/unit_test/data_processor/store_page_token_validation_test.py
+++ b/tests/unit_test/data_processor/store_page_token_validation_test.py
@@ -63,7 +63,11 @@ def _make_token(bot, sender, access_limit=None, token_type=TOKEN_TYPE.STORE_PAGE
         return Authentication.create_store_page_token(
             data={"sub": sender, "bot": bot},
             token_type=token_type,
-            access_limit=access_limit or ["/api/bot/.+/customer_data/.*"],
+            access_limit=access_limit or [
+                "/api/bot/.+/customer_data/.*",
+                "/api/bot/.+/store_page/metadata",
+                "/api/bot/.+/data/collection/.*",
+            ],
         )
 
 

--- a/tests/unit_test/data_processor/store_page_token_validation_test.py
+++ b/tests/unit_test/data_processor/store_page_token_validation_test.py
@@ -58,7 +58,7 @@ _MOCK_BOT_SETTINGS = MagicMock(store_page_token_expiry=15)
 
 
 def _make_token(bot, sender, access_limit=None, token_type=TOKEN_TYPE.STORE_PAGE.value):
-    with patch("kairon.shared.auth.BotSettings") as mock_bs:
+    with patch("kairon.shared.data.data_objects.BotSettings") as mock_bs:
         mock_bs.objects.return_value.get.return_value = _MOCK_BOT_SETTINGS
         return Authentication.create_store_page_token(
             data={"sub": sender, "bot": bot},
@@ -79,7 +79,7 @@ class TestValidateStorePageToken:
 
     @pytest.fixture(autouse=True)
     def patch_bot_settings(self):
-        with patch("kairon.shared.auth.BotSettings") as mock_bs:
+        with patch("kairon.shared.data.data_objects.BotSettings") as mock_bs:
             mock_bs.objects.return_value.get.return_value = _MOCK_BOT_SETTINGS
             yield
 

--- a/tests/unit_test/data_processor/store_page_token_validation_test.py
+++ b/tests/unit_test/data_processor/store_page_token_validation_test.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 from mongoengine import connect
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 os.environ["system_file"] = "./tests/testing_data/system.yaml"
 
@@ -154,3 +154,81 @@ class TestValidateStorePageToken:
         req = MockRequest(token=token, bot=self.BOT)
         with pytest.raises(HTTPException, match="Sender is not registered for this bot"):
             Authentication.validate_store_page_token(req)
+
+
+class TestGetCurrentUserOrStorePageToken:
+    """Tests for combined auth dependency that routes between store page and user tokens."""
+
+    BOT = "combined_auth_test_bot"
+    SENDER = "27831111111"
+
+    @pytest.mark.asyncio
+    async def test_routes_to_store_page_when_token_type_is_store_page(self):
+        mock_customer = MagicMock(spec=CustomerDetails)
+        mock_customer.sender_id = self.SENDER
+        mock_customer.bot = self.BOT
+
+        store_page_token = _make_token(self.BOT, self.SENDER)
+        req = MockRequest(token=store_page_token, bot=self.BOT)
+
+        with patch.object(Authentication, "validate_store_page_token", return_value=mock_customer) as mock_validate:
+            result = await Authentication.get_current_user_or_store_page_token(
+                security_scopes=MagicMock(scopes=[]),
+                request=req,
+                token=store_page_token,
+            )
+
+        mock_validate.assert_called_once_with(req)
+        assert result is mock_customer
+
+    @pytest.mark.asyncio
+    async def test_routes_to_user_auth_when_token_type_is_login(self):
+        mock_user = MagicMock()
+        mock_security_scopes = MagicMock(scopes=[])
+        login_token = "fake.login.jwt"
+        req = MockRequest(token=login_token, bot=self.BOT)
+
+        with patch("kairon.shared.utils.Utility.decode_limited_access_token", return_value={"type": "login", "sub": "user@example.com"}):
+            with patch.object(Authentication, "get_current_user_and_bot", new=AsyncMock(return_value=mock_user)) as mock_user_auth:
+                result = await Authentication.get_current_user_or_store_page_token(
+                    security_scopes=mock_security_scopes,
+                    request=req,
+                    token=login_token,
+                )
+
+        mock_user_auth.assert_called_once_with(mock_security_scopes, req, login_token)
+        assert result is mock_user
+
+    @pytest.mark.asyncio
+    async def test_routes_to_user_auth_when_token_decode_fails(self):
+        mock_user = MagicMock()
+        mock_security_scopes = MagicMock(scopes=[])
+        bad_token = "not.a.valid.jwt"
+        req = MockRequest(token=bad_token, bot=self.BOT)
+
+        with patch("kairon.shared.utils.Utility.decode_limited_access_token", side_effect=Exception("decode failed")):
+            with patch.object(Authentication, "get_current_user_and_bot", new=AsyncMock(return_value=mock_user)) as mock_user_auth:
+                result = await Authentication.get_current_user_or_store_page_token(
+                    security_scopes=mock_security_scopes,
+                    request=req,
+                    token=bad_token,
+                )
+
+        mock_user_auth.assert_called_once_with(mock_security_scopes, req, bad_token)
+        assert result is mock_user
+
+    @pytest.mark.asyncio
+    async def test_routes_to_user_auth_when_no_token(self):
+        mock_user = MagicMock()
+        mock_security_scopes = MagicMock(scopes=[])
+        req = MockRequest(token="", bot=self.BOT)
+
+        with patch.object(Authentication, "get_current_user_and_bot", new=AsyncMock(return_value=mock_user)) as mock_user_auth:
+            result = await Authentication.get_current_user_or_store_page_token(
+                security_scopes=mock_security_scopes,
+                request=req,
+                token="",
+            )
+
+        mock_user_auth.assert_called_once_with(mock_security_scopes, req, "")
+        assert result is mock_user


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Store-page access tokens now support customer data, store-page metadata, and data-collection endpoints.
  * Store-page metadata and collection data can be retrieved using either a store-page access token or a standard user login.
  * Collection data access now includes listings, metadata, records, timestamps, filters, and lookups.

* **Bug Fixes**
  * Store-page links now provide reliable access to required store-page API functionality without authorization errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->