### PR TITLE
callback_identifier in store_page

### DIFF
--- a/kairon/shared/actions/data_objects.py
+++ b/kairon/shared/actions/data_objects.py
@@ -536,6 +536,7 @@ class StorePageAction(Auditlog):
     name = StringField(required=True)
     page_name = StringField(required=True)
     identifier_slot = StringField(required=True)
+    callback_identifier = StringField(default=None)
     bot = StringField(required=True)
     user = StringField(required=True)
     timestamp = DateTimeField(default=datetime.utcnow)

--- a/kairon/shared/data/customer_order_processor.py
+++ b/kairon/shared/data/customer_order_processor.py
@@ -77,7 +77,7 @@ class CustomerOrderProcessor:
 
     @staticmethod
     def _create_razorpay_payment_link(api_key: str, api_secret: str, order_id: str,
-                                      order_details: dict, callback_url: str) -> Dict[str, Any]:
+                                      order_details: dict, callback_url: str, callback_identifier: str) -> Dict[str, Any]:
         amount = order_details.get("amount", 0)
         currency = order_details.get("currency", "INR")
         payload = {
@@ -93,7 +93,8 @@ class CustomerOrderProcessor:
             "reference_id": order_id,
             "notify": {"sms": True, "email": True},
             "notes": {
-                "kairon_id": order_id
+                "kairon_id": callback_identifier,
+                "kairon_order_id": order_id
             },
         }
         resp = http_requests.post(
@@ -226,9 +227,14 @@ class CustomerOrderProcessor:
             store_config = {}
 
         if store_config.get("payment_enabled"):
-            page_name = store_config.get("page_name", "catalog")
-
-            from kairon.shared.actions.data_objects import RazorpayAction
+            from kairon.shared.actions.data_objects import StorePageAction, RazorpayAction
+            try:
+                store_page = StorePageAction.objects(bot=bot, status=True).get()
+                page_name = store_page.page_name
+                callback_identifier = store_page.callback_identifier
+            except DoesNotExist:
+                page_name = "catalog"
+                callback_identifier = None
             try:
                 action = RazorpayAction.objects(bot=bot, status=True).get()
             except DoesNotExist:
@@ -242,7 +248,7 @@ class CustomerOrderProcessor:
 
             try:
                 razorpay_resp = CustomerOrderProcessor._create_razorpay_payment_link(
-                    api_key, api_secret, order_id, order_payload, callback_url
+                    api_key, api_secret, order_id, order_payload, callback_url, callback_identifier
                 )
                 payment_id = razorpay_resp.get("id", "")
                 payment_link = razorpay_resp.get("short_url", "")

--- a/kairon/shared/data/data_models.py
+++ b/kairon/shared/data/data_models.py
@@ -1024,6 +1024,7 @@ class StorePageActionRequest(BaseModel):
     name: constr(to_lower=True, strip_whitespace=True)
     page_name: str
     identifier_slot: str
+    callback_identifier: Optional[str] = None
 
 
 class JiraActionRequest(BaseModel):

--- a/kairon/shared/data/processor.py
+++ b/kairon/shared/data/processor.py
@@ -7279,6 +7279,7 @@ class MongoProcessor:
             name=action["name"],
             page_name=action["page_name"],
             identifier_slot=action["identifier_slot"],
+            callback_identifier=action.get("callback_identifier"),
             bot=bot,
             user=user,
         ).save()
@@ -7295,6 +7296,7 @@ class MongoProcessor:
         store_page_action = StorePageAction.objects(name=action["name"], bot=bot, status=True).get()
         store_page_action.page_name = action["page_name"]
         store_page_action.identifier_slot = action["identifier_slot"]
+        store_page_action.callback_identifier = action.get("callback_identifier")
         store_page_action.user = user
         store_page_action.timestamp = datetime.utcnow()
         store_page_action.save()

--- a/tests/unit_test/data_processor/customer_order_processor_test.py
+++ b/tests/unit_test/data_processor/customer_order_processor_test.py
@@ -692,6 +692,7 @@ class TestCreateRazorpayPaymentLink:
                 order_details={"amount": 100, "currency": "INR", "name": "Alice",
                                "contact": "9999999999", "email": "a@a.com"},
                 callback_url="https://catalog.kairon.com/catalog/bot/enc/token",
+                callback_identifier="cb_001",
             )
         assert result["id"] == "pay_123"
         assert result["short_url"] == "https://rzp.io/pay/abc"
