### PR TITLE
media_id_fix

### DIFF
--- a/kairon/shared/channels/whatsapp/bsp/dialog360.py
+++ b/kairon/shared/channels/whatsapp/bsp/dialog360.py
@@ -435,6 +435,7 @@ class BSP360Dialog(WhatsappBusinessServiceProviderBase):
                 media_id__ne="",
                 upload_type=UserMediaUploadType.broadcast.value,
                 timestamp__gte=thirty_days_ago,
+                external_upload_info__bsp=WhatsappBSPTypes.bsp_360dialog.value,
             ).only("filename", "media_id", "upload_status", "sender_id", "timestamp")
             return [
                 {

--- a/kairon/shared/channels/whatsapp/bsp/gupshup.py
+++ b/kairon/shared/channels/whatsapp/bsp/gupshup.py
@@ -296,7 +296,6 @@ class BSPGupshup(WhatsappBusinessServiceProviderBase):
     @staticmethod
     async def upload_media_file(bot: str, channel_config: dict, sender_id: str, filename: str, extension: str,
                            filesize: int = 0) -> str:
-        from uuid6 import uuid7
 
         app_id = channel_config.get("config", {}).get("app_id")
         partner_app_token = channel_config.get("config", {}).get("partner_app_token")
@@ -358,18 +357,15 @@ class BSPGupshup(WhatsappBusinessServiceProviderBase):
             )
             raise AppException(response.text)
 
-        media_id = uuid7().hex
         resp_data = response.json()
         handle_id_raw = resp_data.get("handleId")
         handle_id = handle_id_raw if isinstance(handle_id_raw, str) else (handle_id_raw or {}).get("message")
-        expiration_date = datetime.utcnow() + timedelta(days = 30)
+        expiration_date = datetime.utcnow() + timedelta(days=30)
 
         output_filename = f"template_media/{bot}/{filename}"
         bucket = Utility.environment["storage"]["whatsapp_media"].get("bucket")
         with open(file_path, "rb") as f:
             binary_data = f.read()
-            media_url = UserMedia.save_media_content(bot, sender_id, media_id, binary_data, filename,
-                                                     file_path, output_filename, bucket, False)
 
         async def _get_external_media_id():
             def _do():
@@ -387,46 +383,43 @@ class BSPGupshup(WhatsappBusinessServiceProviderBase):
             loop = asyncio.get_running_loop()
             return await loop.run_in_executor(None, _do)
 
-        media_doc.update(
-            set__media_url=media_url,
-            set__upload_type=UserMediaUploadType.broadcast.value,
-            set__additional_info={"message": "Upload successful"},
-            set__external_upload_info__handle_id=handle_id,
-            set__external_upload_info__expiry_date=expiration_date,
-        )
-
         external_media_id = None
 
         try:
             media_resp = await _get_external_media_id()
-
         except requests.RequestException as e:
             logger.exception(f"Failed to fetch external media id: {e}")
 
             media_doc.update(
-                set__upload_status = UserMediaUploadStatus.failed.value,
-                set__additional_info ={"message": "Upload failed: network error"},
-                set__external_upload_info__error = str(e),
+                set__upload_status=UserMediaUploadStatus.failed.value,
+                set__additional_info={"message": "Upload failed: network error"},
+                set__external_upload_info__error=str(e),
             )
             raise AppException(f"Upload request failed: {e}") from e
 
         if media_resp.status_code not in (200, 201):
             logger.error(f"Media API failed: {media_resp.text}")
             media_doc.update(
-                set__upload_status = UserMediaUploadStatus.failed.value,
-                set__additional_info ={"message": "Upload failed"},
-                set__external_upload_info__error = media_resp.text,
+                set__upload_status=UserMediaUploadStatus.failed.value,
+                set__additional_info={"message": "Upload failed"},
+                set__external_upload_info__error=media_resp.text,
             )
             raise AppException(media_resp.text)
 
         external_media_id = media_resp.json().get("mediaId")
 
+        media_doc.update(set__media_id=external_media_id)
+
+        UserMedia.save_media_content(bot, sender_id, external_media_id, binary_data, filename,
+                                     file_path, output_filename, bucket, False)
+
         media_doc.update(
-            set__media_id = media_id,
-            set__upload_status = UserMediaUploadStatus.completed.value,
-            set__upload_type = UserMediaUploadType.broadcast.value,
-            set__additional_info ={"message": "Upload successful and media_id generated."},
-            set__external_upload_info__external_media_id = external_media_id,
+            set__upload_status=UserMediaUploadStatus.completed.value,
+            set__upload_type=UserMediaUploadType.broadcast.value,
+            set__additional_info={"message": "Upload successful and media_id generated."},
+            set__external_upload_info__external_media_id=external_media_id,
+            set__external_upload_info__handle_id=handle_id,
+            set__external_upload_info__expiry_date=expiration_date,
         )
 
         return external_media_id
@@ -493,13 +486,8 @@ class BSPGupshup(WhatsappBusinessServiceProviderBase):
     def delete_media_file(bot: str, media_id: str, channel_config):
         app_id = channel_config.get("config", {}).get("app_id")
         partner_app_token = channel_config.get("config", {}).get("partner_app_token")
-        obj = UserMediaData.objects(
-            bot=bot,
-            media_id=media_id
-        ).get()
-        external_media_id = obj.external_upload_info["external_media_id"]
         base_url = Utility.system_metadata["channels"]["whatsapp"]["business_providers"]["gupshup"]["partner_base_url"]
-        url = f"{base_url}/partner/app/{app_id}/media/{external_media_id}"
+        url = f"{base_url}/partner/app/{app_id}/media/{media_id}"
         headers = {"Authorization": partner_app_token}
         Utility.execute_http_request(request_method="DELETE", http_url=url, headers=headers,
                                      validate_status=True,
@@ -641,8 +629,7 @@ class BSPGupshup(WhatsappBusinessServiceProviderBase):
             return [
                 {
                     "filename": doc.filename,
-                    "handle_id": (doc.external_upload_info or {}).get("handle_id"),
-                    "id": (doc.external_upload_info or {}).get("external_media_id"),
+                    "media_id": (doc.external_upload_info or {}).get("handle_id"),
                     "upload_status": doc.upload_status,
                     "sender_id": doc.sender_id,
                     "timestamp": doc.timestamp,
@@ -662,6 +649,7 @@ class BSPGupshup(WhatsappBusinessServiceProviderBase):
                 media_id__ne="",
                 upload_type=UserMediaUploadType.broadcast.value,
                 timestamp__gte=thirty_days_ago,
+                external_upload_info__bsp=WhatsappBSPTypes.bsp_gupshup.value,
             ).only("filename", "media_id", "upload_status", "sender_id", "timestamp")
             return [
                 {

--- a/tests/unit_test/channels/bsp_test.py
+++ b/tests/unit_test/channels/bsp_test.py
@@ -2342,7 +2342,7 @@ class TestBSPGupshup:
         ).save()
         result = BSPGupshup.fetch_media_ids(bot)
         assert len(result) == 1
-        assert result[0]["handle_id"] == "ext_handle_abc"
+        assert result[0]["media_id"] == "ext_handle_abc"
         assert result[0]["filename"] == "promo.pdf"
         UserMediaData.objects(bot=bot).delete()
 
@@ -2363,7 +2363,7 @@ class TestBSPGupshup:
         result = BSPGupshup.fetch_media_ids("bot_with_zero_media_gs_xyz")
         assert result == []
 
-    def test_fetch_media_ids_returns_external_media_id_in_id_field(self):
+    def test_fetch_media_ids_returns_handle_id_as_media_id(self):
         bot = "gs_fetch_media_ids_ext_bot"
         UserMediaData.objects(bot=bot).delete()
         UserMediaData(
@@ -2375,55 +2375,61 @@ class TestBSPGupshup:
         ).save()
         result = BSPGupshup.fetch_media_ids(bot)
         assert len(result) == 1
-        assert result[0]["id"] == "gs_media_456"
-        assert result[0]["handle_id"] == "ext_handle_001"
+        assert result[0]["media_id"] == "ext_handle_001"
         assert result[0]["filename"] == "promo.jpg"
         UserMediaData.objects(bot=bot).delete()
 
-    def test_fetch_media_ids_id_none_when_external_media_id_absent(self):
+    def test_fetch_media_ids_media_id_none_when_handle_id_absent(self):
         bot = "gs_fetch_media_ids_no_ext_bot"
         UserMediaData.objects(bot=bot).delete()
         UserMediaData(
             bot=bot, media_id="internal_uuid2", filename="doc.pdf", extension="application/pdf",
             sender_id="user_d", upload_status=UserMediaUploadStatus.completed.value,
             upload_type=UserMediaUploadType.broadcast.value,
-            external_upload_info={"bsp": "gupshup", "handle_id": "ext_handle_002"},
+            external_upload_info={"bsp": "gupshup"},
             timestamp=datetime.utcnow()
         ).save()
         result = BSPGupshup.fetch_media_ids(bot)
         assert len(result) == 1
-        assert result[0]["id"] is None
-        assert result[0]["handle_id"] == "ext_handle_002"
+        assert result[0]["media_id"] is None
         UserMediaData.objects(bot=bot).delete()
 
     # ─── fetch_broadcast_media_ids ────────────────────────────────────
 
     def test_fetch_broadcast_media_ids_success(self):
+        from unittest.mock import MagicMock
         bot = "gs_fetch_bc_media_ids_bot"
-        UserMediaData.objects(bot=bot).delete()
-        UserMediaData(
-            bot=bot, media_id="ext_media_001", filename="video.mp4", extension="video/mp4",
-            sender_id="user_c", upload_status=UserMediaUploadStatus.completed.value,
-            upload_type=UserMediaUploadType.broadcast.value,
-            timestamp=datetime.utcnow()
-        ).save()
-        result = BSPGupshup.fetch_broadcast_media_ids(bot)
+        mock_doc = MagicMock()
+        mock_doc.filename = "video.mp4"
+        mock_doc.media_id = "ext_media_001"
+        mock_doc.upload_status = UserMediaUploadStatus.completed.value
+        mock_doc.sender_id = "user_c"
+        mock_doc.timestamp = datetime.utcnow()
+
+        mock_qs = MagicMock()
+        mock_qs.only.return_value = [mock_doc]
+
+        with patch(
+            "kairon.shared.channels.whatsapp.bsp.gupshup.UserMediaData.objects",
+            return_value=mock_qs,
+        ):
+            result = BSPGupshup.fetch_broadcast_media_ids(bot)
         assert len(result) == 1
         assert result[0]["media_id"] == "ext_media_001"
-        UserMediaData.objects(bot=bot).delete()
+        assert result[0]["filename"] == "video.mp4"
 
     def test_fetch_broadcast_media_ids_excludes_empty_media_id(self):
+        from unittest.mock import MagicMock
         bot = "gs_fetch_bc_media_excl_bot"
-        UserMediaData.objects(bot=bot).delete()
-        UserMediaData(
-            bot=bot, media_id="", filename="img.png", extension="image/png",
-            sender_id="user_d", upload_status=UserMediaUploadStatus.completed.value,
-            upload_type=UserMediaUploadType.broadcast.value,
-            timestamp=datetime.utcnow()
-        ).save()
-        result = BSPGupshup.fetch_broadcast_media_ids(bot)
+        mock_qs = MagicMock()
+        mock_qs.only.return_value = []
+
+        with patch(
+            "kairon.shared.channels.whatsapp.bsp.gupshup.UserMediaData.objects",
+            return_value=mock_qs,
+        ):
+            result = BSPGupshup.fetch_broadcast_media_ids(bot)
         assert result == []
-        UserMediaData.objects(bot=bot).delete()
 
     # ─── delete_media_file ────────────────────────────────────────────
 
@@ -2522,17 +2528,24 @@ class TestBSPGupshup:
                       json={"mediaId": "ext_media_upload_001"}, status=200)
 
         storage_env = {"storage": {"whatsapp_media": {"bucket": "test-bucket"}}}
+        call_order = []
         with patch("kairon.shared.channels.whatsapp.bsp.gupshup.UserMedia.create_media_doc") as mock_doc, \
-             patch("kairon.shared.channels.whatsapp.bsp.gupshup.UserMedia.save_media_content") as mock_save, \
+             patch("kairon.shared.channels.whatsapp.bsp.gupshup.UserMedia.save_media_content",
+                   side_effect=lambda *a, **kw: call_order.append("save")) as mock_save, \
              mock.patch.dict(Utility.environment, storage_env):
             mock_doc_inst = MagicMock()
+            mock_doc_inst.update.side_effect = lambda **kw: call_order.append(list(kw.keys())[0])
             mock_doc.return_value = mock_doc_inst
-            mock_save.return_value = "https://s3.aws/test/promo.pdf"
             result = await BSPGupshup.upload_media_file(
                 bot=bot, channel_config=channel_config, sender_id="user",
                 filename=filename, extension=extension, filesize=100
             )
         assert result == "ext_media_upload_001"
+        # media_id must be set on the doc BEFORE save_media_content so mark_user_media_data_upload_done can find it
+        assert call_order.index("set__media_id") < call_order.index("save")
+        mock_save.assert_called_once()
+        save_args = mock_save.call_args
+        assert save_args.args[2] == "ext_media_upload_001"
 
     # ─── upload_media ────────────────────────────────────────────
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WhatsApp broadcast media filtering for 360dialog and Gupshup providers.
  - Gupshup uploads now consistently use the provider-assigned media ID, improving media storage, retrieval, and deletion.
  - Media listings now return the correct provider handle when available.
- **Tests**
  - Updated coverage to verify provider media IDs, handles, upload behavior, and provider-specific filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->