@@ -709,6 +710,7 @@ class TestCreateRazorpayPaymentLink:
                     order_id="order_002",
                     order_details={"amount": 0},
                     callback_url="https://cb.url",
+                    callback_identifier=None,
                 )
 
     def test_amount_converted_to_paise(self):
@@ -721,6 +723,7 @@ class TestCreateRazorpayPaymentLink:
                 api_key="k", api_secret="s", order_id="o3",
                 order_details={"amount": 49.99},
                 callback_url="https://cb",
+                callback_identifier=None,
             )
         call_payload = mock_post.call_args.kwargs["json"]
         assert call_payload["amount"] == 4999
@@ -767,16 +770,26 @@ class TestCreateOrderPaymentEnabled:
             persona_type="fnb", payload={"mobile": "9990000001"},
         )
         from kairon.shared.data.data_objects import StorePageMetadata
-        from kairon.shared.actions.data_objects import RazorpayAction
+        from kairon.shared.actions.data_objects import RazorpayAction, StorePageAction
         StorePageMetadata.objects(bot=self.bot).delete()
         RazorpayAction.objects(bot=self.bot).delete()
+        StorePageAction.objects(bot=self.bot).delete()
 
-    def _save_store_metadata(self, payment_enabled=True, page_name="catalog"):
+    def _save_store_metadata(self, payment_enabled=True):
         from kairon.shared.data.data_objects import StorePageMetadata
         StorePageMetadata.objects(bot=self.bot).delete()
         StorePageMetadata(
             bot=self.bot, user="test_user",
-            config={"payment_enabled": payment_enabled, "page_name": page_name},
+            config={"payment_enabled": payment_enabled},
+        ).save()
+
+    def _save_store_page_action(self, page_name="catalog", callback_identifier=None):
+        from kairon.shared.actions.data_objects import StorePageAction
+        StorePageAction.objects(bot=self.bot).delete()
+        StorePageAction(
+            name="test_store_page_action", bot=self.bot, user="test_user",
+            page_name=page_name, identifier_slot="user_identifier",
+            callback_identifier=callback_identifier,
         ).save()
 
     def _save_razorpay_action(self, api_key="rzp_key", api_secret="rzp_secret"):
@@ -803,6 +816,7 @@ class TestCreateOrderPaymentEnabled:
 
     def test_payment_enabled_no_razorpay_action_raises(self):
         self._save_store_metadata(payment_enabled=True)
+        self._save_store_page_action()
         with pytest.raises(AppException, match="Razorpay action not configured"):
             CustomerOrderProcessor.create_order(
                 bot=self.bot, sender_id=self.enc,
@@ -812,6 +826,7 @@ class TestCreateOrderPaymentEnabled:
 
     def test_payment_enabled_razorpay_success_returns_payment_fields(self):
         self._save_store_metadata(payment_enabled=True)
+        self._save_store_page_action(page_name="shop", callback_identifier="cb_001")
         self._save_razorpay_action()
         mock_resp = MagicMock()
         mock_resp.ok = True
@@ -828,9 +843,13 @@ class TestCreateOrderPaymentEnabled:
         assert result["payment_id"] == "pay_xyz"
         assert result["payment_link"] == "https://rzp.io/xyz"
         assert "order_id" in result
+        call_payload = mock_post.call_args[1]["json"]
+        assert call_payload["notes"]["kairon_id"] == "cb_001"
+        assert call_payload["notes"]["kairon_order_id"] == result["order_id"]
 
     def test_payment_enabled_razorpay_app_exception_reraises(self):
         self._save_store_metadata(payment_enabled=True)
+        self._save_store_page_action()
         self._save_razorpay_action()
         mock_resp = MagicMock()
         mock_resp.ok = False
@@ -849,6 +868,7 @@ class TestCreateOrderPaymentEnabled:
 
     def test_payment_enabled_network_error_logs_warning_returns_order(self):
         self._save_store_metadata(payment_enabled=True)
+        self._save_store_page_action()
         self._save_razorpay_action()
         with patch("kairon.shared.data.customer_order_processor.http_requests.post") as mock_post:
             mock_post.side_effect = ConnectionError("network error")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional callback identifiers to store-page actions.
  * Payment links now include callback metadata for improved payment-flow handling.

* **Bug Fixes**
  * Store-page and callback information now comes from the active store-page configuration, with sensible defaults when unavailable.
  * Updated payment-link handling for successful, failed, and network-error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->